### PR TITLE
OSS v1 release prep: positioning, license, CI, release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: "§13 gate (build · vet · gofmt · test -race)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: go build
+        run: go build ./...
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: gofmt
+        run: |
+          out="$(gofmt -l .)"
+          if [ -n "$out" ]; then
+            echo "gofmt needs to be run on:" >&2
+            echo "$out" >&2
+            exit 1
+          fi
+
+      - name: go test -race
+        run: go test ./... -race

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: "§13 gate"
+        run: |
+          go build ./...
+          go vet ./...
+          out="$(gofmt -l .)"
+          if [ -n "$out" ]; then echo "gofmt needed on: $out" >&2; exit 1; fi
+          go test ./... -race
+
+      - name: Build binaries
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          mkdir -p dist
+          for platform in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
+            GOOS="${platform%/*}" GOARCH="${platform#*/}" \
+              go build -trimpath \
+                -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" \
+                -o "dist/director" ./cmd/director
+            tar -C dist -czf "dist/director_${GITHUB_REF_NAME}_${platform%/*}_${platform#*/}.tar.gz" director
+            rm dist/director
+          done
+          (cd dist && sha256sum *.tar.gz > checksums.txt)
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/*.tar.gz dist/checksums.txt \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 # config. Without these, a bare `git add -A` sweeps coordination state into a commit.
 /.director/
 /.claude/settings.local.json
+
+# Local working notes, never committed: session handoff snapshots (superseded by
+# the Director LOG) and raw research data (contains author telemetry).
+/docs/handoff-*.md
+/docs/research/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Colin Surprenant
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 # Director
 
-A standalone Go CLI for a human ("the director") running **many concurrent Claude Code sessions across many repos**. Today that human is the message bus — every cross-session decision, handoff, and "who's working on X" is relayed by hand. Director moves the human from *relay* to *reviewer*: sessions coordinate through a shared, durable, **append-only LOG** and a set of **deterministic projections** over it. The LOG (plus the deliberately-edited living docs) is the only system of record; sessions, rolling handoffs, and every rendered view are disposable caches reconstructible from the log. A single static binary, stdlib-first, with one vetted build-time dependency (`github.com/oklog/ulid/v2`).
+**An engineering daybook your agents actually keep.**
+
+You work with Claude Code across several projects, in blocks: days or weeks deep in one, an afternoon in another, back to the first, sometimes a few parallel worktree sessions in a burst. Native agent memory remembers *facts*. What nothing carries across those boundaries is the **coordination narrative**: what was decided and why, which loops were deliberately deferred, where the baton was parked when the block ended, and what still needs *you*. So the human becomes the message bus, re-explaining last month's decision to this morning's session.
+
+Director moves you from **message bus** to **reviewer**. It's a standalone Go CLI that gives your sessions a shared, durable, **append-only event log** per repo plus **deterministic projections** over it: sessions `emit` typed events as they work (`decision` · `open-item` · `handoff` · `note`) and `resolve` loops when they truly close; folds project the log into `render` (the machine digest), `brief` (the human re-orientation view), and `status` (the one-line-per-workstream cockpit); and a SessionStart hook **injects** the CHARTER + digest into every new session as ground truth, so re-entering a project after three weeks starts from your parked handoff instead of from git archaeology. The LOG (plus the deliberately-edited living docs) is the only system of record; sessions and every rendered view are disposable caches reconstructible from it. A single static binary, stdlib-first, one vetted build-time dependency (`github.com/oklog/ulid/v2`), no daemon, no database, no cloud; the log is plain NDJSON you could read with `cat`.
 
 > **Status: v1.** Director ships the hook-first coordination core plus adoption Tier 0+1 (see [Status & scope](#status--scope)). Single-machine.
 
 > **New here?** [`docs/getting-started.md`](docs/getting-started.md) is the task-oriented first-run guide (install → adopt → first session → cockpit), plus how the model uses Director and a troubleshooting section. This README is the reference.
+
+## Why Director
+
+The design in four ideas — the full argument, including honest comparisons, is [`docs/why-director.md`](docs/why-director.md):
+
+- **A portfolio, not a swarm.** Director's concurrency axis is *time and projects*, not just parallel terminals: one human, many workstreams, mostly one active at a time, dormant-between-blocks as a first-class state. Simultaneous sessions share the log and the cockpit too (supported, just not required).
+- **The git of coordination.** Fierce about invariants (no open loop silently vanishes, a decision another session needs is durable and visible, history is append-only) and completely agnostic about your process. Not a methodology; it constrains *state*, never the *path*. Nudges, never gates.
+- **The durability gradient.** Director owns only the fast layer (coordination in flight); plans and architecture docs own the slower ones. One home per fact; truth flows up, never sideways.
+- **Steering is a hat, not a daemon.** No master session: the big picture is a durable projection owned by nobody, and any session wears the steering hat by reading `brief` + `status`. If a session dying loses real information, that's a liability, not an architecture.
+
+**How it compares, in one line each** ([full versions](docs/why-director.md#how-it-compares)): memory tools answer *"what does the agent know?"* while Director answers *"what is in flight?"*; issue trackers (beads et al.) hold the work items while Director holds **the narrative between tasks**; native multi-session features (Agent Teams) are session-scoped by design while Director is the durable, git-adjacent layer *underneath* them; and versus a markdown file plus discipline, Director adds append-only integrity under concurrent writers, a byte-identical verifiable fold, `resolve` lifecycle semantics, and push-injection that doesn't depend on the model remembering to read a file.
 
 ## Install
 
@@ -39,7 +54,7 @@ A director's projects already exist, so adoption of existing repos is on the cri
 director adopt [<dir>]        # defaults to the current directory
 ```
 
-`adopt` (Tier 0) derives the repo's **stable workstream identity** (handling worktrees, remotes, and forks — see [Identity](#identity)), creates `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub** there, and registers the workstream in the fleet. **Filling in the CHARTER is the only manual step** — goal, non-goals, and the standing "needs a human" risk line. Re-adopting never clobbers an edited CHARTER.
+`adopt` (Tier 0) derives the repo's **stable workstream identity** (handling worktrees, remotes, and forks — see [Identity](#identity)), creates `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub** there, and registers the workstream in the fleet. Filling in the CHARTER (goal, non-goals, and the standing "needs a human" risk line) is the one manual step today; a planned adopt-time pass will instead draft a **CHARTER proposal** from the repo's main docs (README, architecture notes, planning files) for you to confirm, so adoption starts from an informed draft rather than a blank stub. Re-adopting never clobbers an edited CHARTER.
 
 A bare `adopt` stops there (Tier 0). With `--scan` it also runs **Tier 1**: scans the repo's *tracked* files for open loops — `TODO` / `FIXME` / `DEFERRED` / `HACK` / `XXX` and unchecked markdown checklist items (`- [ ]`) — and offers to import the ones you pick as `open-item` events. Tier 1 is opt-in because this keyword scan is noisy on real repos (it surfaces docs/comments/test fixtures, not just real loops); the accurate brownfield import is the **Tier-2 fan-out** (fast-follow). The point of importing is to consolidate loops that would otherwise scatter between memory and per-project docs into their one home in the LOG.
 
@@ -182,3 +197,7 @@ director adopt
 director status
 # some-project-main-1a2b3c4d · active · just now · ok
 ```
+
+## License
+
+[Apache-2.0](LICENSE).

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -14,6 +14,19 @@ import (
 // a source build reports "dev".
 var version = "dev"
 
+// runVersion prints the stamped version. Extra arguments are a usage error,
+// consistent with the rest of the dispatch.
+func runVersion(rest []string) int {
+	if len(rest) != 0 {
+		fmt.Fprintln(os.Stderr, "director: version takes no arguments")
+		return 2
+	}
+	fmt.Println(versionLine())
+	return 0
+}
+
+func versionLine() string { return "director " + version }
+
 func main() {
 	os.Exit(run(os.Args[1:]))
 }
@@ -55,8 +68,7 @@ func run(args []string) int {
 	case "_hook":
 		return runHook(rest)
 	case "version", "--version":
-		fmt.Println("director " + version)
-		return 0
+		return runVersion(rest)
 	case "help", "-h", "--help":
 		usage(os.Stdout)
 		return 0

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -10,6 +10,10 @@ import (
 	"os"
 )
 
+// version is stamped at release time via -ldflags "-X main.version=vX.Y.Z";
+// a source build reports "dev".
+var version = "dev"
+
 func main() {
 	os.Exit(run(os.Args[1:]))
 }
@@ -50,6 +54,9 @@ func run(args []string) int {
 		return runUninstall(rest)
 	case "_hook":
 		return runHook(rest)
+	case "version", "--version":
+		fmt.Println("director " + version)
+		return 0
 	case "help", "-h", "--help":
 		usage(os.Stdout)
 		return 0
@@ -84,5 +91,8 @@ adoption & install:
   adopt       bring an existing repo into the fleet (CHARTER + open-loop import)
   install     idempotent merge of Director hooks into settings.json
   uninstall   remove only Director-managed hook entries
+
+misc:
+  version     print the director version
 `)
 }

--- a/cmd/director/main_test.go
+++ b/cmd/director/main_test.go
@@ -13,6 +13,8 @@ func TestDispatchExitCodes(t *testing.T) {
 	}{
 		{"no args shows usage, non-zero", nil, 2},
 		{"help is zero", []string{"help"}, 0},
+		{"version is zero", []string{"version"}, 0},
+		{"--version is zero", []string{"--version"}, 0},
 		{"unknown verb is non-zero", []string{"bogus"}, 2},
 		{"hook without event is fail-safe", []string{"_hook"}, 0},
 		{"hook with event is fail-safe", []string{"_hook", "sessionstart"}, 0},

--- a/cmd/director/main_test.go
+++ b/cmd/director/main_test.go
@@ -15,6 +15,7 @@ func TestDispatchExitCodes(t *testing.T) {
 		{"help is zero", []string{"help"}, 0},
 		{"version is zero", []string{"version"}, 0},
 		{"--version is zero", []string{"--version"}, 0},
+		{"version rejects extra args", []string{"version", "foo"}, 2},
 		{"unknown verb is non-zero", []string{"bogus"}, 2},
 		{"hook without event is fail-safe", []string{"_hook"}, 0},
 		{"hook with event is fail-safe", []string{"_hook", "sessionstart"}, 0},
@@ -30,5 +31,19 @@ func TestDispatchExitCodes(t *testing.T) {
 				t.Fatalf("run(%v) = %d, want %d", tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestVersionLine locks the version output contract the release workflow's
+// -X main.version stamping relies on.
+func TestVersionLine(t *testing.T) {
+	if got, want := versionLine(), "director dev"; got != want {
+		t.Fatalf("versionLine() = %q, want %q (source build)", got, want)
+	}
+	orig := version
+	defer func() { version = orig }()
+	version = "v1.2.3"
+	if got, want := versionLine(), "director v1.2.3"; got != want {
+		t.Fatalf("versionLine() = %q, want %q (stamped build)", got, want)
 	}
 }

--- a/docs/specs/2026-06-03-director-coordination-design.md
+++ b/docs/specs/2026-06-03-director-coordination-design.md
@@ -69,7 +69,7 @@ Claude's `Edit`/`Write` is whole-file read-modify-rewrite — there is no true a
 
 ### 4.3 Canonical-repo-key algorithm (with fallback chain + test matrix)
 
-Every easy heuristic fails on the real machine: basename collides (`ollama` → `jmorganca/ollama`; `springloader` has 6+ worktrees); `pager`/`springloader` have no remote.
+Every easy heuristic fails on the real machine: basename collides (a fork of `ollama` is still `ollama`); one project can have 6+ worktrees of the same repo; local-only projects have no remote at all.
 
 **Resolution — deterministic fallback chain:**
 1. `git rev-parse --git-common-dir` → collapse all worktrees to one `.git`; slug its absolute path.

--- a/docs/why-director.md
+++ b/docs/why-director.md
@@ -1,0 +1,104 @@
+# Why Director
+
+*The positioning document: what Director is, where it sits, what it refuses to be, and how it compares to its neighbors. If you have five minutes to decide whether this tool is for you, spend them here.*
+
+---
+
+## The problem
+
+You work with coding agents across several projects. Not all at once, but in **blocks**: a few days or weeks deep in one project, an afternoon in another, back to the first. Some blocks overlap; occasionally you run two or three sessions in parallel worktrees. Over weeks, that adds up to a real fleet of workstreams, most of them dormant at any given moment, all of them still *yours*.
+
+Every session starts amnesiac about exactly the layer that matters across those boundaries. Native agent memory has gotten good at *facts*: what the project is, how the build works, your preferences. What nothing carries is the **coordination narrative**: what was decided and why, which loops were deliberately deferred, where the baton was parked when the block ended, and what still needs *you*. So the human becomes the message bus, re-explaining last month's decision to this morning's session, re-discovering their own open loops by grepping git history, relaying context by hand between a worktree session and the main one.
+
+Director exists to move you from **message bus** to **reviewer**.
+
+## What Director is
+
+A standalone Go CLI (single static binary, no daemon, no database, no cloud) that gives your sessions a shared, durable, **append-only event log** per repo, plus **deterministic projections** over it:
+
+- Sessions **emit** typed events as they work, using exactly four kinds (`decision`, `open-item`, `handoff`, `note`), and **resolve** open-items when they are truly closed.
+- Deterministic, non-LLM folds project the log into three views: `render` (the machine digest), `brief` (the human re-orientation view), and `status` (the one-line-per-workstream cockpit with a *Needs-you* band).
+- A SessionStart hook **injects** the project CHARTER plus the folded digest into every new session as authoritative ground truth. Push, not pull: a protocol the model must remember to invoke is a protocol that never fires.
+- Boundary commands mark workstream lifecycle: `/director:handoff` when pausing (parks the baton), `/director:complete` when a workstream is done and merged (human-confirmed close-out of its open loops).
+
+The log is NDJSON: plain, greppable, git-trackable text. If Director disappeared tomorrow, your coordination history would still be readable with `cat`.
+
+The shortest honest description: **an engineering daybook your agents actually keep.** Engineers have known for decades that an append-only, timestamped, never-rewritten journal beats a curated wiki for recovering context. Director mechanizes that practice for a portfolio of agent sessions, and adds the one thing a daybook can't do: deterministic projections that answer "what's open, everywhere, right now."
+
+## A portfolio, not a swarm
+
+Most multi-agent tooling assumes the swarm: many simultaneous sessions on one repo, right now, orchestrated. Director assumes the workload most developers actually have: **one human, many workstreams, across repos and weeks.** The concurrency axis is *time and projects*, not just parallel terminals.
+
+That shapes the design:
+
+- **Dormant is a first-class state.** A workstream idle for three weeks with its baton parked in a handoff isn't stale data to clean up. It's a project between blocks, waiting for re-entry, and `status` and `brief` treat it that way.
+- **Block boundaries are handoffs to your future self.** The `/handoff` you write when leaving a project is the rehydration your next block starts from, injected automatically instead of re-derived from git archaeology.
+- **Re-entry is the payoff.** Opening a session on a repo you haven't touched since last month, and having it already know what was decided, what's open, and what's next: that's the moment Director is built for.
+- **Simultaneous sessions work too.** Parallel worktree sessions share the same log, see each other's decisions, and appear side by side in the cockpit. Supported and proven, just not the headline, because for most developers it's the occasional burst rather than the norm.
+
+## The git of coordination
+
+Director is deliberately shaped like git: **fierce about invariants, agnostic about workflow.**
+
+Git enforces content integrity, append-only history, and the DAG, and could not care less whether you run GitFlow or trunk-based development. Director enforces coordination invariants, and could not care less what methodology you follow:
+
+| Director's invariants (enforced) | Your process (none of Director's business) |
+|---|---|
+| No open loop silently vanishes: `open-item` → `resolve`, or it stays visible | How you plan, estimate, or prioritize |
+| A decision another session needs is durable and injected, not trapped in scrollback | Whether you do TDD, reviews, pairing, ceremonies |
+| History is append-only; events are superseded, never rewritten | Branch strategy, merge style, release cadence |
+| The record is human-legible and lives with your repos | Which planning or documentation tools you use |
+
+The enforcement style follows from the analogy: **make silence loud, never gate the path.** Director nudges (a Stop-hook that notices a session ending without recording anything, a cockpit band for items that need you), but it never blocks a merge, never gates a commit, never inserts itself into your critical path. A linter that warns, not a CI gate that fails. The honest corollary: visibility without forcing functions is only as good as its signal-to-noise, which is why nudge calibration is treated as permanent tuning work rather than a solved problem.
+
+This is also why Director is **not a methodology** and doesn't enforce one. A methodology constrains the *path*: steps, ceremonies, ordering. Director constrains *state*: docs reflect reality, decisions are visible, loops don't vanish. Any methodology (or none) satisfies its invariants.
+
+## Where it sits: the durability gradient
+
+Coordination facts, plans, and architecture move at different speeds. Director deliberately owns only the fastest layer:
+
+| Layer | Speed | Single source of truth for | Lives in |
+|---|---|---|---|
+| **Director** | fast (hours/days) | coordination in flight: decisions-as-made, open loops, handoffs, who's active | the append-only LOG |
+| **Planning tools** | medium (weeks) | roadmaps, phases, task breakdowns | your planning system of choice |
+| **Architecture docs** (e.g. arc42) | slow (months/years) | structure and the durable *why* | curated docs in the repo |
+
+Two rules keep the layers honest. **One home per fact:** Director's locked four-kind schema is itself a drift-prevention mechanism, because a tool too small to hold its neighbors' facts can't absorb them; plans don't leak into the log and architecture doesn't fossilize in handoffs. **Truth flows up, never sideways or down:** a fact is born at the fast layer (a decision event, emitted the moment it's made), and if it proves durable it gets *promoted* into a plan or an ADR, with the append-only record then pointing up. Because events are ULID-ordered, a later decision event beats a stale doc, and flags it.
+
+## Steering is a hat, not a daemon
+
+Director has **no master session.** The big picture, the thing every "orchestrator" architecture centralizes in a coordinator that must stay alive, is here a *durable projection owned by nobody*. Any session (or the human, directly) can wear the steering hat for a moment by reading `brief` and `status`. The integrator is the fold, not a process.
+
+The design test: **if a session dying loses real information, that's a liability, not an architecture.** A long-lived "cockpit" session is fine as a convenience, but it must hold no privileged knowledge; everything it knows is in the stream, so losing it costs only scrollback. Corollary: if you feel you need a master session, the stream isn't rich enough. Fix the stream, don't anoint an owner.
+
+## How it compares
+
+Honest answers to the five-minute evaluation questions.
+
+**vs. memory tools (Claude Code auto-memory, claude-mem, mem0, and the rest).**
+Different question. Memory tools answer *"what does the agent know?"*: recall across sequential sessions, and the good ones do it automatically and well. Director answers *"what is in flight?"*: what was decided, what's still open, where the baton is, and what needs the human, across a portfolio, with lifecycle semantics (an open-item is *open until resolved*, not a note that fades). Run both; they don't overlap. Native per-project memory is a private notebook; Director is the shared ledger.
+
+**vs. beads (and issue trackers as agent memory).**
+Closest neighbor, different shape. Beads is *task-shaped*: a git-backed dependency graph of work items, and excellent at that. Director is *event-shaped*: **the narrative between tasks**. The decision that reframed the task, the loop deferred while doing it, the handoff parked when the block ended. A decision is not a task; forcing it into an issue tracker strips its "why" of ordering and provenance. They compose rather than compete: track your work in beads, carry your narrative in Director. Director is also portfolio-wide by construction (one hub, many repos, one cockpit), where a tracker's world is one repo's graph.
+
+**vs. native multi-session features (Claude Code Agent Teams, tasks, session management).**
+Director sits *under* them, not against them. Native team state is session-scoped by design: as of mid-2026, per the platform's own docs, team configuration is deleted on session exit, task state is machine-bound, and teams can't be shared across sessions. That's the right call for live parallelism, and exactly what Director doesn't do. Director is the layer that survives the session: git-adjacent, vendor-neutral, human-auditable, durable across days, machines, and worktrees. It integrates through the same public hook surface (SessionStart/Stop) the platform provides, and nothing in it competes with spawning, routing, or in-flight messaging.
+
+**vs. a markdown file and discipline (SESSION_LOG.md, RALF, hand-rolled conventions).**
+The cheapest competitor, and the honest baseline: a shared log file plus willpower genuinely covers part of this. What the convention can't give you, and Director does: append-only integrity under concurrent writers (no last-writer-wins clobbering), a deterministic fold (every session and the human read the *same* picture, byte-identical, verifiable), lifecycle semantics (`resolve` means loops close consciously instead of scrolling away), stable workstream identity across worktrees and compactions, and push-injection so rehydration doesn't depend on the model remembering to read the file. Mutable snapshot files drift and lose rationale; a log with projections doesn't.
+
+## What Director refuses to be
+
+Non-goals, stated as firmly as the goals:
+
+- **Not an orchestrator.** Team-room topology, never central command. It doesn't spawn, route, or schedule sessions.
+- **Not a methodology.** Invariants, not process (see above).
+- **Not semantic memory.** No embeddings, no vector DB, no retrieval ranking. The record is small enough to read because emission is deliberate, and legible because it's typed prose.
+- **No database, no daemon, no cloud.** Durable state is NDJSON files in a directory you own. The binary runs and exits.
+- **No autonomy.** Close-out is human-confirmed; nothing auto-resolves your open loops; nudges never write on your behalf.
+
+## The honest caveats
+
+- **The protocol depends on emission.** Hooks inject and nudge, but the events themselves are written by sessions following an injected protocol: deliberate, typed capture, not automatic transcript hoovering. That is what keeps the log signal-dense and legible; it is also the standing risk (a log nobody writes to starts lying). Director's own #1 named risk is abandonment, and it's fought with calibration (cheap emission, loud silence), not enforcement.
+- **Single-machine, for now.** The hub is a local directory; multi-machine sync is deferred, though the log's git-trackability means the escape hatch is the one you already use for everything else.
+- **It's opinionated where it must be.** Four event kinds, no more. If you need a fifth, the answer is probably one of the four, or a different layer of the gradient.


### PR DESCRIPTION
Items 1–5 of the OSS v1 release plan (Director log handoff `01KWHSRKM0`), as four atomic commits:

- **`docs/why-director.md` + README front matter** — the positioning source of truth: portfolio-not-swarm framing, the git-of-coordination invariants model, the durability gradient, steering-is-a-hat, honest comparisons (memory tools / beads / Agent Teams / markdown+discipline), non-goals, and honest caveats. README opening compresses it; the reference body is unchanged.
- **`LICENSE` (Apache-2.0) + hygiene** — canonical license text; `.gitignore` keeps local session notes and raw research data untracked; the one tracked private-project reference (spec §4.3 examples) genericized. Full sweep of tracked files and commit history is clean.
- **`ci.yml`** — the §13 gate (build · vet · gofmt · `test -race`) on every PR and push to main. Read-only token, Go version from `go.mod`.
- **`release.yml` + `director version`** — pushing a `v*` tag re-runs the gate, builds CGO-free darwin/linux (amd64/arm64) tarballs with `-X main.version` stamping, and publishes a GitHub release with sha256 checksums (`--verify-tag`, generated notes). New `version`/`--version` verb (prints `dev` for source builds) with dispatch tests.

Verified: full §13 gate green including `test/integration`; version stamping confirmed end-to-end (`-X main.version=v1.1.0-test` → `director v1.1.0-test`).

Not in this PR (follow-ups): getting-started refresh + install-from-release instructions + demo recording (item 6); the public flip and first `v*` tag are explicit maintainer actions (item 7, `v1.1.0` proposed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
