### PR TITLE
fix: dogfood-hardening — adopt-scan opt-in, SessionStart protocol injection, worktree handle fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ director adopt [<dir>]        # defaults to the current directory
 
 `adopt` (Tier 0) derives the repo's **stable workstream identity** (handling worktrees, remotes, and forks — see [Identity](#identity)), creates `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub** there, and registers the workstream in the fleet. **Filling in the CHARTER is the only manual step** — goal, non-goals, and the standing "needs a human" risk line. Re-adopting never clobbers an edited CHARTER.
 
-It then (Tier 1) scans the repo's *tracked* files for existing open loops — `TODO` / `FIXME` / `DEFERRED` / `HACK` / `XXX` and unchecked markdown checklist items (`- [ ]`) — and offers to import the ones you pick as `open-item` events, consolidating loops that would otherwise scatter between memory and per-project docs into their one home in the LOG.
+A bare `adopt` stops there (Tier 0). With `--scan` it also runs **Tier 1**: scans the repo's *tracked* files for open loops — `TODO` / `FIXME` / `DEFERRED` / `HACK` / `XXX` and unchecked markdown checklist items (`- [ ]`) — and offers to import the ones you pick as `open-item` events. Tier 1 is opt-in because this keyword scan is noisy on real repos (it surfaces docs/comments/test fixtures, not just real loops); the accurate brownfield import is the **Tier-2 fan-out** (fast-follow). The point of importing is to consolidate loops that would otherwise scatter between memory and per-project docs into their one home in the LOG.
 
 ```bash
-director adopt                # interactive: pick which open-loops to import
-director adopt --import-all   # import every discovered open-loop, no prompt
-director adopt --no-import    # Tier 0 only — identity + CHARTER + register
+director adopt                # Tier 0 only — identity + CHARTER + register
+director adopt --scan         # also scan tracked files; pick which open-loops to import
+director adopt --import-all   # scan and import every discovered open-loop, no prompt
 ```
 
-Flags may go before or after the optional `<dir>` (`director adopt path/to/repo --no-import`).
+Flags may go before or after the optional `<dir>` (`director adopt path/to/repo --scan`).
 
 ## Commands
 
@@ -134,7 +134,7 @@ A workstream's id is `<repo>-<branch>-<shortid>`, derived deterministically from
 
 ## Status & scope
 
-**In v1:** the hook-first coordination core (CLI write path, identity, event store, fleet/liveness, `render`/`brief`/`status`, hooks + the `_managedBy` installer, the protocol skill) and **adoption Tier 0+1** (`adopt`: identity + CHARTER + register + assisted open-loop import). Single-machine.
+**In v1:** the hook-first coordination core (CLI write path, identity, event store, fleet/liveness, `render`/`brief`/`status`, hooks + the `_managedBy` installer, the protocol skill) and **adoption Tier 0+1** (`adopt`: identity + CHARTER + register, plus an opt-in `--scan` open-loop import). Single-machine.
 
 **Deferred:** **Tier-2 brownfield fan-out** (parallel code-mapping, doc living/record/rot reconciliation, arc42 synthesis, back-dated ADRs) is the immediate fast-follow. `brief --synthesize` (model-narrated prose) is deferred — v1 ships the deterministic brief. The Phase-3 monitor/reaper, notifications, freshness sweep, and multi-machine sync come later.
 

--- a/cmd/director/adopt.go
+++ b/cmd/director/adopt.go
@@ -12,15 +12,18 @@ import (
 	"github.com/colinsurprenant/director/internal/adopt"
 )
 
-// runAdopt brings an existing repo into the fleet (§6, Tier 0+1). Tier 0 always
-// runs (identity + CHARTER stub + register); Tier 1 then surfaces the repo's
-// existing open-loops and imports the chosen ones as open-items. dir defaults to
-// the current directory.
+// runAdopt brings an existing repo into the fleet (§6). Tier 0 always runs
+// (identity + CHARTER stub + register) and is all a bare `adopt` does. Tier 1 —
+// scanning tracked files for open-loops and importing the chosen ones as
+// open-items — is OPT-IN via --scan (interactive pick) or --import-all (take
+// everything), because the keyword scan is noisy on real repos (it surfaced ~75
+// candidates at ~1% precision when dogfooded; see the adopt decision in the LOG).
+// The durable replacement is the Tier-2 fan-out. dir defaults to the current dir.
 func runAdopt(args []string) int {
 	fs := flag.NewFlagSet("adopt", flag.ContinueOnError)
-	var importAll, noImport bool
-	fs.BoolVar(&importAll, "import-all", false, "import every discovered open-loop without prompting")
-	fs.BoolVar(&noImport, "no-import", false, "Tier 0 only — skip the open-loop import")
+	var importAll, scan bool
+	fs.BoolVar(&scan, "scan", false, "scan tracked files for open-loop candidates and pick which to import (blunt keyword matcher — the real brownfield import is the coming Tier-2 fan-out)")
+	fs.BoolVar(&importAll, "import-all", false, "scan and import every discovered open-loop without prompting (implies --scan)")
 
 	// Pull the optional <dir> positional out before flag parsing so flags work in
 	// any position — Go's flag package otherwise stops at the first positional and
@@ -63,7 +66,10 @@ func runAdopt(args []string) int {
 	} else {
 		fmt.Printf("  CHARTER already present at %s — left untouched\n", res.CharterPath)
 	}
-	if noImport {
+	// Tier 1 is opt-in: a bare `adopt` stops at the Tier-0 floor. The keyword scan
+	// only runs with --scan/--import-all, because surfacing every TODO/FIXME/"deferred"
+	// hit floods real repos with noise (see the adopt decision in the LOG).
+	if !scan && !importAll {
 		return 0
 	}
 

--- a/cmd/director/adopt.go
+++ b/cmd/director/adopt.go
@@ -42,6 +42,13 @@ func runAdopt(args []string) int {
 	if err := fs.Parse(flags); err != nil {
 		return 2
 	}
+	// --import-all is a superset of --scan (scan, then take everything) — the
+	// implication the help text documents. Normalize it into the flag state so
+	// `scan` is the single canonical "Tier 1 requested" signal downstream rather
+	// than every check having to repeat the `|| importAll`.
+	if importAll {
+		scan = true
+	}
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "adopt: %v\n", err)
@@ -68,8 +75,9 @@ func runAdopt(args []string) int {
 	}
 	// Tier 1 is opt-in: a bare `adopt` stops at the Tier-0 floor. The keyword scan
 	// only runs with --scan/--import-all, because surfacing every TODO/FIXME/"deferred"
-	// hit floods real repos with noise (see the adopt decision in the LOG).
-	if !scan && !importAll {
+	// hit floods real repos with noise (see the adopt decision in the LOG). --import-all
+	// normalizes to scan above, so scan alone gates Tier 1 here.
+	if !scan {
 		return 0
 	}
 

--- a/cmd/director/adopt_routing_test.go
+++ b/cmd/director/adopt_routing_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitInitRepo creates a real git repo at dir with one tracked file carrying a TODO,
+// so adopt's Tier-1 scan has a candidate to find when it is asked to run.
+func gitInitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("config", "user.email", "t@e.st")
+	run("config", "user.name", "tester")
+	run("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n// TODO: wire it up\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "main.go")
+	run("commit", "-q", "-m", "seed")
+}
+
+// projectLogEventCount counts NDJSON events across every project log under hub.
+func projectLogEventCount(t *testing.T, hub string) int {
+	t.Helper()
+	logs, err := filepath.Glob(filepath.Join(hub, "projects", "*", "log.ndjson"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	total := 0
+	for _, p := range logs {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+			if strings.TrimSpace(line) != "" {
+				total++
+			}
+		}
+	}
+	return total
+}
+
+// TestRunAdoptScanIsOptIn locks the demoted-scan default: a bare `adopt` does
+// Tier-0 only (no scan, nothing imported), and the keyword scan runs only when
+// explicitly requested — exercised here via --import-all (which skips the prompt,
+// so no stdin is needed).
+func TestRunAdoptScanIsOptIn(t *testing.T) {
+	hub := t.TempDir()
+	t.Setenv("DIRECTOR_HUB", hub)
+	repo := filepath.Join(t.TempDir(), "proj")
+	gitInitRepo(t, repo)
+
+	// Bare adopt: Tier-0 only — the TODO must NOT be imported.
+	if code := runAdopt([]string{repo}); code != 0 {
+		t.Fatalf("adopt exit = %d, want 0", code)
+	}
+	if n := projectLogEventCount(t, hub); n != 0 {
+		t.Fatalf("bare adopt imported %d event(s); the default must be Tier-0 only", n)
+	}
+
+	// --import-all: opts into the scan and imports the TODO → at least one event.
+	if code := runAdopt([]string{"--import-all", repo}); code != 0 {
+		t.Fatalf("adopt --import-all exit = %d, want 0", code)
+	}
+	if n := projectLogEventCount(t, hub); n < 1 {
+		t.Fatalf("adopt --import-all imported %d event(s), want >=1", n)
+	}
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,6 +57,19 @@ director adopt
 ```text
 adopted some-project-main-1a2b3c4d
   CHARTER scaffolded at ~/.director/projects/<repo-key>/CHARTER.md — fill in goal / non-goals / risk-line
+```
+
+A bare `adopt` does **Tier 0 only** — the fast, quiet floor:
+
+- **Tier 0** — derives a **stable workstream identity** (handles worktrees, remotes, forks), creates
+  `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub**, and registers the workstream.
+- **Tier 1 (opt-in, `--scan`)** — scans the repo's *tracked* files for open loops
+  (`TODO`/`FIXME`/`DEFERRED`/`HACK`/`XXX` and unchecked `- [ ]` items) and lets you import the ones you pick
+  as `open-item` events. It's opt-in because the keyword scan is noisy on real repos (it can surface dozens of
+  false hits from docs/comments); the richer, accurate brownfield import is the coming Tier-2 fan-out. With
+  `--scan` you'd see:
+
+```text
   found 3 open-loop candidate(s):
     [1] internal/api/handler.go:42  // TODO: rate-limit this endpoint
     [2] README.md:88  - [ ] document the deploy flow
@@ -64,19 +77,12 @@ adopted some-project-main-1a2b3c4d
   import which as open-items? [all / none / e.g. 1,3,5]:
 ```
 
-`adopt` does two tiers:
-
-- **Tier 0** — derives a **stable workstream identity** (handles worktrees, remotes, forks), creates
-  `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub**, and registers the workstream.
-- **Tier 1** — scans the repo's *tracked* files for open loops (`TODO`/`FIXME`/`DEFERRED`/`HACK`/`XXX` and
-  unchecked `- [ ]` checklist items) and imports the ones you pick as `open-item` events.
-
 Variants:
 
 ```bash
-director adopt --import-all   # import every discovered loop, no prompt
-director adopt --no-import    # Tier 0 only (identity + CHARTER + register)
-director adopt path/to/repo --no-import   # flags may go before or after <dir>
+director adopt --scan         # also run the Tier-1 scan; pick which open-loops to import
+director adopt --import-all   # scan and import every discovered loop, no prompt
+director adopt path/to/repo --scan   # flags may go before or after <dir>
 ```
 
 ### Fill the CHARTER — the one manual step
@@ -173,7 +179,7 @@ answer the escalations, edit CHARTERs to steer — not to relay.
 | **`director _hook ...`** | Internal — invoked by the shims, never run by hand. |
 | **A fleet row looks stale though the session is active** | Liveness is derived from heartbeat age. `PostToolUse` refreshes it on every tool call, so an idle (no tool calls) session can age to `stale` (15m) then `abandoned` (2h). v1 has no live git-branch check — that's a fast-follow. |
 | **`status` shows "N unreadable fleet row(s) skipped"** | One or more row files under `$DIRECTOR_HUB/fleet/` are corrupt; the cockpit skips them rather than failing. Inspect/remove the bad files there. |
-| **`adopt` imported nothing** | It scans only *tracked* files (via `git ls-files`) from the repo root. Untracked files are ignored by design; `git add` them first if they should be scanned. |
+| **`adopt` imported nothing** | A bare `adopt` is **Tier-0 only by design** — it doesn't scan. Use `--scan` (pick) or `--import-all`. The scan covers only *tracked* files (via `git ls-files`) from the repo root; `git add` untracked files first if they should be scanned. |
 | **`install` refused** | Your `~/.claude/settings.json` has a malformed (non-object) `hooks` value. Director won't overwrite data it doesn't understand — fix the file, then re-run. |
 
 ---
@@ -186,7 +192,7 @@ committable, ignoring the volatile `fleet/` and `health/`):
 
 ```bash
 export DIRECTOR_HUB=$(git rev-parse --show-toplevel)
-director adopt --import-all
+director adopt          # Tier-0 only; avoid --import-all here — the keyword scan floods a doc-heavy repo
 director brief
 ```
 

--- a/docs/specs/2026-06-03-director-coordination-design.md
+++ b/docs/specs/2026-06-03-director-coordination-design.md
@@ -177,6 +177,8 @@ Existing hooks observed: SessionStart (`gsd-check-update.js`), PostToolUse (`gsd
 
 **v1 line (decided 2026-06-08).** Adoption of *existing* repos is on the critical path (a director's projects already exist — greenfield-only is unusable). It is tiered: **Tier 0** (default adoption — identity + CHARTER stub + register, via `director adopt`) **and Tier 1** (assisted import of a repo's *existing* open loops into the LOG — consolidating the §17 MEMORY-vs-docs scatter into its one home) **ship in v1**. **Tier 2** — the heavy fan-out below (steps 2–4: parallel code-mapping, doc living/record/rot reconciliation, arc42 synthesis, back-dated ADRs) — is the immediate **fast-follow**, built for the repos that pay off once adoption is felt. Tier 2's value concentrates on cold/unfamiliar/inherited repos; it does **not** gate the coordination value, which accrues forward from adoption.
 
+> **Post-v1 refinement (dogfood, 2026-06-24).** Tier 1's keyword scan is now **opt-in** (`adopt --scan` / `--import-all`); a bare `adopt` is Tier-0 only. Dogfooding adopt on the director repo surfaced ~75 candidates at ~1% precision (it matched its own marker-list definition, doc examples, and completed `[x]` tasks while missing every real prose-bullet loop). "Surface-all, human-picks" doesn't survive a real repo — the accurate brownfield import is the Tier-2 fan-out, not a keyword grep. See the `adopt` decision in the LOG.
+
 Default adoption = hub dir + CHARTER stub + fleet register (~5 min). The **heavy** adoption (Tier 2) is a separate, explicitly-invoked tool (a fan-out workflow) for the repos that pay off (e.g. the elasticsearch fork overlay):
 
 1. **Inventory** existing docs (path, `git log` last-touched, apparent type).

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -238,6 +238,9 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	if !strings.Contains(got, "director render") {
 		t.Errorf("injection missing render digest:\n%s", got)
 	}
+	if !strings.Contains(got, "## Director protocol") {
+		t.Errorf("adopted-repo injection missing the write-side emit protocol:\n%s", got)
+	}
 	if !strings.Contains(got, `"hookEventName":"SessionStart"`) {
 		t.Errorf("injection missing SessionStart control envelope:\n%s", got)
 	}
@@ -245,6 +248,28 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	// A real session registers a fleet row.
 	if !fleetRowExists(t, hub, ws.ID) {
 		t.Errorf("expected a fleet row for %s after SessionStart", ws.ID)
+	}
+}
+
+// TestSessionStartProtocolScopedToAdopted locks that the write-side emit protocol
+// is injected ONLY for a Director-managed repo: absent in a bare git repo with no
+// CHARTER and no LOG, so user-level hooks can't nag in unrelated repos. The
+// read-side Ground-Truth state is still injected either way.
+func TestSessionStartProtocolScopedToAdopted(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main") // no CHARTER, no events → un-adopted
+
+	in := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	got := out.String()
+	if !strings.Contains(got, groundTruthPreamble) {
+		t.Errorf("un-adopted repo should still get the Ground-Truth state:\n%s", got)
+	}
+	if strings.Contains(got, "## Director protocol") {
+		t.Errorf("un-adopted repo must NOT get the emit protocol (would nag unrelated repos):\n%s", got)
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/colinsurprenant/director/internal/event"
 	"github.com/colinsurprenant/director/internal/identity"
 )
 
@@ -221,6 +222,12 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Seed a handoff for THIS workstream so the resume-point anchor appears.
+	store := event.NewStore(hub, ws.RepoKey)
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindHandoff, Area: "x", Body: "doing X, next Y"}); err != nil {
+		t.Fatalf("seed handoff: %v", err)
+	}
+
 	in := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
 	var out bytes.Buffer
 	code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub)
@@ -243,6 +250,12 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	}
 	if !strings.Contains(got, "▸ Director:") {
 		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", got)
+	}
+	if !strings.Contains(got, "Resume point") {
+		t.Errorf("injection missing the resume-point anchor for the current workstream:\n%s", got)
+	}
+	if !strings.Contains(got, "commitment to act") {
+		t.Errorf("injected protocol should clarify that emit RECORDS (not a commitment to act):\n%s", got)
 	}
 	if !strings.Contains(got, "director resolve") {
 		t.Errorf("injected protocol should tell the model to resolve finished open-items:\n%s", got)

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -241,6 +241,9 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	if !strings.Contains(got, "## Director protocol") {
 		t.Errorf("adopted-repo injection missing the write-side emit protocol:\n%s", got)
 	}
+	if !strings.Contains(got, "▸ Director:") {
+		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", got)
+	}
 	if !strings.Contains(got, `"hookEventName":"SessionStart"`) {
 		t.Errorf("injection missing SessionStart control envelope:\n%s", got)
 	}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -244,6 +244,9 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	if !strings.Contains(got, "▸ Director:") {
 		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", got)
 	}
+	if !strings.Contains(got, "director resolve") {
+		t.Errorf("injected protocol should tell the model to resolve finished open-items:\n%s", got)
+	}
 	if !strings.Contains(got, `"hookEventName":"SessionStart"`) {
 		t.Errorf("injection missing SessionStart control envelope:\n%s", got)
 	}

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -73,7 +73,7 @@ func handleSessionStart(in Input, out io.Writer, hub string) error {
 		}
 	}
 
-	ctx, err := buildGroundTruth(hub, ws.RepoKey)
+	ctx, err := buildGroundTruth(hub, ws.RepoKey, ws.ID)
 	if err != nil {
 		logFailure(hub, EventSessionStart, in.SessionID, fmt.Sprintf("build ground truth: %v", err))
 		return nil
@@ -116,13 +116,14 @@ func refreshFleet(hub string, ws identity.Workstream, uuid string) error {
 // from the LOG. The digest is the same one `director render` and
 // `--verify` anchor on, so what the session is handed is exactly what the
 // cockpit shows — no drift between injected and authoritative state.
-func buildGroundTruth(hub, repoKey string) (string, error) {
+func buildGroundTruth(hub, repoKey, workstreamID string) (string, error) {
 	store := event.NewStore(hub, repoKey)
 	events, err := store.ReadAll()
 	if err != nil {
 		return "", fmt.Errorf("read log: %w", err)
 	}
-	digest := render.Digest(render.Fold(events), repoKey)
+	proj := render.Fold(events)
+	digest := render.Digest(proj, repoKey)
 
 	var b strings.Builder
 	b.WriteString(groundTruthPreamble)
@@ -143,9 +144,26 @@ func buildGroundTruth(hub, repoKey string) (string, error) {
 	if charterExists(hub, repoKey) || len(events) > 0 {
 		b.WriteString("\n")
 		b.WriteString(emitProtocol)
+		b.WriteString("\n")
+		b.WriteString(startupBanner(workstreamID, proj))
 	}
 
 	return b.String(), nil
+}
+
+// startupBanner tells the model to surface a one-line Director acknowledgment as
+// the first line of its first reply — a visible signal that the session rehydrated,
+// since the injection is otherwise silent. The line is pre-computed here (workstream
+// + open-item counts) so the model relays it rather than re-deriving the counts.
+func startupBanner(workstreamID string, proj render.Projection) string {
+	needYou := 0
+	for _, o := range proj.OpenItems {
+		if o.Risk == event.RiskEscalate {
+			needYou++
+		}
+	}
+	banner := fmt.Sprintf("▸ Director: %s · %d open-item(s), %d need-you", workstreamID, len(proj.OpenItems), needYou)
+	return "## Acknowledge on entry\nBegin your VERY FIRST reply to the human with this line verbatim (then answer normally), so they can see Director rehydrated:\n" + banner + "\n"
 }
 
 // charterExists reports whether the repo has been adopted — a non-empty CHARTER.md

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -40,6 +40,7 @@ const emitProtocol = "## Director protocol — keep this current as you work\n" 
 	"- a decision the moment you make one — `director emit --type decision --area <area> \"<what + why>\"`\n" +
 	"- an open-item the moment you defer a loop — `director emit --type open-item --area <area> --risk <low|escalate> \"<loop>\"`\n" +
 	"- a handoff at each natural boundary (sub-task done, switching focus, wrapping up) — `director emit --type handoff --area <area> \"current task · next · hypotheses\"`\n" +
+	"- when you FINISH an open-item, close it — `director resolve <ulid>` (use a ULID from the open-items above; resolve only when it is truly done — there is no reopen)\n" +
 	"This is load-bearing — treat it as a standing instruction, not a suggestion.\n"
 
 // handleSessionStart derives identity, refreshes the fleet row, and writes the

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -36,7 +36,7 @@ const groundTruthPreamble = "This is your authoritative current state; build on 
 // (dogfood: 0 emits in ~2.5h of real work with the skill installed). It is injected
 // only for Director-managed repos (see buildGroundTruth) so it can't nag elsewhere.
 const emitProtocol = "## Director protocol — keep this current as you work\n" +
-	"You coordinate with other sessions only through the LOG above, written ONLY via the `director` CLI (never Edit/Write a log file). Emit as you work, not batched at the end — state you don't write during a turn is lost on compaction or a fresh start:\n" +
+	"You coordinate with other sessions only through the LOG above, written ONLY via the `director` CLI (never Edit/Write a log file). Emit as you work, not batched at the end — state you don't write during a turn is lost on compaction or a fresh start. Emitting RECORDS a fact; it is NOT a commitment to act and does NOT need the human's approval first — record the decision/loop the moment it exists, then ask or act if needed:\n" +
 	"- a decision the moment you make one — `director emit --type decision --area <area> \"<what + why>\"`\n" +
 	"- an open-item the moment you defer a loop — `director emit --type open-item --area <area> --risk <low|escalate> \"<loop>\"`\n" +
 	"- a handoff at each natural boundary (sub-task done, switching focus, wrapping up) — `director emit --type handoff --area <area> \"current task · next · hypotheses\"`\n" +
@@ -164,7 +164,14 @@ func startupBanner(workstreamID string, proj render.Projection) string {
 		}
 	}
 	banner := fmt.Sprintf("▸ Director: %s · %d open-item(s), %d need-you", workstreamID, len(proj.OpenItems), needYou)
-	return "## Acknowledge on entry\nBegin your VERY FIRST reply to the human with this line verbatim (then answer normally), so they can see Director rehydrated:\n" + banner + "\n"
+	out := "## Acknowledge on entry\nBegin your VERY FIRST reply to the human with this line verbatim (then answer normally), so they can see Director rehydrated:\n" + banner + "\n"
+	// Name THIS workstream's own latest handoff as the resume anchor. Several
+	// workstreams can share one repo log, so the digest's handoffs section lists one
+	// per workstream — without this, the model must guess which is its continuation.
+	if _, ok := proj.LatestHandoff[workstreamID]; ok {
+		out += "Resume point: the handoff labeled [" + workstreamID + "] above is YOUR last position — resume from it; the other handoffs are sibling workstreams' positions, for awareness only.\n"
+	}
+	return out
 }
 
 // charterExists reports whether the repo has been adopted — a non-empty CHARTER.md

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -29,6 +29,19 @@ import (
 // only useful if the model trusts them instead of re-deriving.
 const groundTruthPreamble = "This is your authoritative current state; build on it, do not re-derive or re-read it."
 
+// emitProtocol is the write-side habit, injected alongside the read-side Ground
+// Truth so it is always in context from turn one. It is PUSHED here rather than
+// delivered as a Claude Code skill on purpose: a skill is model-invoked/lazy, so it
+// never enters context during normal work and the always-on emit habit never fires
+// (dogfood: 0 emits in ~2.5h of real work with the skill installed). It is injected
+// only for Director-managed repos (see buildGroundTruth) so it can't nag elsewhere.
+const emitProtocol = "## Director protocol — keep this current as you work\n" +
+	"You coordinate with other sessions only through the LOG above, written ONLY via the `director` CLI (never Edit/Write a log file). Emit as you work, not batched at the end — state you don't write during a turn is lost on compaction or a fresh start:\n" +
+	"- a decision the moment you make one — `director emit --type decision --area <area> \"<what + why>\"`\n" +
+	"- an open-item the moment you defer a loop — `director emit --type open-item --area <area> --risk <low|escalate> \"<loop>\"`\n" +
+	"- a handoff at each natural boundary (sub-task done, switching focus, wrapping up) — `director emit --type handoff --area <area> \"current task · next · hypotheses\"`\n" +
+	"This is load-bearing — treat it as a standing instruction, not a suggestion.\n"
+
 // handleSessionStart derives identity, refreshes the fleet row, and writes the
 // Ground-Truth injection. It degrades gracefully at every step: a fleet write
 // failure still injects context; an identity failure means there is nothing to
@@ -124,7 +137,23 @@ func buildGroundTruth(hub, repoKey string) (string, error) {
 	// frame — keeping the injected state byte-for-byte the render output.
 	b.WriteString(digest)
 
+	// Push the write-side protocol next to the read-side state, but only for a
+	// Director-managed repo — a CHARTER exists or the LOG already has events — so it
+	// never nags in an unrelated repo when the hooks are installed user-level.
+	if charterExists(hub, repoKey) || len(events) > 0 {
+		b.WriteString("\n")
+		b.WriteString(emitProtocol)
+	}
+
 	return b.String(), nil
+}
+
+// charterExists reports whether the repo has been adopted — a non-empty CHARTER.md
+// under its project dir. One of the two signals (with a non-empty LOG) that gate
+// the emit-protocol injection to Director-managed repos.
+func charterExists(hub, repoKey string) bool {
+	info, err := os.Stat(filepath.Join(hub, "projects", repoKey, "CHARTER.md"))
+	return err == nil && info.Size() > 0
 }
 
 // charterText returns the project's CHARTER.md verbatim (trimmed), or a stable

--- a/internal/identity/workstream.go
+++ b/internal/identity/workstream.go
@@ -56,7 +56,7 @@ func resolve(dir string, git gitRunner) (Workstream, error) {
 		}
 	}
 
-	ws.ID = handle(filepath.Base(top), branch, key)
+	ws.ID = handle(repoBasename(dir, git), branch, key)
 	if err := persist(idPath, ws.ID); err != nil {
 		return Workstream{}, err
 	}
@@ -66,6 +66,27 @@ func resolve(dir string, git gitRunner) (Workstream, error) {
 // handle builds the stable, collision-free workstream handle
 // <repo>-<branch>-<shortid>. shortid is derived from the full repo-key + branch,
 // so two repos that share a basename and branch still get distinct handles.
+// repoBasename is the readable repo prefix for the handle: the basename of the dir
+// holding the shared .git (git-common-dir's parent), so every worktree of a repo
+// yields the SAME name. filepath.Base(toplevel) would instead use a linked
+// worktree's OWN dir (often "<repo>-<branch>"), which doubled the branch in the
+// handle. Degrades to the cwd basename if git can't report the common dir.
+func repoBasename(dir string, git gitRunner) string {
+	commonDir, err := git(dir, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return filepath.Base(dir)
+	}
+	if !filepath.IsAbs(commonDir) {
+		if abs, err := filepath.Abs(dir); err == nil {
+			commonDir = filepath.Join(abs, commonDir)
+		}
+	}
+	if resolved, err := filepath.EvalSymlinks(commonDir); err == nil {
+		commonDir = resolved
+	}
+	return filepath.Base(filepath.Dir(commonDir))
+}
+
 func handle(repoName, branch, key string) string {
 	sum := sha256.Sum256([]byte(key + "\x00" + branch))
 	short := hex.EncodeToString(sum[:])[:8]

--- a/internal/identity/workstream_test.go
+++ b/internal/identity/workstream_test.go
@@ -57,6 +57,28 @@ func TestResolveDerivesToplevelOnce(t *testing.T) {
 	}
 }
 
+// TestWorktreeHandleNotDoubled locks the worktree-handle fix: a worktree whose dir
+// name embeds the branch must NOT double the branch in the workstream id — the repo
+// prefix comes from the canonical repo, not the worktree dir basename.
+func TestWorktreeHandleNotDoubled(t *testing.T) {
+	root := t.TempDir()
+	main := filepath.Join(root, "widget")
+	gitInit(t, main, map[string]string{"origin": "https://github.com/acme/widget.git"})
+	wt := filepath.Join(root, "widget-feature-x") // dir name embeds the branch
+	mustGit(t, main, "worktree", "add", "-q", "-b", "feature-x", wt)
+
+	ws, err := Resolve(wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(ws.ID, "feature-x") != 1 {
+		t.Errorf("worktree handle doubled the branch: %q", ws.ID)
+	}
+	if !strings.HasPrefix(ws.ID, "widget-feature-x-") {
+		t.Errorf("worktree handle = %q, want widget-feature-x-<shortid>", ws.ID)
+	}
+}
+
 // TestWorkstreamBranchRenameKeepsID locks that the persisted id survives a
 // branch rename (§13 t3) while Branch tracks the new name.
 func TestWorkstreamBranchRenameKeepsID(t *testing.T) {


### PR DESCRIPTION
Consolidates three gate-green fixes surfaced by dogfooding on another (private) repo. Files are fully disjoint across the three areas, so this is a clean linear consolidation of 6 commits — no merge resolution.

## Fixes

1. **adopt Tier-1 scan is now opt-in** (`--scan` / `--import-all`); bare `adopt` is Tier-0 only (identity + CHARTER + register). Dogfooding surfaced the keyword scan flooding — 75 candidates at ~1% precision and 0% recall of the real backlog — so bulk open-loop import is now explicit opt-in.
2. **SessionStart push-injects the emit protocol** — a Claude Code skill is pull-based (model-invoked, lazy-loaded) and never fired during real work, so the always-on protocol never entered the working context. Push-injection at SessionStart fixes that. Also adds a startup acknowledgment banner, a resolve-finished-open-items instruction, and an emit=record (not a commitment) clarification.
3. **Worktree handles no longer double the branch** — the handle's repo prefix now derives from the shared git-common-dir's parent, so every worktree of a repo yields the same repo name instead of `<repo>-<branch>`.

## Verification

`go build ./... && go vet ./... && gofmt -l . && go test ./... -race` — all green across every package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

