### PR TITLE
fix(version): go-install'd binaries report their module version instead of 'dev'

### DIFF
--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -13,8 +13,10 @@ import (
 
 // version is stamped at release time via -ldflags "-X main.version=vX.Y.Z".
 // Unstamped binaries fall back to the module version Go embeds in build info —
-// so a `go install ...@v1.3.0` binary still reports "v1.3.0" — and only a true
-// source build (embedded version "(devel)" or none) reports "dev".
+// a `go install ...@v1.3.0` binary reports "v1.3.0", a git-clone `go build`
+// reports the VCS-derived tag or pseudo-version — and only a build without any
+// VCS-derived version info (embedded "(devel)" or none: test binaries,
+// -buildvcs=false, non-git source trees) reports "dev".
 var version = "dev"
 
 // runVersion prints the stamped version. Extra arguments are a usage error,

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -8,10 +8,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 )
 
-// version is stamped at release time via -ldflags "-X main.version=vX.Y.Z";
-// a source build reports "dev".
+// version is stamped at release time via -ldflags "-X main.version=vX.Y.Z".
+// Unstamped binaries fall back to the module version Go embeds in build info —
+// so a `go install ...@v1.3.0` binary still reports "v1.3.0" — and only a true
+// source build (embedded version "(devel)" or none) reports "dev".
 var version = "dev"
 
 // runVersion prints the stamped version. Extra arguments are a usage error,
@@ -25,7 +28,23 @@ func runVersion(rest []string) int {
 	return 0
 }
 
-func versionLine() string { return "director " + version }
+func versionLine() string { return "director " + resolveVersion(version, debug.ReadBuildInfo) }
+
+// resolveVersion prefers the release-stamped version, then the module version
+// from build info (the go-install case), then "dev". The build-info reader is
+// injected so both fallback branches are testable — the real one reports the
+// test binary itself as "(devel)".
+func resolveVersion(stamped string, readBuildInfo func() (*debug.BuildInfo, bool)) string {
+	if stamped != "dev" {
+		return stamped
+	}
+	if info, ok := readBuildInfo(); ok && info != nil {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return "dev"
+}
 
 func main() {
 	os.Exit(run(os.Args[1:]))

--- a/cmd/director/main_test.go
+++ b/cmd/director/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
 // TestDispatchExitCodes locks the dispatch contract, including the load-bearing
 // fail-safe invariant that the hook path never returns non-zero (§5.4, §13 t5)
@@ -45,5 +48,38 @@ func TestVersionLine(t *testing.T) {
 	version = "v1.2.3"
 	if got, want := versionLine(), "director v1.2.3"; got != want {
 		t.Fatalf("versionLine() = %q, want %q (stamped build)", got, want)
+	}
+}
+
+// TestResolveVersion locks the fallback chain: release stamp wins outright; an
+// unstamped binary reports the module version Go embeds on `go install` (the
+// bug this fixes: go-install'd v1.3.0 printed "dev"); a true source build —
+// "(devel)", empty, or no build info at all — stays "dev".
+func TestResolveVersion(t *testing.T) {
+	withMain := func(v string) func() (*debug.BuildInfo, bool) {
+		return func() (*debug.BuildInfo, bool) {
+			return &debug.BuildInfo{Main: debug.Module{Version: v}}, true
+		}
+	}
+	noInfo := func() (*debug.BuildInfo, bool) { return nil, false }
+
+	cases := []struct {
+		name    string
+		stamped string
+		read    func() (*debug.BuildInfo, bool)
+		want    string
+	}{
+		{"stamp wins over module version", "v1.2.3", withMain("v9.9.9"), "v1.2.3"},
+		{"go-install module version", "dev", withMain("v1.3.0"), "v1.3.0"},
+		{"source build (devel)", "dev", withMain("(devel)"), "dev"},
+		{"empty module version", "dev", withMain(""), "dev"},
+		{"no build info", "dev", noInfo, "dev"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveVersion(tt.stamped, tt.read); got != tt.want {
+				t.Fatalf("resolveVersion(%q) = %q, want %q", tt.stamped, got, tt.want)
+			}
+		})
 	}
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,9 @@ sudo install bin/director /usr/local/bin/director   # or copy anywhere on PATH
 ```
 
 Confirm the binary resolves with `director version`. A release or `go install` binary prints its
-version (e.g. `director v1.3.0`); only a from-source `go build` prints `director dev`.
+version (e.g. `director v1.3.0`); a `go build` from a git clone prints the version Go derives from
+the checkout (a tag or pseudo-version, `+dirty` if modified); `director dev` appears only when no
+VCS metadata is available.
 
 ### Wire the hooks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,9 +49,8 @@ go build -o bin/director ./cmd/director
 sudo install bin/director /usr/local/bin/director   # or copy anywhere on PATH
 ```
 
-Confirm the binary resolves with `director version`. A release binary prints its tag (e.g.
-`director v1.3.0`); a `go install` or source build prints `director dev`, because the version is stamped
-only at release time.
+Confirm the binary resolves with `director version`. A release or `go install` binary prints its
+version (e.g. `director v1.3.0`); only a from-source `go build` prints `director dev`.
 
 ### Wire the hooks
 


### PR DESCRIPTION
`go install github.com/colinsurprenant/director/cmd/director@latest` downloads v1.3.0 but the binary printed `director dev` — the version is stamped via `-ldflags` only in the release workflow, and `go install` never applies it.

Fix: `versionLine` falls back to the module version Go embeds in every module-built binary (`debug.ReadBuildInfo().Main.Version`). Resolution order, locked by a table test with an injected reader:

1. release stamp (`-X main.version`) — authoritative, unchanged
2. embedded module version — the `go install @vX.Y.Z` case, now reports `vX.Y.Z`
3. `dev` — true source builds (`(devel)`, empty, or no build info)

getting-started's version note updated to match ("only a from-source `go build` prints `director dev`").

`gofmt`/`go vet` clean, `go test ./... -race -count=1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)