### PR TITLE
fix(hook): make flush-nudge counter atomic under concurrent hooks

### DIFF
--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -692,6 +692,46 @@ func TestPostToolUseFiresOnInterval(t *testing.T) {
 	}
 }
 
+// TestBumpToolCounterAtomicUnderConcurrency locks the flush-nudge debounce
+// against concurrent PostToolUse hook processes (parallel tool calls): N racing
+// bumps must yield N distinct counts covering exactly 1..N, with no
+// read-parse-write pair to lose increments and no count observed twice, so no
+// cadence point can double-fire the nudge.
+func TestBumpToolCounterAtomicUnderConcurrency(t *testing.T) {
+	hub := t.TempDir()
+
+	const racers = 16
+	counts := make(chan int, racers)
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			n, err := bumpToolCounter(hub, "s1")
+			if err != nil {
+				t.Errorf("bumpToolCounter: %v", err)
+				return
+			}
+			counts <- n
+		}()
+	}
+	wg.Wait()
+	close(counts)
+
+	seen := make(map[int]bool, racers)
+	for n := range counts {
+		if seen[n] {
+			t.Errorf("count %d observed twice: a cadence point there would double-fire", n)
+		}
+		seen[n] = true
+	}
+	for n := 1; n <= racers; n++ {
+		if !seen[n] {
+			t.Errorf("count %d never observed: a lost increment", n)
+		}
+	}
+}
+
 // --- PostToolUse handoff-threshold nudge -------------------------------------
 
 // adoptRepo writes a CHARTER.md for the repo's project so the hub reads as

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -702,11 +702,13 @@ func TestBumpToolCounterAtomicUnderConcurrency(t *testing.T) {
 
 	const racers = 16
 	counts := make(chan int, racers)
+	start := make(chan struct{}) // start gate so the bumps actually overlap
 	var wg sync.WaitGroup
 	for i := 0; i < racers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			<-start
 			n, err := bumpToolCounter(hub, "s1")
 			if err != nil {
 				t.Errorf("bumpToolCounter: %v", err)
@@ -715,6 +717,7 @@ func TestBumpToolCounterAtomicUnderConcurrency(t *testing.T) {
 			counts <- n
 		}()
 	}
+	close(start)
 	wg.Wait()
 	close(counts)
 

--- a/internal/hook/posttooluse.go
+++ b/internal/hook/posttooluse.go
@@ -114,7 +114,12 @@ func nudgeInterval() (every int, on bool) {
 // bumpToolCounter increments and returns this session's PostToolUse counter,
 // persisted at <hub>/health/posttooluse.<session>.count so the debounce survives
 // across the short-lived hook processes (each tool call is its own `director
-// _hook` invocation). A missing/garbled counter resets to 1 rather than erroring.
+// _hook` invocation). The count is the FILE SIZE: each bump appends exactly one
+// byte with O_APPEND (the same single-write property as the event store and
+// health log), so concurrent hook processes never lose increments, and the
+// post-write offset (my byte's unique end position) is this call's count.
+// Stat-ing the size instead would let two racers both observe the same cadence
+// point and double-fire.
 func bumpToolCounter(hub, session string) (int, error) {
 	if session == "" {
 		session = "manual"
@@ -125,17 +130,19 @@ func bumpToolCounter(hub, session string) (int, error) {
 	}
 	path := filepath.Join(dir, "posttooluse."+sanitizeSession(session)+".count")
 
-	prev := 0
-	if b, err := os.ReadFile(path); err == nil {
-		if n, perr := strconv.Atoi(strings.TrimSpace(string(b))); perr == nil {
-			prev = n
-		}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return 0, fmt.Errorf("open counter: %w", err)
 	}
-	next := prev + 1
-	if err := os.WriteFile(path, []byte(strconv.Itoa(next)+"\n"), 0o644); err != nil {
-		return 0, fmt.Errorf("write counter: %w", err)
+	defer f.Close()
+	if _, err := f.Write([]byte{'.'}); err != nil {
+		return 0, fmt.Errorf("append counter: %w", err)
 	}
-	return next, nil
+	pos, err := f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0, fmt.Errorf("read counter offset: %w", err)
+	}
+	return int(pos), nil
 }
 
 // sanitizeSession keeps a session id safe to embed in a filename: only


### PR DESCRIPTION
Closes the one FIX-QUEUED verdict from the concurrency audit (Director log `01KWJ7F9GK`, open-item `01KWJ75J`): `bumpToolCounter` was a read-parse-truncate-write sequence, so concurrent PostToolUse hook processes (parallel tool calls) could lose increments and double-fire the flush nudge at a cadence point, with a truncate-window garble that fail-opened to a counter reset.

The counter is now the file size: each bump appends exactly one byte with `O_APPEND` (the same single-write property as the event store and health log), and the call's count is taken from the writing fd's post-write offset. Stat-ing the size instead would let two racers observe the same cadence point; the fd offset is each write's unique end position, so every count 1..N is observed by exactly one process.

No cadence-semantics change: the old counter never reset (monotonic, `count % every == 0`), and neither does this one. Regression test `TestBumpToolCounterAtomicUnderConcurrency` races 16 goroutines and asserts counts cover exactly 1..16 (no lost increments, no double-fire); full §13 gate green including `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
