### PR TITLE
feat(hook): boundary-command protocol + context-fill handoff nudge (close-out steps 2+3a)

### DIFF
--- a/docs/specs/2026-07-01-close-out-commands-design.md
+++ b/docs/specs/2026-07-01-close-out-commands-design.md
@@ -53,10 +53,30 @@ the worktree session, and `is-ancestor` derivation is defeated by squash *and* r
 
 Two surfaces, each for the triggers it detects reliably:
 
-- **Hook-side (deterministic):** branch-gone → nudge `/complete` (Stop/`status`);
-  the **PreCompact** boundary → nudge/checkpoint `/handoff`. PreCompact is the honest
-  version of "% context usage" — the model can't see its own %, and no hook exposes an
-  arbitrary threshold, but PreCompact fires exactly when unsaved state would be lost.
+- **Hook-side (deterministic):** context-fill → nudge `/handoff`. A real fill signal
+  exists (verified 2026-07-02, superseding this spec's earlier PreCompact rationale):
+  every assistant record in the transcript carries `message.usage`, and the sum of
+  `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` on the last
+  assistant record is the current context size. PostToolUse tail-reads the transcript
+  (bounded 1 MiB seek, fail-open) and, once per crossing of
+  `DIRECTOR_HANDOFF_NUDGE_TOKENS` (absolute tokens; unset = off), injects one
+  `additionalContext` nudge. The once-marker re-arms only when usage falls below half
+  the threshold, which only a compaction or clear can cause (emitting a handoff does
+  not shrink context, so no nag loop); a post-compaction re-approach deliberately gets
+  one more nudge. The threshold is absolute by design: CC exposes the window size only
+  to the statusline, never to hooks or transcripts, so percent-of-window is not
+  derivable hook-side. **PreCompact was verified and REJECTED:** it has no
+  model-visible output channel (block-only; the reason goes to the user), so it cannot
+  nudge, and blocking an auto-compaction gates the session at the worst moment.
+  Autocompact-ON users get the same protection by setting the threshold below their
+  compaction point; post-compaction re-grounding is already shipped (SessionStart
+  `source=compact`).
+  Branch-gone → `/complete` remains the second nudge, with an open design question: a
+  session's OWN local branch ref survives while its worktree lives (git refuses to
+  delete a checked-out branch), so branch-gone identifies dead SIBLING workstreams,
+  not the current one. The nudge must therefore surface in a LATER session
+  (SessionStart/status), and `/complete` needs cross-workstream targeting
+  (e.g. `open-items --workstream <id>`) before the nudge has something to point at.
 - **Model-side (judgment, the SessionStart-injected protocol):** suggest `/complete`
   when the task is logically done/merged (before any branch deletion); `/handoff` at
   natural boundaries (already in the protocol — extend it to distinguish the two).
@@ -89,6 +109,9 @@ to the current workstream) — no fold/schema change. `/complete` consumes it di
 1. **The commands** — `internal/install/commands/{complete,handoff}.md` + the
    `director open-items` read affordance + `install` places them (SHIPPED).
 2. **Injected-protocol update** — distinguish complete-vs-handoff; suggest at the
-   judgment triggers.
-3. **Deterministic nudges** — branch-gone → `/complete` (Stop/`status`); PreCompact →
-   `/handoff` checkpoint (confirm CC exposes PreCompact).
+   judgment triggers (SHIPPED).
+3. **Deterministic nudges** — context-fill threshold → `/handoff` via PostToolUse
+   (SHIPPED; see the hook-side bullet above — PreCompact rejected after verification).
+   Branch-gone → `/complete` is pending its targeting design: surface it at
+   SessionStart/status in a later session and give `/complete` cross-workstream
+   targeting first.

--- a/internal/hook/handoffnudge.go
+++ b/internal/hook/handoffnudge.go
@@ -88,15 +88,18 @@ func runHandoffNudge(in Input, hub string, ws identity.Workstream) (text string,
 
 	mark := handoffNudgeMarkerPath(hub, in.SessionID)
 	if usage >= threshold {
-		if _, err := os.Stat(mark); err == nil {
-			return "", usage // already nudged this crossing
-		}
 		if err := os.MkdirAll(filepath.Dir(mark), 0o755); err != nil {
 			return "", usage // can't record the one-shot → stay silent, never nag
 		}
-		if err := os.WriteFile(mark, []byte("1\n"), 0o644); err != nil {
+		// O_EXCL create is the atomic once-marker: parallel tool calls fire
+		// concurrent PostToolUse hook processes that can race the crossing, and
+		// exactly one may win — a stat-then-write pair would let several nudge.
+		// Any error (marker already exists, or it can't be recorded) → silent.
+		f, err := os.OpenFile(mark, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err != nil {
 			return "", usage
 		}
+		f.Close()
 		return fmt.Sprintf(
 			"Director: context is at ~%dk tokens, past the %dk handoff threshold. "+
 				"Suggest /director:handoff to the human now, and emit any unrecorded decisions/open-items via `director emit` before this context is lost.",

--- a/internal/hook/handoffnudge.go
+++ b/internal/hook/handoffnudge.go
@@ -1,0 +1,203 @@
+package hook
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/colinsurprenant/director/internal/identity"
+)
+
+// handoffnudge.go is the deterministic /director:handoff nudge (close-out spec
+// step 3): when the session's context grows past a user-set token threshold, one
+// PostToolUse additionalContext nudge suggests checkpointing via
+// /director:handoff before state is lost to a compaction or an abandoned session.
+//
+// The context-fill signal CC doesn't provide on the hook payload IS derivable:
+// every assistant record in the transcript carries message.usage, and
+// input_tokens + cache_creation_input_tokens + cache_read_input_tokens on the
+// LAST assistant record is the current context size. The transcript path is on
+// every hook payload, so a bounded tail-read gives a deterministic threshold
+// with zero new hook wiring. (PreCompact was rejected for this job: it has no
+// model-visible output channel — block-only — and blocking an auto-compaction
+// is a gate at the worst possible moment.)
+//
+// Anti-nag semantics (the emit-guard lesson — an over-firing nudge becomes
+// wallpaper): the nudge fires ONCE per threshold crossing, recorded by a marker
+// under health/. The marker re-arms only when usage falls below HALF the
+// threshold — which only a compaction or context clear can cause, since
+// emitting a handoff does not shrink context. A post-compaction re-approach to
+// the ceiling is a genuinely new event, so one more nudge is deliberate.
+//
+// Off by default: a no-op unless DIRECTOR_HANDOFF_NUDGE_TOKENS is a positive
+// integer. The threshold is ABSOLUTE tokens by design — CC exposes the model's
+// window size only to the statusline, not to hooks or transcripts, so a
+// percent-of-window threshold cannot be derived hook-side.
+
+// handoffNudgeEnv is the opt-in threshold variable, in absolute tokens
+// (e.g. 400000 for a 1M-window user targeting a 500k ceiling).
+const handoffNudgeEnv = "DIRECTOR_HANDOFF_NUDGE_TOKENS"
+
+// handoffNudgeTailBytes bounds the transcript tail-read. Large enough to almost
+// always contain a complete recent assistant record (a tool_use line carrying a
+// big Write payload can run hundreds of KB); if no complete assistant record
+// falls inside the window the nudge fails open (no read of the whole file).
+const handoffNudgeTailBytes = 1 << 20 // 1 MiB
+
+// handoffNudgeThreshold reads the opt-in threshold. Missing/zero/invalid
+// disables the nudge — the conservative default, matching nudgeInterval.
+func handoffNudgeThreshold() (tokens int, on bool) {
+	v := strings.TrimSpace(os.Getenv(handoffNudgeEnv))
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// runHandoffNudge decides whether to fire and returns the nudge text ("" = stay
+// silent) plus the measured usage for the caller's health log line. Best-effort
+// and fail-open throughout: any trouble measuring or gating yields silence,
+// never an error that could interfere with the tool flow.
+func runHandoffNudge(in Input, hub string) (text string, usage int) {
+	threshold, on := handoffNudgeThreshold()
+	if !on || isThrowawaySession(in) {
+		return "", 0
+	}
+
+	// Politeness gate, mirroring the emit-protocol injection: the nudge names
+	// /director:handoff, which only means something in an adopted repo. charter
+	// presence is the one-stat cheap check suited to a per-tool-call hook.
+	ws, err := identity.Resolve(in.CWD)
+	if err != nil || !charterExists(hub, ws.RepoKey) {
+		return "", 0
+	}
+
+	usage = tailContextTokens(in.TranscriptPath)
+	if usage <= 0 {
+		return "", 0
+	}
+
+	mark := handoffNudgeMarkerPath(hub, in.SessionID)
+	if usage >= threshold {
+		if _, err := os.Stat(mark); err == nil {
+			return "", usage // already nudged this crossing
+		}
+		if err := os.MkdirAll(filepath.Dir(mark), 0o755); err != nil {
+			return "", usage // can't record the one-shot → stay silent, never nag
+		}
+		if err := os.WriteFile(mark, []byte("1\n"), 0o644); err != nil {
+			return "", usage
+		}
+		return fmt.Sprintf(
+			"Director: context is at ~%dk tokens, past the %dk handoff threshold. "+
+				"Suggest /director:handoff to the human now, and emit any unrecorded decisions/open-items via `director emit` before this context is lost.",
+			usage/1000, threshold/1000), usage
+	}
+	if usage < threshold/2 {
+		// Usage collapsed to under half the threshold: only a compaction or a
+		// context clear does that. Re-arm so the next approach to the ceiling
+		// gets its own single nudge.
+		os.Remove(mark)
+	}
+	return "", usage
+}
+
+// handoffNudgeMarkerPath is the once-per-crossing marker, persisted under
+// health/ because each tool call is its own short-lived hook process (same
+// reason the flush-nudge counter lives there).
+func handoffNudgeMarkerPath(hub, session string) string {
+	if session == "" {
+		session = "manual"
+	}
+	return filepath.Join(hub, "health", "handoffnudge."+sanitizeSession(session)+".mark")
+}
+
+// tailContextTokens returns the current context size derived from the
+// transcript: the usage sum on the last assistant record within the bounded
+// tail. 0 means "could not measure" (missing/short/unparseable transcript, or
+// no complete assistant record in the window) — the caller treats it as
+// fail-open silence.
+func tailContextTokens(path string) int {
+	if strings.TrimSpace(path) == "" {
+		return 0
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return 0
+	}
+	offset := info.Size() - handoffNudgeTailBytes
+	if offset < 0 {
+		offset = 0
+	}
+	if _, err := f.Seek(offset, 0); err != nil {
+		return 0
+	}
+	data, err := readAllBounded(f, handoffNudgeTailBytes)
+	if err != nil {
+		return 0
+	}
+
+	lines := strings.Split(string(data), "\n")
+	if offset > 0 && len(lines) > 0 {
+		lines = lines[1:] // the seek almost surely landed mid-line; drop the partial
+	}
+	total := 0
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var rec usageRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue // tolerate partial/foreign lines — fail-open
+		}
+		if rec.Type != "assistant" {
+			continue
+		}
+		u := rec.Message.Usage
+		if sum := u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens; sum > 0 {
+			total = sum // last assistant usage in the tail wins
+		}
+	}
+	return total
+}
+
+// readAllBounded reads at most n bytes from r. Split out so the tail-read can't
+// grow unbounded if the file is appended between Stat and read.
+func readAllBounded(r *os.File, n int64) ([]byte, error) {
+	buf := make([]byte, n)
+	total := 0
+	for int64(total) < n {
+		m, err := r.Read(buf[total:])
+		total += m
+		if err != nil {
+			break // EOF (or a read error) ends the tail — return what we have
+		}
+	}
+	return buf[:total], nil
+}
+
+// usageRecord is the minimal projection of a transcript line the tail-read
+// needs: enough to find the last assistant record's usage sum.
+type usageRecord struct {
+	Type    string `json:"type"`
+	Message struct {
+		Usage struct {
+			InputTokens              int `json:"input_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}

--- a/internal/hook/handoffnudge.go
+++ b/internal/hook/handoffnudge.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -62,20 +63,21 @@ func handoffNudgeThreshold() (tokens int, on bool) {
 }
 
 // runHandoffNudge decides whether to fire and returns the nudge text ("" = stay
-// silent) plus the measured usage for the caller's health log line. Best-effort
-// and fail-open throughout: any trouble measuring or gating yields silence,
-// never an error that could interfere with the tool flow.
-func runHandoffNudge(in Input, hub string) (text string, usage int) {
+// silent) plus the measured usage for the caller's health log line. The caller
+// (handlePostToolUse) resolves ws once for the whole hot path and filters
+// throwaway sessions before calling. Best-effort and fail-open throughout: any
+// trouble measuring or gating yields silence, never an error that could
+// interfere with the tool flow.
+func runHandoffNudge(in Input, hub string, ws identity.Workstream) (text string, usage int) {
 	threshold, on := handoffNudgeThreshold()
-	if !on || isThrowawaySession(in) {
+	if !on {
 		return "", 0
 	}
 
 	// Politeness gate, mirroring the emit-protocol injection: the nudge names
 	// /director:handoff, which only means something in an adopted repo. charter
 	// presence is the one-stat cheap check suited to a per-tool-call hook.
-	ws, err := identity.Resolve(in.CWD)
-	if err != nil || !charterExists(hub, ws.RepoKey) {
+	if !charterExists(hub, ws.RepoKey) {
 		return "", 0
 	}
 
@@ -142,17 +144,29 @@ func tailContextTokens(path string) int {
 	if offset < 0 {
 		offset = 0
 	}
+	// A mid-line seek leaves a partial first segment that must be dropped — but
+	// only a mid-line one: when the byte before the window is a newline, the
+	// window starts on a record boundary and the first segment is complete
+	// (dropping it could silence the only assistant record in the window).
+	dropFirst := false
+	if offset > 0 {
+		prev := make([]byte, 1)
+		if _, err := f.ReadAt(prev, offset-1); err != nil {
+			return 0
+		}
+		dropFirst = prev[0] != '\n'
+	}
 	if _, err := f.Seek(offset, 0); err != nil {
 		return 0
 	}
-	data, err := readAllBounded(f, handoffNudgeTailBytes)
+	data, err := io.ReadAll(io.LimitReader(f, handoffNudgeTailBytes))
 	if err != nil {
 		return 0
 	}
 
 	lines := strings.Split(string(data), "\n")
-	if offset > 0 && len(lines) > 0 {
-		lines = lines[1:] // the seek almost surely landed mid-line; drop the partial
+	if dropFirst && len(lines) > 0 {
+		lines = lines[1:]
 	}
 	total := 0
 	for _, line := range lines {
@@ -172,21 +186,6 @@ func tailContextTokens(path string) int {
 		}
 	}
 	return total
-}
-
-// readAllBounded reads at most n bytes from r. Split out so the tail-read can't
-// grow unbounded if the file is appended between Stat and read.
-func readAllBounded(r *os.File, n int64) ([]byte, error) {
-	buf := make([]byte, n)
-	total := 0
-	for int64(total) < n {
-		m, err := r.Read(buf[total:])
-		total += m
-		if err != nil {
-			break // EOF (or a read error) ends the tail — return what we have
-		}
-	}
-	return buf[:total], nil
 }
 
 // usageRecord is the minimal projection of a transcript line the tail-read

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -273,6 +273,12 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	if !strings.Contains(got, "director resolve") {
 		t.Errorf("injected protocol should tell the model to resolve finished open-items:\n%s", got)
 	}
+	if !strings.Contains(got, "/director:complete") || !strings.Contains(got, "/director:handoff") {
+		t.Errorf("injected protocol should name BOTH close-out commands at the workstream-boundary triggers:\n%s", got)
+	}
+	if !strings.Contains(got, "Never hand off a finished workstream") {
+		t.Errorf("injected protocol should warn that done+merged takes /director:complete, not a handoff:\n%s", got)
+	}
 	if !strings.Contains(got, `"hookEventName":"SessionStart"`) {
 		t.Errorf("injection missing SessionStart control envelope:\n%s", got)
 	}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -835,6 +835,26 @@ func TestTailContextTokensTailBounded(t *testing.T) {
 	}
 }
 
+// TestTailContextTokensWindowOnRecordBoundary covers the seek landing EXACTLY on
+// a newline boundary: the first line in the window is then a complete record and
+// must NOT be dropped — here it is the only assistant usage record in the window.
+func TestTailContextTokensWindowOnRecordBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "boundary.jsonl")
+	head := `{"type":"user","message":{"content":"before the window"}}` + "\n"
+	a := `{"type":"assistant","message":{"usage":{"input_tokens":40000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":1000}}}` + "\n"
+	// One user pad record sized so head ends exactly at (size - tail window):
+	// the window then starts at the first byte of the assistant record.
+	padPrefix := `{"type":"user","message":{"content":"`
+	padSuffix := `"}}` + "\n"
+	pad := padPrefix + strings.Repeat("x", handoffNudgeTailBytes-len(a)-len(padPrefix)-len(padSuffix)) + padSuffix
+	if err := os.WriteFile(path, []byte(head+a+pad), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tailContextTokens(path); got != 43000 {
+		t.Fatalf("tailContextTokens = %d, want 43000 (boundary-aligned first record must survive)", got)
+	}
+}
+
 // --- shared input builders --------------------------------------------------
 
 // mustResolve resolves the workstream for a repo dir, failing the test on error.

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -686,6 +687,151 @@ func TestPostToolUseFiresOnInterval(t *testing.T) {
 	}
 	if fired != 2 { // tool calls 3 and 6
 		t.Fatalf("nudge fired %d times over 6 calls at every=3, want 2", fired)
+	}
+}
+
+// --- PostToolUse handoff-threshold nudge -------------------------------------
+
+// adoptRepo writes a CHARTER.md for the repo's project so the hub reads as
+// adopted — the politeness gate both the emit protocol and the handoff nudge key on.
+func adoptRepo(t *testing.T, hub, repoKey string) {
+	t.Helper()
+	dir := filepath.Join(hub, "projects", repoKey)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "CHARTER.md"), []byte("Goal: ship\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeUsageTranscript writes a minimal CC transcript whose LAST assistant
+// record carries the given usage sum (split across the three input fields to
+// prove they are summed), preceded by a user line and a stale assistant line
+// that must NOT win.
+func writeUsageTranscript(t *testing.T, path string, lastSum int) {
+	t.Helper()
+	lines := `{"type":"user","message":{"content":"hi"}}
+{"type":"assistant","message":{"usage":{"input_tokens":1,"cache_creation_input_tokens":1,"cache_read_input_tokens":1}}}
+{"type":"assistant","message":{"usage":{"input_tokens":2,"cache_creation_input_tokens":3,"cache_read_input_tokens":` + strconv.Itoa(lastSum-5) + `}}}
+`
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestHandoffNudgeLifecycle drives the full anti-nag state machine through
+// Dispatch: fires once on crossing, stays silent while the marker holds, re-arms
+// only when usage falls below half the threshold, then fires once again.
+func TestHandoffNudgeLifecycle(t *testing.T) {
+	t.Setenv(handoffNudgeEnv, "100000")
+	t.Setenv("DIRECTOR_FLUSH_NUDGE_EVERY", "")
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	adoptRepo(t, hub, mustResolve(t, repo).RepoKey)
+	transcript := filepath.Join(t.TempDir(), "session.jsonl")
+	in := `{"session_id":"s1","cwd":` + jsonString(repo) + `,"transcript_path":` + jsonString(transcript) + `,"hook_event_name":"PostToolUse","tool_name":"Bash"}`
+
+	call := func() string {
+		t.Helper()
+		var out bytes.Buffer
+		if code := Dispatch(EventPostToolUse, strings.NewReader(in), &out, hub); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		return out.String()
+	}
+
+	writeUsageTranscript(t, transcript, 120_000)
+	if got := call(); !strings.Contains(got, "/director:handoff") {
+		t.Fatalf("crossing the threshold should fire the handoff nudge, got %q", got)
+	}
+	if got := call(); got != "" {
+		t.Fatalf("second call over threshold must stay silent (marker), got %q", got)
+	}
+
+	// Still above HALF the threshold: emitting a handoff doesn't shrink context,
+	// so this must NOT re-arm — the reviewer's nag-loop edge.
+	writeUsageTranscript(t, transcript, 60_000)
+	if got := call(); got != "" {
+		t.Fatalf("usage above threshold/2 must not re-arm, got %q", got)
+	}
+	writeUsageTranscript(t, transcript, 120_000)
+	if got := call(); got != "" {
+		t.Fatalf("re-crossing without a re-arm must stay silent, got %q", got)
+	}
+
+	// Collapse below half (a compaction/clear): re-arms, next crossing fires once.
+	writeUsageTranscript(t, transcript, 30_000)
+	if got := call(); got != "" {
+		t.Fatalf("below threshold/2 re-arms silently, got %q", got)
+	}
+	writeUsageTranscript(t, transcript, 110_000)
+	if got := call(); !strings.Contains(got, "/director:handoff") {
+		t.Fatalf("post-re-arm crossing should fire one more nudge, got %q", got)
+	}
+	if got := call(); got != "" {
+		t.Fatalf("and only once, got %q", got)
+	}
+}
+
+// TestHandoffNudgeOffByDefault verifies the nudge is a no-op when the threshold
+// env var is unset, even with usage plainly over any sane ceiling.
+func TestHandoffNudgeOffByDefault(t *testing.T) {
+	t.Setenv(handoffNudgeEnv, "")
+	t.Setenv("DIRECTOR_FLUSH_NUDGE_EVERY", "")
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	adoptRepo(t, hub, mustResolve(t, repo).RepoKey)
+	transcript := filepath.Join(t.TempDir(), "session.jsonl")
+	writeUsageTranscript(t, transcript, 900_000)
+	in := `{"session_id":"s1","cwd":` + jsonString(repo) + `,"transcript_path":` + jsonString(transcript) + `,"hook_event_name":"PostToolUse","tool_name":"Bash"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventPostToolUse, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("handoff nudge must be off by default, got %q", out.String())
+	}
+}
+
+// TestHandoffNudgeUnadoptedRepoSilent verifies the politeness gate: no CHARTER →
+// no nudge, so user-level hooks can't push /director:handoff in unrelated repos.
+func TestHandoffNudgeUnadoptedRepoSilent(t *testing.T) {
+	t.Setenv(handoffNudgeEnv, "100000")
+	t.Setenv("DIRECTOR_FLUSH_NUDGE_EVERY", "")
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main") // no CHARTER → un-adopted
+	transcript := filepath.Join(t.TempDir(), "session.jsonl")
+	writeUsageTranscript(t, transcript, 120_000)
+	in := `{"session_id":"s1","cwd":` + jsonString(repo) + `,"transcript_path":` + jsonString(transcript) + `,"hook_event_name":"PostToolUse","tool_name":"Bash"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventPostToolUse, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("un-adopted repo must not get the handoff nudge, got %q", out.String())
+	}
+}
+
+// TestTailContextTokensTailBounded verifies the measurement survives a tail-read
+// that starts mid-file: the partial first line is dropped and the LAST assistant
+// usage in the window wins.
+func TestTailContextTokensTailBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "big.jsonl")
+	var b strings.Builder
+	b.WriteString(`{"type":"assistant","message":{"usage":{"input_tokens":999999,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}` + "\n")
+	// Pad past the tail window so the seek lands mid-file and the stale record above
+	// falls outside it.
+	pad := `{"type":"user","message":{"content":"` + strings.Repeat("x", 4096) + `"}}` + "\n"
+	for b.Len() < handoffNudgeTailBytes+len(pad) {
+		b.WriteString(pad)
+	}
+	b.WriteString(`{"type":"assistant","message":{"usage":{"input_tokens":40000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":1000}}}` + "\n")
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := tailContextTokens(path); got != 43000 {
+		t.Fatalf("tailContextTokens = %d, want 43000 (last assistant usage in the tail)", got)
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -832,6 +834,38 @@ func TestTailContextTokensTailBounded(t *testing.T) {
 	}
 	if got := tailContextTokens(path); got != 43000 {
 		t.Fatalf("tailContextTokens = %d, want 43000 (last assistant usage in the tail)", got)
+	}
+}
+
+// TestHandoffNudgeMarkerAtomicUnderConcurrency locks the once-per-crossing
+// guarantee against concurrent PostToolUse hook processes (parallel tool calls):
+// N racing crossings must produce exactly ONE nudge — the O_EXCL marker create,
+// not a stat-then-write pair, decides the winner.
+func TestHandoffNudgeMarkerAtomicUnderConcurrency(t *testing.T) {
+	t.Setenv(handoffNudgeEnv, "100000")
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+	adoptRepo(t, hub, ws.RepoKey)
+	transcript := filepath.Join(t.TempDir(), "session.jsonl")
+	writeUsageTranscript(t, transcript, 120_000)
+	in := Input{SessionID: "s1", CWD: repo, TranscriptPath: transcript}
+
+	const racers = 16
+	var fired atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if text, _ := runHandoffNudge(in, hub, ws); text != "" {
+				fired.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := fired.Load(); got != 1 {
+		t.Fatalf("nudge fired %d times across %d concurrent crossings, want exactly 1", got, racers)
 	}
 }
 

--- a/internal/hook/posttooluse.go
+++ b/internal/hook/posttooluse.go
@@ -40,23 +40,33 @@ const flushNudgeText = "Director: context is accumulating. If you've made a deci
 // debounced flush nudge. It is best-effort throughout: any bookkeeping failure
 // logs and degrades, never an error to CC.
 func handlePostToolUse(in Input, out io.Writer, hub string) error {
-	// Heartbeat FIRST, regardless of the nudge setting: liveness is derived from
-	// heartbeat age (§5.5), and PostToolUse — firing on every tool call — is the
-	// signal that keeps a long-running ACTIVE session from aging into stale/
-	// abandoned while it is plainly still working. Without this, SessionStart is
-	// the only heartbeat source and any session older than the stale TTL misreads
-	// in the cockpit. Best-effort: failures log and continue.
-	refreshHeartbeat(in, hub)
+	// Identity is resolved ONCE for the whole hot path — it shells out to git,
+	// and both the heartbeat and the handoff nudge need the same workstream.
+	// Throwaway/subagent sessions (no session_id) skip both: they must not
+	// materialize a liveness row (H3) and their transcripts aren't this session's.
+	if !isThrowawaySession(in) {
+		if ws, err := identity.Resolve(in.CWD); err != nil {
+			logFailure(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("resolve workstream from %q: %v", in.CWD, err))
+		} else {
+			// Heartbeat first, regardless of any nudge setting: liveness is derived
+			// from heartbeat age (§5.5), and PostToolUse — firing on every tool call —
+			// is what keeps a long-running ACTIVE session from aging into stale/
+			// abandoned. fleet.Heartbeat is create-or-update; failures log and continue.
+			if err := fleet.Heartbeat(hub, ws.ID, sessionUUID(in), time.Now()); err != nil {
+				logFailure(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("heartbeat: %v", err))
+			}
 
-	// Handoff-threshold nudge first (handoffnudge.go): it has the real context-fill
-	// signal, so when it fires this call carries ITS nudge alone — never stacked
-	// with the blind flush nudge below on the same tool call.
-	if text, usage := runHandoffNudge(in, hub); text != "" {
-		if err := writePostToolUseContext(out, text); err != nil {
-			return fmt.Errorf("write handoff nudge: %w", err)
+			// Handoff-threshold nudge (handoffnudge.go): it has the real context-fill
+			// signal, so when it fires this call carries ITS nudge alone — never
+			// stacked with the blind flush nudge below on the same tool call.
+			if text, usage := runHandoffNudge(in, hub, ws); text != "" {
+				if err := writePostToolUseContext(out, text); err != nil {
+					return fmt.Errorf("write handoff nudge: %w", err)
+				}
+				logSuccess(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("handoff nudge fired at ~%d context tokens", usage))
+				return nil
+			}
 		}
-		logSuccess(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("handoff nudge fired at ~%d context tokens", usage))
-		return nil
 	}
 
 	every, on := nudgeInterval()
@@ -84,27 +94,6 @@ func handlePostToolUse(in Input, out io.Writer, hub string) error {
 	}
 	logSuccess(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("flush nudge fired at tool #%d", count))
 	return nil
-}
-
-// refreshHeartbeat touches the workstream's fleet row so an active session keeps
-// reading live in the cockpit. It is gated by the same throwaway filter
-// SessionStart uses — a subagent/throwaway session (no session_id) must not
-// materialize a liveness row — and is best-effort: an identity or fleet failure
-// logs and returns rather than interfering with the tool flow. fleet.Heartbeat is
-// create-or-update, so it preserves an existing row's RepoKey/Handle and only
-// advances the heartbeat.
-func refreshHeartbeat(in Input, hub string) {
-	if isThrowawaySession(in) {
-		return
-	}
-	ws, err := identity.Resolve(in.CWD)
-	if err != nil {
-		logFailure(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("resolve workstream from %q: %v", in.CWD, err))
-		return
-	}
-	if err := fleet.Heartbeat(hub, ws.ID, sessionUUID(in), time.Now()); err != nil {
-		logFailure(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("heartbeat: %v", err))
-	}
 }
 
 // nudgeInterval reads the opt-in cadence from DIRECTOR_FLUSH_NUDGE_EVERY. A

--- a/internal/hook/posttooluse.go
+++ b/internal/hook/posttooluse.go
@@ -17,14 +17,14 @@ import (
 // The intent is to remind the model to emit accumulated decisions/open-items/
 // handoffs BEFORE the context fills enough to force a lossy compaction.
 //
-// v1 limitation (documented, per §4.4 / §5.4): a PostToolUse hook receives no
-// true context-fill signal from CC — there is no token-budget field on the
-// payload. So this nudge CANNOT actually measure "healthy fill". It is therefore
-// gated two ways and ships OFF by default:
+// The hook PAYLOAD carries no context-fill signal, and this nudge predates the
+// discovery that one is derivable from the transcript's usage fields — that
+// signal now powers the handoff-threshold nudge (handoffnudge.go), which runs
+// first and preempts this one. This blind cadence nudge remains as the simpler
+// opt-in, gated two ways and OFF by default:
 //
 //  1. Opt-in: it is a no-op unless DIRECTOR_FLUSH_NUDGE_EVERY is set to a
-//     positive integer N. The durable signal (deriving fill/health from
-//     git/PostToolUse activity) is a TODO; this is the conservative placeholder.
+//     positive integer N.
 //  2. Debounced: even when enabled it fires at most once per N tool calls per
 //     session (a tool-call counter persisted under health/), so it can't nag on
 //     every single tool use and accelerate the compaction it's trying to prevent.
@@ -47,6 +47,17 @@ func handlePostToolUse(in Input, out io.Writer, hub string) error {
 	// the only heartbeat source and any session older than the stale TTL misreads
 	// in the cockpit. Best-effort: failures log and continue.
 	refreshHeartbeat(in, hub)
+
+	// Handoff-threshold nudge first (handoffnudge.go): it has the real context-fill
+	// signal, so when it fires this call carries ITS nudge alone — never stacked
+	// with the blind flush nudge below on the same tool call.
+	if text, usage := runHandoffNudge(in, hub); text != "" {
+		if err := writePostToolUseContext(out, text); err != nil {
+			return fmt.Errorf("write handoff nudge: %w", err)
+		}
+		logSuccess(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("handoff nudge fired at ~%d context tokens", usage))
+		return nil
+	}
 
 	every, on := nudgeInterval()
 	if !on {

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -41,6 +41,10 @@ const emitProtocol = "## Director protocol — keep this current as you work\n" 
 	"- an open-item the moment you defer a loop — `director emit --type open-item --area <area> --risk <low|escalate> \"<loop>\"`\n" +
 	"- a handoff at each natural boundary (sub-task done, switching focus, wrapping up) — `director emit --type handoff --area <area> \"current task · next · hypotheses\"`\n" +
 	"- when you FINISH an open-item, close it — `director resolve <ulid>` (use a ULID from the open-items above; resolve only when it is truly done — there is no reopen)\n" +
+	"At a WORKSTREAM boundary, suggest the matching close-out command to the human — the two are not interchangeable:\n" +
+	"- work DONE and merged → suggest `/director:complete`, BEFORE the branch/worktree is deleted — it reviews this workstream's open-items with the human, resolves the finished ones, and archives the workstream\n" +
+	"- PAUSING work that will resume (session ending mid-task, switching focus, context filling up) → suggest `/director:handoff` — it flushes unrecorded state and writes a self-sufficient resume baton\n" +
+	"Never hand off a finished workstream: a handoff there plants a phantom baton that keeps a dead workstream surfacing as resumable — done+merged always takes `/director:complete`.\n" +
 	"This is load-bearing — treat it as a standing instruction, not a suggestion.\n"
 
 // handleSessionStart derives identity, refreshes the fleet row, and writes the


### PR DESCRIPTION
## What

Steps 2 and 3 (first half) of the close-out design (`docs/specs/2026-07-01-close-out-commands-design.md`):

**Step 2 — injected protocol distinguishes the boundary commands.** The SessionStart emit protocol now names both close-out commands at their judgment triggers: suggest `/director:complete` when work is done+merged (before the branch is deleted), `/director:handoff` when merely pausing, plus a warning that a handoff on a finished workstream plants a phantom resume baton (decision `01KWCH30`).

**Step 3a — deterministic `/director:handoff` nudge on context fill.** PostToolUse tail-reads the transcript (bounded 1 MiB seek, fail-open): the usage sum on the last assistant record is the current context size, a signal the hook payload doesn't carry but the transcript does (verified against live transcripts). One `additionalContext` nudge fires per crossing of `DIRECTOR_HANDOFF_NUDGE_TOKENS` (absolute tokens; unset = off, the conservative default).

Anti-nag semantics (the emit-guard lesson): the once-marker under `health/` re-arms only when usage falls below half the threshold. Emitting a handoff doesn't shrink context, so no nag loop; only a compaction/clear re-arms, so a post-compaction re-approach deliberately earns one more nudge. Gated to adopted repos (CHARTER stat) and preempts the blind flush nudge on the same call.

## Why not PreCompact

Verified against the hooks docs and rejected: PreCompact has no model-visible output channel (block-only; the reason goes to the user), so it cannot nudge, and blocking an auto-compaction gates the session at the worst moment. Autocompact users get the same protection by setting the threshold below their compaction point; post-compaction re-grounding already ships (`SessionStart source=compact`). The threshold is absolute by design: CC exposes window size only to the statusline, so percent-of-window is not derivable hook-side. Spec updated accordingly.

## Deferred

- Branch-gone → `/director:complete` nudge: split out pending targeting design — a session's own local branch ref survives while its worktree lives, so branch-gone only identifies dead sibling workstreams; needs a later-session surface + cross-workstream targeting for `/complete` (open-item `01KWJ0W0`).
- README env-table line for the new var: follows after the OSS positioning README rewrite lands (open-item `01KWJ0HW8X`).

## Testing

§13 gate green locally: `go build ./... && go vet ./... && gofmt -l . && go test ./... -race`. New integration tests drive the full nudge lifecycle through `Dispatch` (fire once, marker holds above threshold/2, re-arm below, fire once again), the off-by-default and unadopted-repo gates, and the bounded tail-read (partial first line dropped, last assistant usage wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
