### PR TITLE
chore: gitignore .director/ and .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 /projects/*/*
 !/projects/*/log.ndjson
 !/projects/*/CHARTER.md
+
+# Per-repo local state, never committed: .director/ is this repo's identity cache
+# (repo-key + workstream-id, derive-once), and — when dogfooding with the repo as
+# its own hub — its live LOG/fleet; .claude/settings.local.json is per-machine CC
+# config. Without these, a bare `git add -A` sweeps coordination state into a commit.
+/.director/
+/.claude/settings.local.json


### PR DESCRIPTION
Prevents a bare `git add -A` from sweeping Director's own coordination state into a commit.

`.director/` (identity cache: repo-key, workstream-id — and the live LOG/fleet when dogfooding with the repo as its own hub) and `.claude/settings.local.json` (per-machine CC config) were untracked-but-not-ignored. This was caught while committing the branch-liveness work, before anything left local.

The existing `.gitignore` only covered the hub-at-repo-root layout (`/fleet/`, `/health/`, `/projects/`); this adds the two in-repo local-state paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)