### PR TITLE
feat: /director:complete + /director:handoff close-out commands (step 1)

### DIFF
--- a/cmd/director/installcmd.go
+++ b/cmd/director/installcmd.go
@@ -30,6 +30,14 @@ func runInstall(args []string) int {
 		return 0
 	}
 	fmt.Printf("  shims written to %s (set DIRECTOR_HOOKS_DIR to override)\n", hooksDir)
+	commandsDir, err := install.DefaultCommandsDir()
+	if err != nil {
+		// Install already resolved and wrote to this same dir, so this is unreachable
+		// in practice — degrade rather than print a misleading empty path.
+		fmt.Fprintf(os.Stderr, "install: resolve commands dir for confirmation: %v\n", err)
+		return 0
+	}
+	fmt.Printf("  commands written to %s (/director:complete, /director:handoff)\n", commandsDir)
 	return 0
 }
 

--- a/cmd/director/installcmd.go
+++ b/cmd/director/installcmd.go
@@ -37,7 +37,7 @@ func runInstall(args []string) int {
 		fmt.Fprintf(os.Stderr, "install: resolve commands dir for confirmation: %v\n", err)
 		return 0
 	}
-	fmt.Printf("  commands written to %s (/director:complete, /director:handoff)\n", commandsDir)
+	fmt.Printf("  commands written to %s (/director:complete, /director:handoff; set DIRECTOR_COMMANDS_DIR to override)\n", commandsDir)
 	return 0
 }
 

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -40,6 +40,8 @@ func run(args []string) int {
 		return runBrief(rest)
 	case "status":
 		return runStatus(rest)
+	case "open-items":
+		return runOpenItems(rest)
 	case "adopt": // adoption (Phase 7)
 		return runAdopt(rest)
 	case "install": // installer (Phase 5)
@@ -71,6 +73,7 @@ projections:
   render      deterministic machine digest (+ --verify, manifest)
   brief       human re-orientation view (the bigger picture)
   status      one-line-per-workstream fleet cockpit
+  open-items  this workstream's open open-items (ULID + body), for /complete
 
 fleet lifecycle (hook-emitted):
   register    create/refresh this workstream's fleet row

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -73,7 +73,7 @@ projections:
   render      deterministic machine digest (+ --verify, manifest)
   brief       human re-orientation view (the bigger picture)
   status      one-line-per-workstream fleet cockpit
-  open-items  this workstream's open open-items (ULID + body), for /complete
+  open-items  this workstream's unresolved open-items (ULID + body), for /complete
 
 fleet lifecycle (hook-emitted):
   register    create/refresh this workstream's fleet row

--- a/cmd/director/projection.go
+++ b/cmd/director/projection.go
@@ -131,6 +131,30 @@ func runBrief(args []string) int {
 	return 0
 }
 
+// runOpenItems lists THIS workstream's OPEN open-items (`<ULID> <body>` per line),
+// the read affordance `/complete` consumes to present, recommend, and resolve them.
+// It is scoped to the current workstream because the repo log is shared across every
+// branch on the repo (§5.3) — run it from the session being closed out.
+func runOpenItems(args []string) int {
+	fs := flag.NewFlagSet("open-items", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	hub, ws, err := resolveContext()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open-items: %v\n", err)
+		return 1
+	}
+	store := event.NewStore(hub, ws.RepoKey)
+	events, err := store.ReadAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open-items: %v\n", err)
+		return 1
+	}
+	fmt.Print(render.OpenItemsFor(render.Fold(events), ws.ID))
+	return 0
+}
+
 // projectTarget resolves the (hub, repoKey) a render targets. An explicit
 // --project skips identity resolution (so render works from anywhere, e.g. a
 // hook outside a repo); otherwise it falls back to the current workstream's

--- a/docs/specs/2026-07-01-close-out-commands-design.md
+++ b/docs/specs/2026-07-01-close-out-commands-design.md
@@ -1,6 +1,7 @@
 # Close-out commands: `/complete` and `/handoff`
 
-Status: design → implementing (step 1). Supersedes the informal notes in the LOG
+Status: step 1 shipped (`director open-items` verb + the two commands + install
+wiring, gate-green); steps 2–3 pending. Supersedes the informal notes in the LOG
 (decisions `01KWCH30WRTMKVMYETR34KS8PQ`, `01KWFEZZT3V6GSD8PX9R3XZJBJ`; open-items
 `01KW0BKQXQS12AQ9BZVZ6FBP3W`, `01KW0BKQXAFBXYK7M1R4M01NAV`).
 
@@ -68,22 +69,25 @@ prompted this session); this is permanent calibration, and always a nudge.
 ## Delivery
 
 Slash commands are **model-orchestrated markdown** (they drive existing `director`
-CLI verbs: `render`/`brief`, `resolve`, `emit`, `done`) — not new Go subcommands. They
-live in the repo under `commands/director/{complete,handoff}.md` and `director install`
+CLI verbs: `render`/`brief`, `resolve`, `emit`, `done`, `open-items`) — not new Go
+subcommands. The embed source lives at `internal/install/commands/{complete,handoff}.md`
+— co-located with the install package because `//go:embed` cannot reach a parent dir,
+exactly as the hook shims live at `internal/install/shims/`. `director install`
 materializes them to `~/.claude/commands/director/` via the same `//go:embed` +
-write/remove pattern already used for hook shims — entirely separate from the
-settings.json merge. The `director/` subdir namespaces them (`/director:complete`,
+write/remove pattern (`writeCommands`/`removeCommands`) used for the shims — entirely
+separate from the settings.json merge (a plain file drop, no settings reference). The
+destination `director/` subdir namespaces them (`/director:complete`,
 `/director:handoff`) and avoids clobbering a user's own `complete.md`/`handoff.md`.
 
-Open implementation question for step 1: `/complete` needs *this workstream's*
-open-items with their ULIDs. If `render`/`brief` don't already surface the workstream
-per open-item clearly enough for the model to filter, add a small read affordance;
-otherwise the command orchestrates existing verbs unchanged.
+Resolved implementation question (step 1): `/complete` needs *this workstream's*
+open-items with their ULIDs, which `render`/`brief` don't surface per-workstream. Shipped
+as the small read-only verb **`director open-items`** (`<ULID> <body>` per line, scoped
+to the current workstream) — no fold/schema change. `/complete` consumes it directly.
 
 ## Build sequence
 
-1. **The commands** — `commands/director/{complete,handoff}.md` + `install` places
-   them (this step).
+1. **The commands** — `internal/install/commands/{complete,handoff}.md` + the
+   `director open-items` read affordance + `install` places them (SHIPPED).
 2. **Injected-protocol update** — distinguish complete-vs-handoff; suggest at the
    judgment triggers.
 3. **Deterministic nudges** — branch-gone → `/complete` (Stop/`status`); PreCompact →

--- a/docs/specs/2026-07-01-close-out-commands-design.md
+++ b/docs/specs/2026-07-01-close-out-commands-design.md
@@ -1,0 +1,90 @@
+# Close-out commands: `/complete` and `/handoff`
+
+Status: design → implementing (step 1). Supersedes the informal notes in the LOG
+(decisions `01KWCH30WRTMKVMYETR34KS8PQ`, `01KWFEZZT3V6GSD8PX9R3XZJBJ`; open-items
+`01KW0BKQXQS12AQ9BZVZ6FBP3W`, `01KW0BKQXAFBXYK7M1R4M01NAV`).
+
+## Problem
+
+A worktree session is usually spun up for one task; once it merges, its open-items
+need a deliberate close-out — resolve what it finished, hand real follow-ups to the
+repo backlog, retire its fleet row. Today that is manual (`director resolve` per
+item) and easy to forget: sessions exit leaving open-items attached to a dead
+workstream. And `/handoff` (continuation) is the wrong verb for a *finished*
+workstream — a handoff writes a "next action" that a done workstream doesn't have.
+
+## Two boundary commands
+
+| | `/handoff` | `/complete` |
+|---|---|---|
+| meaning | pausing, will resume | workstream finished |
+| writes | a `handoff` event (the baton) | close-markers + a summary `note` |
+| fleet row | stays live | archived (`director done`) |
+| trigger | mid-stream boundary | task done + branch merged/gone |
+
+## `/complete` behavior
+
+1. Fold **this** workstream's open-set.
+2. Per open-item, show an analysis + recommendation from the live diff/PR context —
+   e.g. *"item X — resolved by this PR (rec: close)"* vs *"item Y — deferred
+   follow-up, untouched (rec: keep — migrates to the repo backlog)"*.
+3. Human confirms.
+4. `director resolve <ulid>` each confirmed item. Follow-ups stay **open** — the
+   shared repo log means the next session on `main` inherits them (they *are* the
+   continuation; no handoff needed).
+5. `director emit --type note` — a one-line completion summary.
+6. `director done` — archive the fleet row.
+
+No new event kind (schema is locked, §17): completion = close-markers + note +
+fleet archive. A finished workstream has no next action, so `/complete` must **not**
+write a handoff (it would plant a phantom baton in `LatestHandoff` → `render`/`brief`
+keep showing a dead workstream as resumable).
+
+## Trigger: branch-gone, not merge-interception
+
+The reliable signal is **branch-gone** (shipped: `fleet.BranchAlive`). Do NOT try to
+intercept the merge: a CC hook misses GitHub-UI merges and the merger usually isn't
+the worktree session, and `is-ancestor` derivation is defeated by squash *and* rebase
+(new SHAs — our own rebase-merge workflow evades it). Rationale in decision
+`01KWFEZZT3V6GSD8PX9R3XZJBJ`.
+
+## Proactive suggestion layer (calibrated; nudge, never gate)
+
+Two surfaces, each for the triggers it detects reliably:
+
+- **Hook-side (deterministic):** branch-gone → nudge `/complete` (Stop/`status`);
+  the **PreCompact** boundary → nudge/checkpoint `/handoff`. PreCompact is the honest
+  version of "% context usage" — the model can't see its own %, and no hook exposes an
+  arbitrary threshold, but PreCompact fires exactly when unsaved state would be lost.
+- **Model-side (judgment, the SessionStart-injected protocol):** suggest `/complete`
+  when the task is logically done/merged (before any branch deletion); `/handoff` at
+  natural boundaries (already in the protocol — extend it to distinguish the two).
+
+Caveat (the emit-guard lesson): proactive prompts have a signal-to-noise cost. Fire
+them too eagerly and they become ignored wallpaper. Criteria stay tight (e.g.
+`/complete` nudge only when branch-gone **and** open items exist **and** not already
+prompted this session); this is permanent calibration, and always a nudge.
+
+## Delivery
+
+Slash commands are **model-orchestrated markdown** (they drive existing `director`
+CLI verbs: `render`/`brief`, `resolve`, `emit`, `done`) — not new Go subcommands. They
+live in the repo under `commands/director/{complete,handoff}.md` and `director install`
+materializes them to `~/.claude/commands/director/` via the same `//go:embed` +
+write/remove pattern already used for hook shims — entirely separate from the
+settings.json merge. The `director/` subdir namespaces them (`/director:complete`,
+`/director:handoff`) and avoids clobbering a user's own `complete.md`/`handoff.md`.
+
+Open implementation question for step 1: `/complete` needs *this workstream's*
+open-items with their ULIDs. If `render`/`brief` don't already surface the workstream
+per open-item clearly enough for the model to filter, add a small read affordance;
+otherwise the command orchestrates existing verbs unchanged.
+
+## Build sequence
+
+1. **The commands** — `commands/director/{complete,handoff}.md` + `install` places
+   them (this step).
+2. **Injected-protocol update** — distinguish complete-vs-handoff; suggest at the
+   judgment triggers.
+3. **Deterministic nudges** — branch-gone → `/complete` (Stop/`status`); PreCompact →
+   `/handoff` checkpoint (confirm CC exposes PreCompact).

--- a/internal/install/commands/complete.md
+++ b/internal/install/commands/complete.md
@@ -8,7 +8,7 @@ You are running the TERMINAL close-out for THIS workstream: its task is finished
 
 2. **List this workstream's open loops.** Run:
    `director open-items`
-   It prints `<ULID> <body>`, one per line, for the open-items this workstream still owns. If it prints nothing, skip to step 5.
+   It prints `<ULID> <body>` one per line (an escalate item as `<ULID> [risk:escalate] <body>`) for the open-items this workstream still owns. If it prints `(none)`, there is nothing to close — skip to step 5.
 
 3. **Triage each open-item against what this work actually shipped.** For every line, decide from the diff / PR context whether the work you just completed RESOLVED it, and present a recommendation to me — do not resolve anything yet:
    - resolved by this work → *"<body> — resolved by this PR (rec: close)"*

--- a/internal/install/commands/complete.md
+++ b/internal/install/commands/complete.md
@@ -1,0 +1,28 @@
+---
+description: Close out a finished, merged workstream — resolve what it completed, hand genuine follow-ups to the repo backlog, and archive its fleet row. Use when the task is DONE and the branch is merged/gone; to pause work you will resume, use /director:handoff instead.
+---
+
+You are running the TERMINAL close-out for THIS workstream: its task is finished and its branch is merged (or gone). This is not a pause — a finished workstream has no next action, so you must NOT write a handoff (that would leave a phantom baton that keeps showing this workstream as resumable). Work through these steps in order.
+
+1. **Sanity-check that this workstream is actually done.** Confirm the work is complete and the branch is merged or gone. If you are only pausing and will resume, STOP and run `/director:handoff` instead — that is the continuation checkpoint; this is the terminal close-out.
+
+2. **List this workstream's open loops.** Run:
+   `director open-items`
+   It prints `<ULID> <body>`, one per line, for the open-items this workstream still owns. If it prints nothing, skip to step 5.
+
+3. **Triage each open-item against what this work actually shipped.** For every line, decide from the diff / PR context whether the work you just completed RESOLVED it, and present a recommendation to me — do not resolve anything yet:
+   - resolved by this work → *"<body> — resolved by this PR (rec: close)"*
+   - genuine follow-up, untouched → *"<body> — deferred follow-up (rec: keep — migrates to the repo backlog)"*
+   Show me the full list with one recommendation per item.
+
+4. **Wait for my confirmation**, then resolve ONLY the items I confirm as done:
+   `director resolve <ULID>`   (copy the exact ULID from the step-2 output — never invent or reconstruct one; `resolve` rejects any id it did not surface)
+   Leave every genuine follow-up OPEN. Do not "tidy" them closed. The repo log is shared, so the next session on `main` inherits the still-open items automatically — they ARE the continuation, and need no handoff.
+
+5. **Emit a one-line completion summary** as a note (FYI for future / parallel sessions):
+   `director emit --type note --area <subsystem> "<workstream> complete — <what shipped, e.g. PR #N merged>"`
+
+6. **Archive the fleet row:**
+   `director done`
+
+7. **Confirm to me plainly:** which items you resolved, which stay open (now inherited by `main`), and the note's ULID. Do NOT emit a handoff event.

--- a/internal/install/commands/handoff.md
+++ b/internal/install/commands/handoff.md
@@ -1,0 +1,15 @@
+---
+description: Checkpoint this session into Director — flush pending decisions/open-items and emit a self-sufficient handoff so a fresh session can fully rehydrate. Use when PAUSING work you will resume; for a finished, merged workstream use /director:complete instead.
+---
+
+You are checkpointing THIS session into Director (the coordination LOG) so a fresh session — you after a compaction, or a peer — can pick up exactly where you left off. The next session rehydrates from Director's injected Ground Truth (CHARTER + decisions + open-items + latest handoff); anything not in the LOG is lost. If this workstream is actually FINISHED and merged, stop and run `/director:complete` instead — a done workstream needs a close-out, not a baton. Otherwise do this now, in order:
+
+1. **Flush this session's durable items** — emit each as its own event, capturing everything not already in the LOG (do not assume earlier turns emitted them):
+   - every decision made → `director emit --type decision --area <area> "<what + the why>"`
+   - every open loop / deferred follow-up → `director emit --type open-item --area <area> --risk <low|escalate> "<the loop>"` (use `escalate` ONLY when it needs the human)
+
+2. **Emit a SELF-SUFFICIENT handoff** — complete enough that a fresh session can continue from it ALONE:
+   `director emit --type handoff --area <area> "<current position> · <the next 3–5 concrete steps, in order> · <every gotcha / constraint / in-flight state>"`
+   Be thorough: PR / build / deploy state, branches, local-only commits, what's verified vs pending, and any trap a fresh session must avoid.
+
+3. **Confirm:** report the new handoff ULID, run `director brief`, and tell me plainly if anything important from this session could NOT be reliably reconstructed from the LOG — so I can fill the gap before the context is lost.

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -353,25 +353,25 @@ func writeExecutable(path string, data []byte) error {
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("install: create temp file: %w", err)
+		return fmt.Errorf("install: create temp file for %s: %w", path, err)
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		os.Remove(tmpName)
-		return fmt.Errorf("install: write temp file: %w", err)
+		return fmt.Errorf("install: write temp file for %s: %w", path, err)
 	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpName)
-		return fmt.Errorf("install: close temp file: %w", err)
+		return fmt.Errorf("install: close temp file for %s: %w", path, err)
 	}
 	if err := os.Chmod(tmpName, perm); err != nil {
 		os.Remove(tmpName)
-		return fmt.Errorf("install: chmod file: %w", err)
+		return fmt.Errorf("install: chmod %s: %w", path, err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
 		os.Remove(tmpName)
-		return fmt.Errorf("install: rename file into place: %w", err)
+		return fmt.Errorf("install: rename %s into place: %w", path, err)
 	}
 	return nil
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -30,6 +30,17 @@ import (
 //go:embed shims/*.sh
 var shimFS embed.FS
 
+// commandsFS embeds the slash-command markdown (/director:complete,
+// /director:handoff) into the binary so `director install` places them itself, the
+// same self-contained pattern as shimFS. internal/install/commands/ is the single
+// source of truth; the on-disk copies install writes therefore never drift from the
+// binary. These are model-orchestrated commands that drive existing `director` CLI
+// verbs — writing them is pure file materialization, wholly separate from the
+// settings.json merge, so it stays clear of the merge's clobber risk.
+//
+//go:embed commands/*.md
+var commandsFS embed.FS
+
 // managedByKey / managedByValue tag every command object Director owns. CC
 // ignores unknown fields, so the tag is invisible to the platform but lets
 // install/uninstall find exactly Director's entries and nothing else.
@@ -43,6 +54,10 @@ const (
 // installed command is the shim path, NOT the binary, so settings.json stays
 // stable across rebuilds (§5.4).
 const hooksDirEnv = "DIRECTOR_HOOKS_DIR"
+
+// commandsDirEnv lets a caller (and the tests) redirect where the slash-command
+// markdown is materialized. When unset, DefaultCommandsDir is used.
+const commandsDirEnv = "DIRECTOR_COMMANDS_DIR"
 
 // managedEntry describes one hook Director installs: which CC event it attaches
 // to, the matcher (empty = all), and the shim filename under the hooks dir.
@@ -89,6 +104,22 @@ func DefaultHooksDir() (string, error) {
 	return filepath.Join(home, ".claude", "director", "hooks"), nil
 }
 
+// DefaultCommandsDir resolves the standard slash-command directory,
+// ~/.claude/commands/director. The `director/` subdir both namespaces the commands
+// (CC exposes them as /director:complete, /director:handoff) and guarantees Director
+// only ever writes into a directory it owns — it never touches a user's own
+// commands/complete.md. DIRECTOR_COMMANDS_DIR overrides the location.
+func DefaultCommandsDir() (string, error) {
+	if d := os.Getenv(commandsDirEnv); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("install: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".claude", "commands", "director"), nil
+}
+
 // Install merges Director's tagged hook entries into the settings file at
 // settingsPath. It is idempotent: an identical tagged entry already present is
 // left as-is, so re-running adds nothing (entry-count-stable). Untagged and
@@ -102,6 +133,16 @@ func Install(settingsPath string) error {
 	// Materialize the embedded shims FIRST: if this fails we return before touching
 	// settings.json, so the file never ends up pointing at shims that aren't there.
 	if err := writeShims(hooksDir); err != nil {
+		return err
+	}
+	// Materialize the slash commands too, before the settings merge. This is an
+	// independent file-drop (no settings.json reference), so a failure here also
+	// leaves the merge untouched.
+	commandsDir, err := DefaultCommandsDir()
+	if err != nil {
+		return err
+	}
+	if err := writeCommands(commandsDir); err != nil {
 		return err
 	}
 	root, err := loadSettings(settingsPath)
@@ -219,6 +260,11 @@ func Uninstall(settingsPath string) error {
 	if hooksDir, err := DefaultHooksDir(); err == nil {
 		removeShims(hooksDir)
 	}
+	// And the Director-owned slash commands — the inverse of writeCommands, same
+	// best-effort, exact-filenames-only discipline.
+	if commandsDir, err := DefaultCommandsDir(); err == nil {
+		removeCommands(commandsDir)
+	}
 	return nil
 }
 
@@ -250,30 +296,82 @@ func writeShims(hooksDir string) error {
 	return nil
 }
 
+// writeCommands materializes the embedded slash-command markdown into commandsDir,
+// creating the dir and overwriting any existing copies so they always match THIS
+// binary — the exact shape of writeShims, but the files are read by CC (not run), so
+// they are written 0o644, not executable. Idempotent (re-install reproduces the same
+// files) and atomic per file (temp + rename).
+func writeCommands(commandsDir string) error {
+	if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+		return fmt.Errorf("install: create commands dir %s: %w", commandsDir, err)
+	}
+	entries, err := fs.ReadDir(commandsFS, "commands")
+	if err != nil {
+		return fmt.Errorf("install: read embedded commands: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := commandsFS.ReadFile("commands/" + e.Name())
+		if err != nil {
+			return fmt.Errorf("install: read embedded command %s: %w", e.Name(), err)
+		}
+		if err := writeFileAtomic(filepath.Join(commandsDir, e.Name()), data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeCommands deletes the Director-owned command files from commandsDir — the
+// inverse of writeCommands — touching ONLY the exact embedded filenames so a foreign
+// file in the dir is never removed, then drops the dir if it is left empty.
+// Best-effort: errors are swallowed so uninstall succeeds even if a file was already
+// gone or the dir holds other files.
+func removeCommands(commandsDir string) {
+	entries, err := fs.ReadDir(commandsFS, "commands")
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		_ = os.Remove(filepath.Join(commandsDir, e.Name()))
+	}
+	_ = os.Remove(commandsDir) // succeeds only if now empty; a dir with foreign files is left intact
+}
+
 // writeExecutable writes data to path with mode 0o755 via temp + chmod + rename so
 // the file appears atomically and already executable.
 func writeExecutable(path string, data []byte) error {
+	return writeFileAtomic(path, data, 0o755)
+}
+
+// writeFileAtomic writes data to path with the given mode via temp + chmod + rename,
+// so a concurrent reader never sees a half-written file or the wrong permission bits.
+// It is the shared mechanism behind both the executable shims (0o755) and the
+// read-only command markdown (0o644).
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("install: create temp shim: %w", err)
+		return fmt.Errorf("install: create temp file: %w", err)
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		os.Remove(tmpName)
-		return fmt.Errorf("install: write temp shim: %w", err)
+		return fmt.Errorf("install: write temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpName)
-		return fmt.Errorf("install: close temp shim: %w", err)
+		return fmt.Errorf("install: close temp file: %w", err)
 	}
-	if err := os.Chmod(tmpName, 0o755); err != nil {
+	if err := os.Chmod(tmpName, perm); err != nil {
 		os.Remove(tmpName)
-		return fmt.Errorf("install: chmod shim: %w", err)
+		return fmt.Errorf("install: chmod file: %w", err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
 		os.Remove(tmpName)
-		return fmt.Errorf("install: rename shim into place: %w", err)
+		return fmt.Errorf("install: rename file into place: %w", err)
 	}
 	return nil
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -106,9 +106,12 @@ func DefaultHooksDir() (string, error) {
 
 // DefaultCommandsDir resolves the standard slash-command directory,
 // ~/.claude/commands/director. The `director/` subdir both namespaces the commands
-// (CC exposes them as /director:complete, /director:handoff) and guarantees Director
-// only ever writes into a directory it owns — it never touches a user's own
-// commands/complete.md. DIRECTOR_COMMANDS_DIR overrides the location.
+// (CC exposes them as /director:complete, /director:handoff) and keeps Director's
+// writes inside a directory it owns, so on the default path it never clobbers a
+// user's own ~/.claude/commands/complete.md. That no-clobber property is a property
+// of the DEFAULT path only: DIRECTOR_COMMANDS_DIR overrides the location to any
+// directory (writeCommands overwrites complete.md/handoff.md there and removeCommands
+// deletes them), so avoiding a collision under an override is the caller's responsibility.
 func DefaultCommandsDir() (string, error) {
 	if d := os.Getenv(commandsDirEnv); d != "" {
 		return d, nil

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -318,6 +318,48 @@ func TestInstallWritesAndUninstallRemovesCommands(t *testing.T) {
 			t.Errorf("Uninstall left command %s in place", name)
 		}
 	}
+	// With only Director's files, the now-empty dir is pruned (mirrors removeShims).
+	if _, err := os.Stat(commandsDir); !os.IsNotExist(err) {
+		t.Errorf("Uninstall did not prune the now-empty commands dir")
+	}
+}
+
+// TestUninstallPreservesForeignCommands is the charter's touch-only-our-files
+// invariant for the commands dir: a user-authored file in ~/.claude/commands/director/
+// must survive Uninstall, and its presence must keep the dir alive. This dir is a
+// plausible home for a user's own commands, so the guard matters — a naive
+// os.RemoveAll(commandsDir) cleanup would pass every other test while silently
+// deleting the user's file.
+func TestUninstallPreservesForeignCommands(t *testing.T) {
+	path, _ := writeFixture(t, "")
+	commandsDir := filepath.Join(t.TempDir(), "commands")
+	t.Setenv(commandsDirEnv, commandsDir)
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(commandsDir, "my-notes.md")
+	if err := os.WriteFile(foreign, []byte("mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// Director's own commands are gone...
+	for _, name := range []string{"complete.md", "handoff.md"} {
+		if _, err := os.Stat(filepath.Join(commandsDir, name)); !os.IsNotExist(err) {
+			t.Errorf("Uninstall left Director command %s in place", name)
+		}
+	}
+	// ...but the foreign file and the dir it lives in survive untouched.
+	if _, err := os.Stat(foreign); err != nil {
+		t.Errorf("Uninstall deleted a foreign command file: %v", err)
+	}
+	if _, err := os.Stat(commandsDir); err != nil {
+		t.Errorf("Uninstall pruned the commands dir while a foreign file remained: %v", err)
+	}
 }
 
 // TestInstallRefusesWrongTypedHooks is H1: a present-but-wrong-typed "hooks" value

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -274,6 +274,52 @@ func TestInstallWritesAndUninstallRemovesShims(t *testing.T) {
 	}
 }
 
+// TestInstallWritesAndUninstallRemovesCommands verifies Install materializes the
+// embedded slash-command markdown into the commands dir — byte-identical to the
+// embedded source and mode 0644 (read by CC, not executed) — and Uninstall removes
+// them. This is the turnkey delivery of /director:complete and /director:handoff:
+// no manual command placement, and entirely separate from the settings.json merge.
+func TestInstallWritesAndUninstallRemovesCommands(t *testing.T) {
+	path, _ := writeFixture(t, "")
+	commandsDir := filepath.Join(t.TempDir(), "commands")
+	t.Setenv(commandsDirEnv, commandsDir)
+	cmds := []string{"complete.md", "handoff.md"}
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range cmds {
+		dest := filepath.Join(commandsDir, name)
+		info, err := os.Stat(dest)
+		if err != nil {
+			t.Fatalf("command %s not written by Install: %v", name, err)
+		}
+		if info.Mode().Perm() != 0o644 {
+			t.Errorf("command %s mode = %v, want 0644", name, info.Mode().Perm())
+		}
+		got, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want, err := commandsFS.ReadFile("commands/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("written command %s does not match the embedded source", name)
+		}
+	}
+
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range cmds {
+		if _, err := os.Stat(filepath.Join(commandsDir, name)); !os.IsNotExist(err) {
+			t.Errorf("Uninstall left command %s in place", name)
+		}
+	}
+}
+
 // TestInstallRefusesWrongTypedHooks is H1: a present-but-wrong-typed "hooks" value
 // must make Install REFUSE (error) and leave the file byte-for-byte unchanged,
 // never silently overwriting foreign data.

--- a/internal/render/openitems.go
+++ b/internal/render/openitems.go
@@ -1,0 +1,28 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OpenItemsFor renders one workstream's OPEN open-items as `<ULID> <body>` lines
+// (escalate-tagged), the read affordance `/complete` consumes to list, recommend,
+// and resolve its own loops. It filters the folded open-set to items EMITTED by
+// workstream: the repo log is shared across every branch on the repo (§5.3), so
+// without the filter `/complete` would surface a peer workstream's loops and might
+// resolve them. Deterministic — the open-set is already ULID-ordered. Empty (no open
+// items for this workstream) yields a stable "(none)" line so the caller can branch
+// on it without special-casing empty output.
+func OpenItemsFor(proj Projection, workstream string) string {
+	var b strings.Builder
+	for _, o := range proj.OpenItems {
+		if o.Workstream != workstream {
+			continue
+		}
+		fmt.Fprintf(&b, "%s %s%s\n", o.ID, escalateTag(o.Risk), oneLine(o.Body))
+	}
+	if b.Len() == 0 {
+		return "(none)\n"
+	}
+	return b.String()
+}

--- a/internal/render/openitems_test.go
+++ b/internal/render/openitems_test.go
@@ -1,0 +1,52 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/colinsurprenant/director/internal/event"
+)
+
+// TestOpenItemsForScopesToWorkstream is the core contract /complete relies on: the
+// repo log is shared across branches, so the affordance must return ONLY the given
+// workstream's open-items — never a peer workstream's — each as `<ULID> <body>`.
+func TestOpenItemsForScopesToWorkstream(t *testing.T) {
+	a, b, c := mint(t), mint(t), mint(t)
+	proj := Fold([]event.Event{
+		{ID: a, SchemaVersion: event.SchemaVersion, Type: event.KindOpenItem, Workstream: "ws1", Status: event.StatusOpen, Body: "finish the parser"},
+		{ID: b, SchemaVersion: event.SchemaVersion, Type: event.KindOpenItem, Workstream: "ws2", Status: event.StatusOpen, Body: "unrelated peer loop"},
+		{ID: c, SchemaVersion: event.SchemaVersion, Type: event.KindOpenItem, Workstream: "ws1", Status: event.StatusOpen, Risk: event.RiskEscalate, Body: "need a decision"},
+	})
+
+	out := OpenItemsFor(proj, "ws1")
+
+	if !strings.Contains(out, a+" finish the parser") {
+		t.Errorf("ws1 item (id+body) missing:\n%s", out)
+	}
+	if !strings.Contains(out, c) || !strings.Contains(out, "need a decision") {
+		t.Errorf("ws1 escalate item missing:\n%s", out)
+	}
+	if strings.Contains(out, "unrelated peer loop") || strings.Contains(out, b) {
+		t.Errorf("ws2 peer item leaked into ws1 output:\n%s", out)
+	}
+}
+
+// TestOpenItemsForExcludesResolved: an open-item closed by a marker is not part of
+// the open-set, so it must not appear (Fold already drops it; this locks the seam).
+func TestOpenItemsForExcludesResolved(t *testing.T) {
+	open, marker := mint(t), mint(t)
+	proj := Fold([]event.Event{
+		{ID: open, SchemaVersion: event.SchemaVersion, Type: event.KindOpenItem, Workstream: "ws1", Status: event.StatusOpen, Body: "already handled"},
+		{ID: marker, SchemaVersion: event.SchemaVersion, Type: event.KindOpenItem, Workstream: "ws1", Status: event.StatusClosed, Refs: []string{open}},
+	})
+	if got := OpenItemsFor(proj, "ws1"); got != "(none)\n" {
+		t.Errorf("resolved item should not list; got %q", got)
+	}
+}
+
+// TestOpenItemsForEmpty: no items for the workstream → a stable "(none)" line.
+func TestOpenItemsForEmpty(t *testing.T) {
+	if got := OpenItemsFor(Projection{}, "ws1"); got != "(none)\n" {
+		t.Errorf("empty → %q, want \"(none)\\n\"", got)
+	}
+}


### PR DESCRIPTION
Delivers **step 1** of the close-out-commands design (`docs/specs/2026-07-01-close-out-commands-design.md`): two model-orchestrated slash commands for workstream boundaries, plus the read affordance and install wiring they need.

## What ships
- **`director open-items`** — a read-only verb printing THIS workstream's open open-items (`<ULID> <body>`, escalate-tagged; `(none)` sentinel when empty). Scoped to the current workstream because the repo log is shared across branches — so `/complete` never surfaces or resolves a peer's loops. No fold/schema change.
- **`/director:complete`** — TERMINAL close-out of a finished, merged worktree: `open-items` → per-item close/keep recommendation from the diff → **human-confirmed** `resolve` → summary `note` → `done` (archive the fleet row). Deliberately emits **no handoff** (a finished workstream has no next action; a baton would keep showing it as resumable). Genuine follow-ups stay OPEN — `main` inherits them via the shared log.
- **`/director:handoff`** — CONTINUATION checkpoint: flush pending decisions/open-items, emit a self-sufficient handoff, show `brief`.
- **Install wiring** — `//go:embed commands/*.md` + `DefaultCommandsDir` (`~/.claude/commands/director/`) + `writeCommands`/`removeCommands`, materialized on `director install` exactly like the hook shims. A plain file drop with **no settings.json reference** — entirely separate from the `_managedBy` merge, so it stays clear of the merge's clobber-safety.

## Notes
- `writeExecutable` was extracted to a shared `writeFileAtomic(path, data, perm)` — shims stay 0755, the markdown commands write 0644 (CC reads them, never execs). Behavior-preserving for the shim path.
- Uninstall removes ONLY the exact embedded filenames and prunes the dir only if empty — a user's own file in `commands/director/` is never touched (regression-guarded).
- The embed source lives at `internal/install/commands/` (co-located with the package; `//go:embed` can't reach a parent dir), installed to the namespaced `~/.claude/commands/director/`.

## Verification
- §13 gate green: `go build ./... && go vet ./... && gofmt -l . && go test ./... -race`.
- TDD'd (`TestInstallWritesAndUninstallRemovesCommands`, `TestUninstallPreservesForeignCommands` — the foreign-file guard is mutation-proven to fail against a naive `RemoveAll`).
- End-to-end: real binary `install` writes both commands at 0644 and reports them; `uninstall` removes them and prunes the empty dir; the settings merge is untouched.
- Reviewed (ce:code-reviewer): APPROVE, no critical/high; all four charter constraints verified. Review findings applied in `43c3f0d`.

Next (separate PRs): step 2 (protocol update distinguishing `/complete` vs `/handoff` at judgment triggers) and step 3 (deterministic nudges: branch-gone→`/complete`, PreCompact→`/handoff`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
