### PR TITLE
ci: bump actions/checkout to v7, actions/setup-go to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     name: "§13 gate (build · vet · gofmt · test -race)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
Clears the Node 20 deprecation annotation that appeared on the v1.1.0 release run. Both new majors run on Node 24.

Safety notes: neither workflow depends on behavior that changed across these majors — ci.yml does no git writes after checkout, and release.yml authenticates `gh release create` with `github.token` directly rather than checkout's persisted credentials. Gate green locally (`go build/vet/gofmt/test -race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)