### PR TITLE
feat(fleet): branch-liveness — status self-cleans merged-away worktrees

### DIFF
--- a/cmd/director/fleetcmd.go
+++ b/cmd/director/fleetcmd.go
@@ -17,12 +17,21 @@ func runRegister(args []string) int {
 		fmt.Fprintf(os.Stderr, "register: %v\n", err)
 		return 1
 	}
+	// cwd stamps the row's Dir so liveness can branch-check this workstream (§5.5).
+	// resolveContext already resolved identity from cwd, so Getwd is known-good here.
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "register: %v\n", err)
+		return 1
+	}
 	now := time.Now().UTC()
 	row := fleet.Row{
 		Workstream: ws.ID,
 		UUID:       sessionUUID(),
 		RepoKey:    ws.RepoKey,
 		Handle:     ws.ID,
+		Branch:     ws.Branch,
+		Dir:        cwd,
 		Heartbeat:  now.Format(time.RFC3339Nano),
 	}
 	if err := fleet.Register(hub, row); err != nil {

--- a/internal/fleet/branchalive.go
+++ b/internal/fleet/branchalive.go
@@ -35,16 +35,17 @@ func BranchAlive(r Row) bool {
 	return branchAliveWith(runGit, r)
 }
 
-// branchAliveWith is BranchAlive with the git seam injected. It FAILS OPEN: a row
-// that can't be checked is never abandoned on that basis (it still ages out by
-// heartbeat TTL). Only a definitive "branch is gone" signal returns false.
+// branchAliveWith is BranchAlive with the git seam injected. It fails open only
+// where the check cannot be RUN, and is deliberately fail-CLOSED once it can:
 //
 //   - missing branch or dir → indeterminate (a row materialized by a bare heartbeat
 //     before register) → alive; git is not run.
 //   - detached HEAD → no branch ref exists to check → alive; git is not run.
 //   - otherwise → `git show-ref --verify --quiet refs/heads/<branch>` in dir:
-//     exit 0 (ref present) → alive; any non-zero exit (ref absent, or the worktree
-//     dir was deleted so git can't run) → the branch is gone → not alive.
+//     exit 0 (ref present) → alive; ANY error → not alive. A removed worktree dir
+//     surfaces as a git error (chdir fails) rather than a clean "ref absent" exit,
+//     and that is exactly a case we must abandon — so any show-ref failure, not just
+//     a definitive ref-absent, is treated as gone.
 func branchAliveWith(run gitRunner, r Row) bool {
 	if r.Branch == "" || r.Dir == "" {
 		return true

--- a/internal/fleet/branchalive.go
+++ b/internal/fleet/branchalive.go
@@ -1,0 +1,57 @@
+package fleet
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// branchalive.go is the production branch-existence predicate liveness derives
+// abandonment from (§5.5): a workstream whose branch no longer exists — the merge
+// deleted it, or the worktree is gone — is abandoned regardless of heartbeat age.
+// List takes this as an injectable seam so derivation stays testable without git.
+
+// gitRunner runs git in dir and returns trimmed stdout, or a typed error on a
+// non-zero exit. It is the injectable seam over the git CLI (mirroring identity's)
+// so branchAliveWith is testable without a real repo.
+type gitRunner func(dir string, args ...string) (string, error)
+
+func runGit(dir string, args ...string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// BranchAlive reports whether the row's workstream branch still exists — the
+// predicate status passes to fleet.List so a merged-away worktree self-cleans.
+func BranchAlive(r Row) bool {
+	return branchAliveWith(runGit, r)
+}
+
+// branchAliveWith is BranchAlive with the git seam injected. It FAILS OPEN: a row
+// that can't be checked is never abandoned on that basis (it still ages out by
+// heartbeat TTL). Only a definitive "branch is gone" signal returns false.
+//
+//   - missing branch or dir → indeterminate (a row materialized by a bare heartbeat
+//     before register) → alive; git is not run.
+//   - detached HEAD → no branch ref exists to check → alive; git is not run.
+//   - otherwise → `git show-ref --verify --quiet refs/heads/<branch>` in dir:
+//     exit 0 (ref present) → alive; any non-zero exit (ref absent, or the worktree
+//     dir was deleted so git can't run) → the branch is gone → not alive.
+func branchAliveWith(run gitRunner, r Row) bool {
+	if r.Branch == "" || r.Dir == "" {
+		return true
+	}
+	if strings.HasPrefix(r.Branch, "detached-") {
+		return true
+	}
+	_, err := run(r.Dir, "show-ref", "--verify", "--quiet", "refs/heads/"+r.Branch)
+	return err == nil
+}

--- a/internal/fleet/branchalive_test.go
+++ b/internal/fleet/branchalive_test.go
@@ -1,0 +1,114 @@
+package fleet
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestBranchAliveRefPresent: when the branch ref resolves, the workstream is alive,
+// and the predicate runs `show-ref --verify` for that branch in the row's dir.
+func TestBranchAliveRefPresent(t *testing.T) {
+	var gotDir string
+	var gotArgs []string
+	run := func(dir string, args ...string) (string, error) {
+		gotDir, gotArgs = dir, args
+		return "", nil // exit 0 → ref exists
+	}
+	row := Row{Branch: "feature-x", Dir: "/repo/wt"}
+
+	if !branchAliveWith(run, row) {
+		t.Fatal("ref present → want alive")
+	}
+	if gotDir != "/repo/wt" {
+		t.Errorf("git run dir = %q, want /repo/wt", gotDir)
+	}
+	want := []string{"show-ref", "--verify", "--quiet", "refs/heads/feature-x"}
+	if !equalArgs(gotArgs, want) {
+		t.Errorf("git args = %v, want %v", gotArgs, want)
+	}
+}
+
+// TestBranchAliveRefAbsentIsDead: a non-zero git exit (ref gone, or the worktree
+// dir was deleted so git can't run) means the branch is gone → not alive.
+func TestBranchAliveRefAbsentIsDead(t *testing.T) {
+	run := func(string, ...string) (string, error) { return "", errors.New("not a valid ref") }
+	if branchAliveWith(run, Row{Branch: "gone", Dir: "/repo/wt"}) {
+		t.Fatal("ref absent (git error) → want dead")
+	}
+}
+
+// TestBranchAliveIndeterminateMetadataIsAlive: a row missing branch or dir cannot
+// be checked, so the predicate must fail-open (never abandon on absent metadata —
+// the row still ages out by heartbeat TTL) and must not invoke git.
+func TestBranchAliveIndeterminateMetadataIsAlive(t *testing.T) {
+	called := false
+	run := func(string, ...string) (string, error) { called = true; return "", errors.New("x") }
+	for _, row := range []Row{
+		{Branch: "", Dir: "/repo"},
+		{Branch: "feature", Dir: ""},
+		{Branch: "", Dir: ""},
+	} {
+		if !branchAliveWith(run, row) {
+			t.Errorf("indeterminate metadata %+v → want alive", row)
+		}
+	}
+	if called {
+		t.Error("git must not run when branch/dir is missing")
+	}
+}
+
+// TestBranchAliveDetachedHeadIsAlive: a detached-HEAD workstream has no branch ref,
+// so the branch check must never abandon it (it ages out by heartbeat TTL instead)
+// and must not invoke git.
+func TestBranchAliveDetachedHeadIsAlive(t *testing.T) {
+	called := false
+	run := func(string, ...string) (string, error) { called = true; return "", nil }
+	if !branchAliveWith(run, Row{Branch: "detached-1a2b3c4", Dir: "/repo"}) {
+		t.Fatal("detached HEAD → want alive")
+	}
+	if called {
+		t.Error("git must not run for a detached-HEAD workstream")
+	}
+}
+
+// TestBranchAliveRealGit exercises the production predicate against a real repo —
+// the fake-runner tests can't catch a malformed git invocation. It locks the whole
+// contract: an existing branch is alive; a deleted branch is dead; a dir that is no
+// longer a repo (worktree removed) is dead.
+func TestBranchAliveRealGit(t *testing.T) {
+	repo := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		if _, err := runGit(repo, args...); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+	git("init", "-q")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "t")
+	git("commit", "--allow-empty", "-q", "-m", "root")
+	git("branch", "feature")
+
+	if !BranchAlive(Row{Branch: "feature", Dir: repo}) {
+		t.Error("existing branch → want alive")
+	}
+	git("branch", "-D", "feature")
+	if BranchAlive(Row{Branch: "feature", Dir: repo}) {
+		t.Error("deleted branch → want dead")
+	}
+	if BranchAlive(Row{Branch: "feature", Dir: t.TempDir()}) {
+		t.Error("non-repo dir (worktree removed) → want dead")
+	}
+}
+
+func equalArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -46,6 +46,8 @@ type Row struct {
 	UUID       string `json:"uuid"`
 	RepoKey    string `json:"repo_key,omitempty"` // canonical repo-key; locates this workstream's LOG for status' blocked-on (§5.3)
 	Handle     string `json:"handle,omitempty"`
+	Branch     string `json:"branch,omitempty"` // the workstream's branch; with Dir, lets liveness check the branch still exists (§5.5)
+	Dir        string `json:"dir,omitempty"`    // a working dir in the repo to run the branch check from — a deleted worktree makes git fail → abandoned
 	Heartbeat  string `json:"heartbeat"`        // RFC3339Nano, set from the injected now
 	Status     string `json:"status,omitempty"` // terminal marker only; "" while live
 }

--- a/internal/fleet/liveness.go
+++ b/internal/fleet/liveness.go
@@ -40,8 +40,9 @@ type Liveness struct {
 // collapses rows by workstream — newest heartbeat wins — and derives each
 // workstream's State from heartbeat age (staleAfter, abandonedAfter) and the
 // branchAlive predicate. branchAlive is the injectable seam over the git
-// branch/worktree check (mirroring identity's gitRunner) so liveness derivation
-// is testable without git: a workstream whose branch is gone is abandoned
+// branch/worktree check (fleet.BranchAlive in production) so liveness derivation
+// is testable without git; it is passed the newest row so it can read that
+// workstream's branch + dir, and a workstream whose branch is gone is abandoned
 // regardless of heartbeat age. Entries are returned sorted by workstream for a
 // deterministic cockpit ordering. A missing fleet dir is not an error — it
 // yields an empty fleet.
@@ -53,7 +54,7 @@ type Liveness struct {
 // more lenient than the event log's scan, which stays fail-loud: a liveness row is
 // ephemeral/derived, while a torn LOG line is durable-record corruption the human
 // must see.
-func List(hub string, now time.Time, staleAfter, abandonedAfter time.Duration, branchAlive func(workstream string) bool) (entries []Liveness, skipped int, err error) {
+func List(hub string, now time.Time, staleAfter, abandonedAfter time.Duration, branchAlive func(Row) bool) (entries []Liveness, skipped int, err error) {
 	dir := filepath.Join(hub, fleetDir)
 	files, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
@@ -109,7 +110,7 @@ func List(hub string, now time.Time, staleAfter, abandonedAfter time.Duration, b
 	for ws, a := range byWorkstream {
 		out = append(out, Liveness{
 			Workstream: ws,
-			State:      derive(a.newestHB, now, staleAfter, abandonedAfter, branchAlive(ws)),
+			State:      derive(a.newestHB, now, staleAfter, abandonedAfter, branchAlive(a.newest)),
 			UUID:       a.newest.UUID,
 			RepoKey:    a.newest.RepoKey,
 			Handle:     a.newest.Handle,

--- a/internal/fleet/liveness_test.go
+++ b/internal/fleet/liveness_test.go
@@ -14,8 +14,8 @@ const (
 
 // alive / dead are the two branch-existence predicates the liveness tests inject
 // in place of a real git check.
-func alive(string) bool { return true }
-func dead(string) bool  { return false }
+func alive(Row) bool { return true }
+func dead(Row) bool  { return false }
 
 // registerAt is a test helper: register a row with an explicit heartbeat time.
 func registerAt(t *testing.T, hub, ws, uuid, handle string, hb time.Time) {
@@ -30,7 +30,7 @@ func registerAt(t *testing.T, hub, ws, uuid, handle string, hb time.Time) {
 	}
 }
 
-func onlyEntry(t *testing.T, hub string, now time.Time, branchAlive func(string) bool) Liveness {
+func onlyEntry(t *testing.T, hub string, now time.Time, branchAlive func(Row) bool) Liveness {
 	t.Helper()
 	got, _, err := List(hub, now, staleTTL, abandonedTTL, branchAlive)
 	if err != nil {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -7,8 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/colinsurprenant/director/internal/event"
+	"github.com/colinsurprenant/director/internal/fleet"
 	"github.com/colinsurprenant/director/internal/identity"
 )
 
@@ -45,6 +47,17 @@ func gitRepo(t *testing.T, name, branch string) string {
 	// matches the repo's init.defaultBranch (which may itself be "main").
 	git("checkout", "-q", "-B", branch)
 	return dir
+}
+
+// gitIn runs git in dir, failing the test on error — for mutating a repo the test
+// already created (e.g. deleting a branch to simulate a merged-away worktree).
+func gitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
 }
 
 // readHealth returns the hook health log contents (or "" if absent).
@@ -322,6 +335,49 @@ func TestSessionStartThrowawayDoesNotRegister(t *testing.T) {
 	}
 	if fleetRowExists(t, hub, ws.ID) {
 		t.Errorf("throwaway session should not register a fleet row")
+	}
+}
+
+// TestSessionStartRegistersBranchForAbandonment locks the branch-liveness cleanup:
+// a real SessionStart stamps the row's branch + dir, so once that branch is gone
+// (its worktree merged away and was deleted) the cockpit derives the workstream
+// abandoned even though its heartbeat is still fresh.
+func TestSessionStartRegistersBranchForAbandonment(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "feature")
+	ws := mustResolve(t, repo)
+
+	in := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	if code := Dispatch(EventSessionStart, strings.NewReader(in), &bytes.Buffer{}, hub); code != 0 {
+		t.Fatalf("session start exit = %d", code)
+	}
+
+	stateOf := func() fleet.State {
+		t.Helper()
+		live, _, err := fleet.List(hub, time.Now(), 15*time.Minute, 2*time.Hour, fleet.BranchAlive)
+		if err != nil {
+			t.Fatalf("fleet.List: %v", err)
+		}
+		for _, l := range live {
+			if l.Workstream == ws.ID {
+				return l.State
+			}
+		}
+		t.Fatalf("no fleet entry for %s in %+v", ws.ID, live)
+		return ""
+	}
+
+	if got := stateOf(); got != fleet.StateActive {
+		t.Fatalf("fresh session on an existing branch → %q, want active", got)
+	}
+
+	// The branch merges away and is deleted (check out elsewhere first — git won't
+	// delete the checked-out branch).
+	gitIn(t, repo, "checkout", "-q", "-B", "scratch")
+	gitIn(t, repo, "branch", "-D", "feature")
+
+	if got := stateOf(); got != fleet.StateAbandoned {
+		t.Errorf("branch deleted → %q, want abandoned (the row's branch/dir must drive the check)", got)
 	}
 }
 

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -66,7 +66,7 @@ func handleSessionStart(in Input, out io.Writer, hub string) error {
 	}
 
 	if !throwaway {
-		if err := refreshFleet(hub, ws, sessionUUID(in)); err != nil {
+		if err := refreshFleet(hub, ws, sessionUUID(in), in.CWD); err != nil {
 			// A fleet write failure must not stop the injection — visibility of
 			// current state is more valuable than the heartbeat. Log loudly and
 			// continue to build the Ground-Truth block.
@@ -93,14 +93,18 @@ func handleSessionStart(in Input, out io.Writer, hub string) error {
 // (or resumed/compacted) session shows up live in the cockpit. Register is
 // create-or-refresh, so calling it on every start — first run or resume — keeps
 // one row current rather than spawning duplicates. The caller resolves uuid via
-// sessionUUID so every surface keys the same row.
-func refreshFleet(hub string, ws identity.Workstream, uuid string) error {
+// sessionUUID so every surface keys the same row. cwd (the session's working dir)
+// is stamped alongside the branch so liveness can check the branch still exists
+// and self-clean a merged-away worktree (§5.5).
+func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
 	now := time.Now()
 	row := fleet.Row{
 		Workstream: ws.ID,
 		UUID:       uuid,
 		RepoKey:    ws.RepoKey,
 		Handle:     ws.ID,
+		Branch:     ws.Branch,
+		Dir:        cwd,
 		Heartbeat:  now.Format(time.RFC3339Nano),
 	}
 	if err := fleet.Register(hub, row); err != nil {

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -97,7 +97,9 @@ func handleSessionStart(in Input, out io.Writer, hub string) error {
 // is stamped alongside the branch so liveness can check the branch still exists
 // and self-clean a merged-away worktree (§5.5).
 func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
-	now := time.Now()
+	// UTC to match every other fleet writer (register/heartbeat/adopt) so fleet/
+	// rows never carry mixed-offset timestamps.
+	now := time.Now().UTC()
 	row := fleet.Row{
 		Workstream: ws.ID,
 		UUID:       uuid,

--- a/internal/render/status.go
+++ b/internal/render/status.go
@@ -26,16 +26,17 @@ const (
 // liveness via fleet.List and, for each live workstream, folds that workstream's
 // LOG to surface the Needs-you band.
 //
-// branchAlive is the injectable git-branch-existence seam fleet.List takes; for
-// v1 status passes a predicate that always returns true, so liveness is driven by
-// heartbeat TTL alone. A real branch/worktree check is a documented fast-follow
-// (§5.5) — wiring it is a one-line change to the predicate here, not a fold change.
+// Liveness is derived from heartbeat age plus fleet.BranchAlive: a workstream
+// whose branch is gone (its worktree merged away and was deleted) reads abandoned
+// even with a fresh heartbeat, so the cockpit self-cleans. Rows registered without
+// branch/dir (older rows, or a bare-heartbeat row) fail open — BranchAlive returns
+// true — so they still age out by TTL rather than being falsely abandoned.
 //
 // now is injected (never time.Now() inside) so the cockpit is testable against a
 // fixed clock; recency is the only time-derived field and it is intentionally
 // excluded from the determinism gate (§13 t4 covers render/brief, not status).
 func Status(hub string, now time.Time) (string, error) {
-	live, skipped, err := fleet.List(hub, now, StaleAfter, AbandonedAfter, func(string) bool { return true })
+	live, skipped, err := fleet.List(hub, now, StaleAfter, AbandonedAfter, fleet.BranchAlive)
 	if err != nil {
 		return "", fmt.Errorf("status: list fleet: %w", err)
 	}


### PR DESCRIPTION
Wires the `branchAlive` predicate that v1 left stubbed (`status.go` passed `func(string) bool { return true }`), so the fleet cockpit self-cleans instead of waiting on the 2h heartbeat TTL.

## What changed

A workstream whose branch is gone — its worktree merged away and was deleted — now reads **abandoned** even with a fresh heartbeat.

- `fleet.Row` carries `Branch` + `Dir`, stamped at register (the SessionStart hook + the `director register` CLI) from the resolved workstream + cwd.
- `fleet.BranchAlive(Row)` runs `git -C <dir> show-ref --verify --quiet refs/heads/<branch>`. It **fails open** on missing metadata or a detached HEAD (never a false abandon), and reports gone on a deleted branch or a removed worktree dir.
- `fleet.List`'s predicate seam now takes the `Row` (it needs the branch + dir); `status` passes `fleet.BranchAlive` instead of the always-true stub.

The comment that called this a "one-line change" was wrong: the row carried no branch or repo path to run the check against, so the row schema, the register write path, and the predicate seam all had to change.

## Tests (TDD, each watched to fail first)

- Predicate unit tests with a fake git runner: present → alive, absent → dead, missing metadata → alive, detached HEAD → alive.
- Real-git integration test: existing branch → alive, deleted branch → dead, non-repo dir (worktree removed) → dead.
- End-to-end SessionStart test: registering on a branch then deleting it flips the workstream to abandoned.

## Verification

`go build ./... && go vet ./... && gofmt -l . && go test ./... -race` — all green across every package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
