### PR TITLE
Ground-Truth injection hardening: survive harness demotion (L0) + bounded digest with director show (L1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ projections:
   status      one-line-per-workstream fleet cockpit
   open-items  a workstream's unresolved open-items (ULID + body), for /complete
               (default: current workstream; --workstream <id> targets a sibling)
+  show        one event in full by ULID — the pull path behind the digest's
+              capped headlines (--project <repo-key> targets another project)
 
 fleet lifecycle (hook-emitted):
   register    create/refresh this workstream's fleet row
@@ -164,6 +166,8 @@ director resolve <ulid>
 | `status` | human | the one-line-per-workstream fleet cockpit: handle · liveness · heartbeat recency · the **Needs-you** band (open `escalate` items). |
 
 `brief` and `render` share the same byte-identical fold — the human reads the same picture a fresh session reads. A fourth, narrower projection, `open-items`, lists a workstream's unresolved open-items (ULID + body); it exists to feed `resolve` and `/director:complete`. It defaults to the current workstream; `--workstream <id>` retargets it at a sibling — the close-out path for a workstream whose session is already gone.
+
+The digest is deliberately an *index*: every line is capped to a headline so the injection stays small as a project's log grows, and nothing is lost — `show <ulid>` prints any single event in full (body verbatim, as recorded), one deterministic hop from any headline. When even the capped digest would overrun the injection budget, the decisions section collapses to a count-plus-pointer line and the overflow lands in `health/` as a grooming signal; the open-set and the handoff baton are never cut.
 
 ### Fleet lifecycle
 

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -80,6 +80,8 @@ func run(args []string) int {
 		return runStatus(rest)
 	case "open-items":
 		return runOpenItems(rest)
+	case "show":
+		return runShow(rest)
 	case "adopt": // adoption (Phase 7)
 		return runAdopt(rest)
 	case "install": // installer (Phase 5)
@@ -115,6 +117,8 @@ projections:
   status      one-line-per-workstream fleet cockpit
   open-items  a workstream's unresolved open-items (ULID + body), for /complete
               (default: current workstream; --workstream <id> targets a sibling)
+  show        one event in full by ULID — the pull path behind the digest's
+              capped headlines (--project <repo-key> targets another project)
 
 fleet lifecycle (hook-emitted):
   register    create/refresh this workstream's fleet row

--- a/cmd/director/show.go
+++ b/cmd/director/show.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/colinsurprenant/director/internal/event"
+	"github.com/colinsurprenant/director/internal/id"
 )
 
 // runShow prints one event's full record by ULID — the read affordance the
@@ -31,7 +32,14 @@ func runShow(args []string) int {
 		fmt.Fprintln(os.Stderr, "usage: director show [--project <repo-key>] <ulid>")
 		return 2
 	}
-	target := fs.Arg(0)
+	// Same input contract as resolve (internal/event/write.go): strict-parse and
+	// canonicalize the ULID, so a lowercase id matches and a malformed one is a
+	// usage error (exit 2) — not a misleading "no event" miss.
+	target, err := id.Parse(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "show: invalid ulid %q: %v\n", fs.Arg(0), err)
+		return 2
+	}
 
 	hub, repoKey, err := projectTarget(project)
 	if err != nil {
@@ -57,7 +65,9 @@ func runShow(args []string) int {
 
 // formatEvent renders one event in full: a headline line mirroring the digest
 // grammar (so the two are visually relatable), the remaining metadata, then the
-// untruncated body verbatim.
+// untruncated body verbatim. It prints the event AS RECORDED — lifecycle state
+// (closed, superseded) lives in the fold, not here, so a resolved open-item
+// still shows [status:open]; the digest is where current state lives.
 func formatEvent(ev event.Event) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s %s", ev.ID, ev.Type)

--- a/cmd/director/show.go
+++ b/cmd/director/show.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/colinsurprenant/director/internal/event"
+)
+
+// runShow prints one event's full record by ULID — the read affordance the
+// line-capped digest points at (§15.5): digest entries are headlines, `show` is
+// the full body one deterministic hop away. Read-only; it adds no event kind
+// and writes nothing, so the locked write surface (4 kinds + boundary
+// commands) is untouched.
+func runShow(args []string) int {
+	fs := flag.NewFlagSet("show", flag.ContinueOnError)
+	var project string
+	fs.StringVar(&project, "project", "", "repo-key to read (default: current workstream's repo)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if project != "" {
+		if err := validProjectKey(project); err != nil {
+			fmt.Fprintf(os.Stderr, "show: %v\n", err)
+			return 2
+		}
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: director show [--project <repo-key>] <ulid>")
+		return 2
+	}
+	target := fs.Arg(0)
+
+	hub, repoKey, err := projectTarget(project)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "show: %v\n", err)
+		return 1
+	}
+
+	store := event.NewStore(hub, repoKey)
+	events, err := store.ReadAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "show: %v\n", err)
+		return 1
+	}
+	for _, ev := range events {
+		if ev.ID == target {
+			fmt.Print(formatEvent(ev))
+			return 0
+		}
+	}
+	fmt.Fprintf(os.Stderr, "show: no event %s in %s — ULIDs come from the digest, `director render`, or an emit; another project's event needs --project\n", target, repoKey)
+	return 1
+}
+
+// formatEvent renders one event in full: a headline line mirroring the digest
+// grammar (so the two are visually relatable), the remaining metadata, then the
+// untruncated body verbatim.
+func formatEvent(ev event.Event) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s", ev.ID, ev.Type)
+	if ev.Status != "" {
+		fmt.Fprintf(&b, " [status:%s]", ev.Status)
+	}
+	if ev.Area != "" {
+		fmt.Fprintf(&b, " [%s]", ev.Area)
+	}
+	if ev.Risk != "" {
+		fmt.Fprintf(&b, " [risk:%s]", ev.Risk)
+	}
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "workstream: %s\n", ev.Workstream)
+	if ev.TS != "" {
+		fmt.Fprintf(&b, "ts: %s\n", ev.TS)
+	}
+	if len(ev.Refs) > 0 {
+		fmt.Fprintf(&b, "refs: %s\n", strings.Join(ev.Refs, " "))
+	}
+	b.WriteString("\n")
+	b.WriteString(ev.Body)
+	if !strings.HasSuffix(ev.Body, "\n") {
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/cmd/director/show_test.go
+++ b/cmd/director/show_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/colinsurprenant/director/internal/event"
+	"github.com/colinsurprenant/director/internal/id"
+)
+
+// TestShowExitCodes locks show's dispatch contract: found → 0, unknown ULID → 1
+// (an invented id must fail loudly, same discipline as resolve), usage and
+// path-traversal --project values → 2 before any path is built.
+func TestShowExitCodes(t *testing.T) {
+	hub := t.TempDir()
+	t.Setenv("DIRECTOR_HUB", hub)
+
+	store := event.NewStore(hub, "widget")
+	ulid, err := id.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev := event.Event{
+		ID: ulid, SchemaVersion: event.SchemaVersion, Type: event.KindDecision,
+		Workstream: "widget-main", Area: "hooks", Body: "full rationale body",
+	}
+	if err := store.Append(ev); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"found event", []string{"show", "--project", "widget", ulid}, 0},
+		{"unknown ulid", []string{"show", "--project", "widget", "01INVENTEDULIDXXXXXXXXXXXX"}, 1},
+		{"missing ulid arg", []string{"show", "--project", "widget"}, 2},
+		{"two ulid args", []string{"show", "--project", "widget", ulid, ulid}, 2},
+		{"traversal project", []string{"show", "--project", "../../tmp/evil", ulid}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := run(tt.args); got != tt.want {
+				t.Fatalf("run(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatEvent locks the full-record rendering: headline line mirrors the
+// digest grammar (type + tags), metadata lines follow, and the body arrives
+// verbatim and untruncated — the whole point of the pull path behind the
+// digest's capped headlines.
+func TestFormatEvent(t *testing.T) {
+	body := strings.Repeat("a long paragraph of rationale. ", 40) // well past any digest cap
+	got := formatEvent(event.Event{
+		ID: "01TESTULID0000000000000000", Type: event.KindOpenItem, Status: event.StatusOpen,
+		Workstream: "widget-main", Area: "sync", Risk: event.RiskEscalate,
+		Refs: []string{"01REF00000000000000000000A"}, TS: "2026-07-03T12:00:00Z", Body: body,
+	})
+
+	for _, want := range []string{
+		"01TESTULID0000000000000000 open-item [status:open] [sync] [risk:escalate]",
+		"workstream: widget-main",
+		"ts: 2026-07-03T12:00:00Z",
+		"refs: 01REF00000000000000000000A",
+		body, // verbatim, no cap, no "…"
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatEvent missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "…") {
+		t.Errorf("show output must never truncate:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("output should end with a newline")
+	}
+}

--- a/cmd/director/show_test.go
+++ b/cmd/director/show_test.go
@@ -8,15 +8,20 @@ import (
 	"github.com/colinsurprenant/director/internal/id"
 )
 
-// TestShowExitCodes locks show's dispatch contract: found → 0, unknown ULID → 1
-// (an invented id must fail loudly, same discipline as resolve), usage and
-// path-traversal --project values → 2 before any path is built.
+// TestShowExitCodes locks show's dispatch contract: found → 0 (lowercase ids
+// canonicalize, matching resolve's input contract), a valid-but-absent ULID → 1
+// (a lookup miss), and malformed ids / usage / path-traversal --project values
+// → 2 before any path is built.
 func TestShowExitCodes(t *testing.T) {
 	hub := t.TempDir()
 	t.Setenv("DIRECTOR_HUB", hub)
 
 	store := event.NewStore(hub, "widget")
 	ulid, err := id.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	absent, err := id.New() // valid ULID, never appended
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +39,9 @@ func TestShowExitCodes(t *testing.T) {
 		want int
 	}{
 		{"found event", []string{"show", "--project", "widget", ulid}, 0},
-		{"unknown ulid", []string{"show", "--project", "widget", "01INVENTEDULIDXXXXXXXXXXXX"}, 1},
+		{"lowercase ulid canonicalizes", []string{"show", "--project", "widget", strings.ToLower(ulid)}, 0},
+		{"valid but absent ulid", []string{"show", "--project", "widget", absent}, 1},
+		{"malformed ulid", []string{"show", "--project", "widget", "01INVENTEDULIDXXXXXXXXXXXX"}, 2},
 		{"missing ulid arg", []string{"show", "--project", "widget"}, 2},
 		{"two ulid args", []string{"show", "--project", "widget", ulid, ulid}, 2},
 		{"traversal project", []string{"show", "--project", "../../tmp/evil", ulid}, 2},

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -215,7 +215,8 @@ handoff. It's fully deterministic: you read the same picture a fresh session rea
 When an item in the Needs-you band is yours to decide, make the call in the session, then close the loop:
 
 ```bash
-director resolve <ulid>   # the ULID from emit/render/open-items; rejects invented/closed ids
+director resolve <ulid>   # the ULID from emit/render/open-items/show; rejects invented/closed ids
+director show <ulid>      # read any event in full first — digest lines are capped headlines
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,7 +180,8 @@ Just start Claude Code (or Codex) in the adopted repo as usual. Director's `Sess
 
 - registers/refreshes the workstream's liveness row, and
 - injects the **CHARTER + a deterministic digest** of the LOG as the session's *authoritative current
-  state* ("Ground Truth").
+  state* ("Ground Truth"). The digest is an index of capped headlines — `director show <ulid>` prints
+  any entry in full.
 
 You don't run anything. The session is now coordinating. As it works, its `PostToolUse` hook keeps the
 liveness heartbeat fresh, and its `Stop` hook does end-of-session bookkeeping.

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -223,6 +224,23 @@ func TestHealthDetailStaysOneLine(t *testing.T) {
 
 // --- SessionStart Ground Truth ---------------------------------------------
 
+// injectedContext unmarshals a hook control envelope and returns its
+// additionalContext payload, so multi-line constants (the preamble carries the
+// truncation contract on its second line) can be matched against the decoded
+// text rather than its JSON-escaped form.
+func injectedContext(t *testing.T, raw string) string {
+	t.Helper()
+	var env struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		t.Fatalf("unmarshal hook output: %v\n%s", err, raw)
+	}
+	return env.HookSpecificOutput.AdditionalContext
+}
+
 // TestSessionStartInjectsGroundTruth verifies the injected additionalContext
 // carries the Ground-Truth framing plus the CHARTER and the render digest.
 func TestSessionStartInjectsGroundTruth(t *testing.T) {
@@ -253,8 +271,11 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	}
 
 	got := out.String()
-	if !strings.Contains(got, groundTruthPreamble) {
-		t.Errorf("injection missing Ground-Truth framing:\n%s", got)
+	ctx := injectedContext(t, got)
+	// The preamble (with its truncation contract) must LEAD the block: the head
+	// is the only position that survives a harness persisted-output demotion.
+	if !strings.HasPrefix(ctx, groundTruthPreamble) {
+		t.Errorf("Ground-Truth preamble must lead the injected block:\n%s", ctx)
 	}
 	if !strings.Contains(got, "Goal: ship the widget") {
 		t.Errorf("injection missing CHARTER body:\n%s", got)
@@ -264,6 +285,11 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	}
 	if !strings.Contains(got, "## Director protocol") {
 		t.Errorf("adopted-repo injection missing the write-side emit protocol:\n%s", got)
+	}
+	// Survival order: the protocol must precede the digest, so a truncated
+	// delivery costs digest tail (decision rationale), never the emit habit.
+	if p, d := strings.Index(ctx, "## Director protocol"), strings.Index(ctx, "# director render"); p > d {
+		t.Errorf("emit protocol must precede the render digest (protocol@%d, digest@%d):\n%s", p, d, ctx)
 	}
 	if !strings.Contains(got, "▸ Director:") {
 		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", got)
@@ -307,7 +333,7 @@ func TestSessionStartProtocolScopedToAdopted(t *testing.T) {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
 	got := out.String()
-	if !strings.Contains(got, groundTruthPreamble) {
+	if !strings.Contains(injectedContext(t, got), groundTruthPreamble) {
 		t.Errorf("un-adopted repo should still get the Ground-Truth state:\n%s", got)
 	}
 	if strings.Contains(got, "## Director protocol") {
@@ -326,7 +352,7 @@ func TestSessionStartCompactReinjects(t *testing.T) {
 	if code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub); code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
-	if !strings.Contains(out.String(), groundTruthPreamble) {
+	if !strings.Contains(injectedContext(t, out.String()), groundTruthPreamble) {
 		t.Errorf("compact start did not re-inject Ground Truth:\n%s", out.String())
 	}
 }
@@ -545,7 +571,7 @@ func TestSessionStartCloseOutNudgeFailsOpen(t *testing.T) {
 		t.Fatalf("exit code = %d, want 0 (hooks are fail-safe)", code)
 	}
 	got := out.String()
-	if !strings.Contains(got, groundTruthPreamble) || !strings.Contains(got, "## Director protocol") {
+	if !strings.Contains(injectedContext(t, got), groundTruthPreamble) || !strings.Contains(got, "## Director protocol") {
 		t.Fatalf("fleet failure must not cost the session its Ground Truth + protocol:\n%s", got)
 	}
 	if strings.Contains(got, "## Close-out pending") {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -294,22 +294,22 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 		t.Errorf("emit protocol must precede the render digest (protocol@%d, digest@%d):\n%s", p, d, ctx)
 	}
 	if !strings.Contains(ctx, "▸ Director:") {
-		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", got)
+		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", ctx)
 	}
 	if !strings.Contains(ctx, "Resume point") {
-		t.Errorf("injection missing the resume-point anchor for the current workstream:\n%s", got)
+		t.Errorf("injection missing the resume-point anchor for the current workstream:\n%s", ctx)
 	}
 	if !strings.Contains(ctx, "commitment to act") {
-		t.Errorf("injected protocol should clarify that emit RECORDS (not a commitment to act):\n%s", got)
+		t.Errorf("injected protocol should clarify that emit RECORDS (not a commitment to act):\n%s", ctx)
 	}
 	if !strings.Contains(ctx, "director resolve") {
-		t.Errorf("injected protocol should tell the model to resolve finished open-items:\n%s", got)
+		t.Errorf("injected protocol should tell the model to resolve finished open-items:\n%s", ctx)
 	}
 	if !strings.Contains(ctx, "/director:complete") || !strings.Contains(ctx, "/director:handoff") {
-		t.Errorf("injected protocol should name BOTH close-out commands at the workstream-boundary triggers:\n%s", got)
+		t.Errorf("injected protocol should name BOTH close-out commands at the workstream-boundary triggers:\n%s", ctx)
 	}
 	if !strings.Contains(ctx, "Never hand off a finished workstream") {
-		t.Errorf("injected protocol should warn that done+merged takes /director:complete, not a handoff:\n%s", got)
+		t.Errorf("injected protocol should warn that done+merged takes /director:complete, not a handoff:\n%s", ctx)
 	}
 	if !strings.Contains(got, `"hookEventName":"SessionStart"`) {
 		t.Errorf("injection missing SessionStart control envelope:\n%s", got)

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1296,7 +1296,14 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 	if len(ctx) > injectionBudgetBytes {
 		t.Errorf("degraded payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
 	}
-	if health := readHealth(t, hub); !strings.Contains(health, "injection budget") {
+	health := readHealth(t, hub)
+	if !strings.Contains(health, "injection budget") {
 		t.Errorf("budget overflow should be health-logged as a grooming signal, got:\n%s", health)
+	}
+	// Pin WHICH branch ran: the compact fallback must suffice here — the
+	// last-resort "actionable sections alone are over" sentinel firing would
+	// mean the fixture (or the degradation) is not what this test believes.
+	if strings.Contains(health, "STILL over budget") {
+		t.Errorf("fixture should overflow on decisions only, not on actionable sections:\n%s", health)
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -277,36 +277,38 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	if !strings.HasPrefix(ctx, groundTruthPreamble) {
 		t.Errorf("Ground-Truth preamble must lead the injected block:\n%s", ctx)
 	}
-	if !strings.Contains(got, "Goal: ship the widget") {
-		t.Errorf("injection missing CHARTER body:\n%s", got)
+	if !strings.Contains(ctx, "Goal: ship the widget") {
+		t.Errorf("injection missing CHARTER body:\n%s", ctx)
 	}
-	if !strings.Contains(got, "director render") {
-		t.Errorf("injection missing render digest:\n%s", got)
+	if !strings.Contains(ctx, "director render") {
+		t.Errorf("injection missing render digest:\n%s", ctx)
 	}
-	if !strings.Contains(got, "## Director protocol") {
-		t.Errorf("adopted-repo injection missing the write-side emit protocol:\n%s", got)
+	if !strings.Contains(ctx, "## Director protocol") {
+		t.Errorf("adopted-repo injection missing the write-side emit protocol:\n%s", ctx)
 	}
 	// Survival order: the protocol must precede the digest, so a truncated
 	// delivery costs digest tail (decision rationale), never the emit habit.
-	if p, d := strings.Index(ctx, "## Director protocol"), strings.Index(ctx, "# director render"); p > d {
+	// A missing marker fails HERE (not just in a sibling Contains) so the
+	// ordering assertion can't pass vacuously.
+	if p, d := strings.Index(ctx, "## Director protocol"), strings.Index(ctx, "# director render"); p < 0 || d < 0 || p > d {
 		t.Errorf("emit protocol must precede the render digest (protocol@%d, digest@%d):\n%s", p, d, ctx)
 	}
-	if !strings.Contains(got, "▸ Director:") {
+	if !strings.Contains(ctx, "▸ Director:") {
 		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", got)
 	}
-	if !strings.Contains(got, "Resume point") {
+	if !strings.Contains(ctx, "Resume point") {
 		t.Errorf("injection missing the resume-point anchor for the current workstream:\n%s", got)
 	}
-	if !strings.Contains(got, "commitment to act") {
+	if !strings.Contains(ctx, "commitment to act") {
 		t.Errorf("injected protocol should clarify that emit RECORDS (not a commitment to act):\n%s", got)
 	}
-	if !strings.Contains(got, "director resolve") {
+	if !strings.Contains(ctx, "director resolve") {
 		t.Errorf("injected protocol should tell the model to resolve finished open-items:\n%s", got)
 	}
-	if !strings.Contains(got, "/director:complete") || !strings.Contains(got, "/director:handoff") {
+	if !strings.Contains(ctx, "/director:complete") || !strings.Contains(ctx, "/director:handoff") {
 		t.Errorf("injected protocol should name BOTH close-out commands at the workstream-boundary triggers:\n%s", got)
 	}
-	if !strings.Contains(got, "Never hand off a finished workstream") {
+	if !strings.Contains(ctx, "Never hand off a finished workstream") {
 		t.Errorf("injected protocol should warn that done+merged takes /director:complete, not a handoff:\n%s", got)
 	}
 	if !strings.Contains(got, `"hookEventName":"SessionStart"`) {
@@ -571,8 +573,8 @@ func TestSessionStartCloseOutNudgeFailsOpen(t *testing.T) {
 		t.Fatalf("exit code = %d, want 0 (hooks are fail-safe)", code)
 	}
 	got := out.String()
-	if !strings.Contains(injectedContext(t, got), groundTruthPreamble) || !strings.Contains(got, "## Director protocol") {
-		t.Fatalf("fleet failure must not cost the session its Ground Truth + protocol:\n%s", got)
+	if ctx := injectedContext(t, got); !strings.Contains(ctx, groundTruthPreamble) || !strings.Contains(ctx, "## Director protocol") {
+		t.Fatalf("fleet failure must not cost the session its Ground Truth + protocol:\n%s", ctx)
 	}
 	if strings.Contains(got, "## Close-out pending") {
 		t.Errorf("broken fleet surface should skip the nudge, not fabricate one:\n%s", got)
@@ -1251,4 +1253,50 @@ func stopInput(cwd, transcript string, stopHookActive bool) string {
 	return `{"session_id":"s-real","cwd":` + jsonString(cwd) +
 		`,"transcript_path":` + jsonString(transcript) +
 		`,"hook_event_name":"Stop","stop_hook_active":` + active + `}`
+}
+
+// TestSessionStartBudgetDegradesDeterministically locks the §15.5 self-measure:
+// a log whose line-capped digest still pushes the payload over the injection
+// budget degrades to DigestCompact — decisions collapse to a count+pointer line,
+// open-items and handoffs survive untouched — and the overflow lands in health/
+// as a grooming signal. The harness's own demotion threshold must never be the
+// first thing that notices growth.
+func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+
+	store := event.NewStore(hub, ws.RepoKey)
+	body := strings.Repeat("rationale ", 30) // ~300 chars, capped to a ~160-rune headline
+	for i := 0; i < 120; i++ {               // ~120 index lines ≈ 22KB > 16KB budget
+		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindDecision, Area: "hooks", Body: body}); err != nil {
+			t.Fatalf("seed decision %d: %v", i, err)
+		}
+	}
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindOpenItem, Area: "sync", Body: "the open loop must survive degradation"}); err != nil {
+		t.Fatalf("seed open-item: %v", err)
+	}
+
+	in := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	ctx := injectedContext(t, out.String())
+
+	if !strings.Contains(ctx, "120 active decisions elided for size") {
+		t.Errorf("over-budget injection should collapse decisions with the count:\n%.2000s", ctx)
+	}
+	if strings.Contains(ctx, "rationale rationale") {
+		t.Errorf("collapsed injection must not carry decision bodies")
+	}
+	if !strings.Contains(ctx, "the open loop must survive degradation") {
+		t.Errorf("degradation must never eat the open-set:\n%.2000s", ctx)
+	}
+	if len(ctx) > injectionBudgetBytes {
+		t.Errorf("degraded payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
+	}
+	if health := readHealth(t, hub); !strings.Contains(health, "injection budget") {
+		t.Errorf("budget overflow should be health-logged as a grooming signal, got:\n%s", health)
+	}
 }

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -152,9 +152,12 @@ const injectionBudgetBytes = 16 * 1024
 // buildGroundTruth assembles the injected block: the Ground-Truth preamble
 // (with the truncation contract), the write-side protocol (managed repos only),
 // the project CHARTER (graceful when absent), and the deterministic digest
-// folded from the LOG. The digest is the same one `director render` and
-// `--verify` anchor on, so what the session is handed is exactly what the
-// cockpit shows — no drift between injected and authoritative state. sessionID
+// folded from the LOG. Under budget — the normal case — the digest is
+// byte-for-byte the `director render` / `--verify` output, so what the session
+// is handed is exactly what the cockpit shows. Over injectionBudgetBytes it is
+// the DigestCompact variant instead (decisions collapsed to a count+pointer
+// line): still deterministic, but deliberately NOT the render output — the
+// divergence is announced in the digest itself and health-logged. sessionID
 // is only for health-logging a close-out-nudge failure (which is fail-open,
 // never blocking the injection). codex switches the protocol/nudge command
 // names to Codex's skill-mention namespace (see codexCommandNames).

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -27,7 +27,17 @@ import (
 // groundTruthPreamble is the explicit authoritativeness instruction (§4.4 /
 // §14.2). It MUST lead the injected block; the digest and charter below it are
 // only useful if the model trusts them instead of re-deriving.
-const groundTruthPreamble = "This is your authoritative current state; build on it, do not re-derive or re-read it."
+//
+// The truncation contract rides in the preamble because the head is the ONLY
+// position guaranteed to survive: when this block outgrows the harness's inline
+// hook-output budget, Claude Code silently persists it to a file and injects
+// just a short head preview (observed live 2026-07-03: a 36KB injection demoted
+// to a 2KB preview — push degraded to pull and the session worked memory-zero).
+// The contract turns that silent degradation into a loud, self-healing one; it
+// is the delivery backstop, while keeping the payload small is the real fix
+// (§15.5 bounded digest).
+const groundTruthPreamble = "This is your authoritative current state; build on it, do not re-derive or re-read it.\n" +
+	"DELIVERY CHECK (overrides the line above when it applies): if what you received is a truncated or persisted-output rendering of this block (a 'saved to' file path plus a short preview instead of the full text), the state did NOT reach you — Read that full file before doing anything else; the file, not the preview, is the authoritative block."
 
 // emitProtocol is the write-side habit, injected alongside the read-side Ground
 // Truth so it is always in context from turn one. It is PUSHED here rather than
@@ -36,11 +46,11 @@ const groundTruthPreamble = "This is your authoritative current state; build on 
 // (dogfood: 0 emits in ~2.5h of real work with the skill installed). It is injected
 // only for Director-managed repos (see buildGroundTruth) so it can't nag elsewhere.
 const emitProtocol = "## Director protocol — keep this current as you work\n" +
-	"You coordinate with other sessions only through the LOG above, written ONLY via the `director` CLI (never Edit/Write a log file). Emit as you work, not batched at the end — state you don't write during a turn is lost on compaction or a fresh start. Emitting RECORDS a fact; it is NOT a commitment to act and does NOT need the human's approval first — record the decision/loop the moment it exists, then ask or act if needed:\n" +
+	"You coordinate with other sessions only through the LOG (digested below), written ONLY via the `director` CLI (never Edit/Write a log file). Emit as you work, not batched at the end — state you don't write during a turn is lost on compaction or a fresh start. Emitting RECORDS a fact; it is NOT a commitment to act and does NOT need the human's approval first — record the decision/loop the moment it exists, then ask or act if needed:\n" +
 	"- a decision the moment you make one — `director emit --type decision --area <area> \"<what + why>\"`\n" +
 	"- an open-item the moment you defer a loop — `director emit --type open-item --area <area> --risk <low|escalate> \"<loop>\"`\n" +
 	"- a handoff at each natural boundary (sub-task done, switching focus, wrapping up) — `director emit --type handoff --area <area> \"current task · next · hypotheses\"`\n" +
-	"- when you FINISH an open-item, close it — `director resolve <ulid>` (use a ULID from the open-items above; resolve only when it is truly done — there is no reopen)\n" +
+	"- when you FINISH an open-item, close it — `director resolve <ulid>` (use a ULID from the open-items listed below; resolve only when it is truly done — there is no reopen)\n" +
 	"At a WORKSTREAM boundary, suggest the matching close-out command to the human — the two are not interchangeable:\n" +
 	"- work DONE and merged → suggest `/director:complete`, BEFORE the branch/worktree is deleted — it reviews this workstream's open-items with the human, resolves the finished ones, and archives the workstream\n" +
 	"- PAUSING work that will resume (session ending mid-task, switching focus, context filling up) → suggest `/director:handoff` — it flushes unrecorded state and writes a self-sufficient resume baton\n" +
@@ -122,9 +132,10 @@ func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
 	return nil
 }
 
-// buildGroundTruth assembles the injected block: the Ground-Truth preamble, the
-// project CHARTER (graceful when absent), and the deterministic digest folded
-// from the LOG. The digest is the same one `director render` and
+// buildGroundTruth assembles the injected block: the Ground-Truth preamble
+// (with the truncation contract), the write-side protocol (managed repos only),
+// the project CHARTER (graceful when absent), and the deterministic digest
+// folded from the LOG. The digest is the same one `director render` and
 // `--verify` anchor on, so what the session is handed is exactly what the
 // cockpit shows — no drift between injected and authoritative state. sessionID
 // is only for health-logging a close-out-nudge failure (which is fail-open,
@@ -139,9 +150,24 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 	proj := render.Fold(events)
 	digest := render.Digest(proj, repoKey)
 
+	// Managed = a CHARTER exists or the LOG already has events. The write-side
+	// protocol and nudges are injected only then, so they never nag in an
+	// unrelated repo when the hooks are installed user-level.
+	managed := charterExists(hub, repoKey) || len(events) > 0
+
 	var b strings.Builder
 	b.WriteString(groundTruthPreamble)
 	b.WriteString("\n\n")
+
+	// Assembly order is survival order: any truncation (harness demotion, a
+	// human skimming) eats the tail first, so the blocks a session cannot
+	// work without ride highest — preamble+contract, then the write-side
+	// protocol, then identity (CHARTER), then the digest, whose own sections
+	// put deferrable decision rationale last.
+	if managed {
+		b.WriteString(codexCommandNames(emitProtocol, codex))
+		b.WriteString("\n")
+	}
 
 	b.WriteString("## CHARTER\n")
 	b.WriteString(charterText(hub, repoKey))
@@ -152,12 +178,7 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 	// frame — keeping the injected state byte-for-byte the render output.
 	b.WriteString(digest)
 
-	// Push the write-side protocol next to the read-side state, but only for a
-	// Director-managed repo — a CHARTER exists or the LOG already has events — so it
-	// never nags in an unrelated repo when the hooks are installed user-level.
-	if charterExists(hub, repoKey) || len(events) > 0 {
-		b.WriteString("\n")
-		b.WriteString(codexCommandNames(emitProtocol, codex))
+	if managed {
 		nudge, err := closeOutNudge(hub, repoKey, workstreamID, proj, time.Now().UTC())
 		if err != nil {
 			// Fail open: the nudge is advisory — a fleet read problem must never

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -51,6 +51,7 @@ const emitProtocol = "## Director protocol — keep this current as you work\n" 
 	"- an open-item the moment you defer a loop — `director emit --type open-item --area <area> --risk <low|escalate> \"<loop>\"`\n" +
 	"- a handoff at each natural boundary (sub-task done, switching focus, wrapping up) — `director emit --type handoff --area <area> \"current task · next · hypotheses\"`\n" +
 	"- when you FINISH an open-item, close it — `director resolve <ulid>` (use a ULID from the open-items listed below; resolve only when it is truly done — there is no reopen)\n" +
+	"The digest below is an INDEX: entries are capped headlines, not full text. `director show <ulid>` prints any event in full — before touching an area, pull the full bodies of its listed decisions rather than guessing past a headline.\n" +
 	"At a WORKSTREAM boundary, suggest the matching close-out command to the human — the two are not interchangeable:\n" +
 	"- work DONE and merged → suggest `/director:complete`, BEFORE the branch/worktree is deleted — it reviews this workstream's open-items with the human, resolves the finished ones, and archives the workstream\n" +
 	"- PAUSING work that will resume (session ending mid-task, switching focus, context filling up) → suggest `/director:handoff` — it flushes unrecorded state and writes a self-sufficient resume baton\n" +
@@ -132,6 +133,17 @@ func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
 	return nil
 }
 
+// injectionBudgetBytes is the target size for the whole Ground-Truth injection.
+// It is sized to CONTEXT ECONOMY — what a session start should reasonably cost —
+// not to the harness's inline hook-output limit: that limit is undocumented and
+// has been observed to drift (docs said 50K; a 36KB payload was demoted to a 2KB
+// preview on 2026-07-03), so it must never be load-bearing. Over budget, the
+// digest degrades deterministically (DigestCompact: decisions collapse to a
+// count+pointer line — never the open loops or the baton) and the overflow is
+// health-logged so growth is loud long before any harness threshold bites. The
+// preamble's DELIVERY CHECK contract remains the backstop of last resort.
+const injectionBudgetBytes = 16 * 1024
+
 // buildGroundTruth assembles the injected block: the Ground-Truth preamble
 // (with the truncation contract), the write-side protocol (managed repos only),
 // the project CHARTER (graceful when absent), and the deterministic digest
@@ -148,51 +160,78 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 		return "", fmt.Errorf("read log: %w", err)
 	}
 	proj := render.Fold(events)
-	digest := render.Digest(proj, repoKey)
 
 	// Managed = a CHARTER exists or the LOG already has events. The write-side
 	// protocol and nudges are injected only then, so they never nag in an
 	// unrelated repo when the hooks are installed user-level.
 	managed := charterExists(hub, repoKey) || len(events) > 0
 
-	var b strings.Builder
-	b.WriteString(groundTruthPreamble)
-	b.WriteString("\n\n")
+	// Compute the managed-only blocks once, outside the assembler: closeOutNudge
+	// reads the fleet and health-logs its own failure, so a budget re-assembly
+	// must not run it twice.
+	var protocol, nudge, banner string
+	if managed {
+		protocol = codexCommandNames(emitProtocol, codex)
+		n, err := closeOutNudge(hub, repoKey, workstreamID, proj, time.Now().UTC())
+		if err != nil {
+			// Fail open: the nudge is advisory — a fleet read problem must never
+			// cost the session its Ground Truth. Log it and inject without.
+			logFailure(hub, EventSessionStart, sessionID, fmt.Sprintf("close-out nudge: %v", err))
+		} else if n != "" {
+			nudge = codexCommandNames(n, codex)
+		}
+		banner = startupBanner(workstreamID, proj)
+	}
 
 	// Assembly order is survival order: any truncation (harness demotion, a
 	// human skimming) eats the tail first, so the blocks a session cannot
 	// work without ride highest — preamble+contract, then the write-side
 	// protocol, then identity (CHARTER), then the digest, whose own sections
 	// put deferrable decision rationale last.
-	if managed {
-		b.WriteString(codexCommandNames(emitProtocol, codex))
-		b.WriteString("\n")
-	}
-
-	b.WriteString("## CHARTER\n")
-	b.WriteString(charterText(hub, repoKey))
-	b.WriteString("\n")
-
-	// The digest already carries its own "# director render — <key>" heading and
-	// fixed-order sections, so it is appended verbatim under the Ground-Truth
-	// frame — keeping the injected state byte-for-byte the render output.
-	b.WriteString(digest)
-
-	if managed {
-		nudge, err := closeOutNudge(hub, repoKey, workstreamID, proj, time.Now().UTC())
-		if err != nil {
-			// Fail open: the nudge is advisory — a fleet read problem must never
-			// cost the session its Ground Truth. Log it and inject without.
-			logFailure(hub, EventSessionStart, sessionID, fmt.Sprintf("close-out nudge: %v", err))
-		} else if nudge != "" {
+	assemble := func(digest string) string {
+		var b strings.Builder
+		b.WriteString(groundTruthPreamble)
+		b.WriteString("\n\n")
+		if managed {
+			b.WriteString(protocol)
 			b.WriteString("\n")
-			b.WriteString(codexCommandNames(nudge, codex))
 		}
+		b.WriteString("## CHARTER\n")
+		b.WriteString(charterText(hub, repoKey))
 		b.WriteString("\n")
-		b.WriteString(startupBanner(workstreamID, proj))
+		// The digest already carries its own "# director render — <key>" heading
+		// and fixed-order sections, so it is appended verbatim under the
+		// Ground-Truth frame — in the normal (under-budget) case, byte-for-byte
+		// the render output.
+		b.WriteString(digest)
+		if managed {
+			if nudge != "" {
+				b.WriteString("\n")
+				b.WriteString(nudge)
+			}
+			b.WriteString("\n")
+			b.WriteString(banner)
+		}
+		return b.String()
 	}
 
-	return b.String(), nil
+	ctx := assemble(render.Digest(proj, repoKey))
+	if len(ctx) > injectionBudgetBytes {
+		// Deterministic degradation: collapse the decisions section (the one
+		// deferrable section) and say so loudly in health/ — over-budget growth
+		// is a grooming signal (§15.5 / L2 promotion), not a silent state.
+		full := len(ctx)
+		ctx = assemble(render.DigestCompact(proj, repoKey))
+		detail := fmt.Sprintf("injection budget: full payload %dB > %dB — decisions collapsed to count+pointer (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, len(ctx))
+		if len(ctx) > injectionBudgetBytes {
+			// Still over on open-items + handoffs alone: never eat the actionable
+			// sections — inject as-is and make the overflow visible.
+			detail += " — STILL over budget on actionable sections alone; the open-set needs grooming"
+		}
+		logFailure(hub, EventSessionStart, sessionID, detail)
+	}
+
+	return ctx, nil
 }
 
 // isCodexTranscript reports whether a hook payload's transcript_path identifies

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -142,6 +142,11 @@ func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
 // count+pointer line — never the open loops or the baton) and the overflow is
 // health-logged so growth is loud long before any harness threshold bites. The
 // preamble's DELIVERY CHECK contract remains the backstop of last resort.
+//
+// Measured on the DECODED payload — what actually enters the model's context.
+// The JSON envelope on the wire runs ~30% larger (escaping of <>, quotes, and
+// newlines); account for that before ever comparing this constant to a
+// wire-size threshold.
 const injectionBudgetBytes = 16 * 1024
 
 // buildGroundTruth assembles the injected block: the Ground-Truth preamble

--- a/internal/install/commands/handoff.md
+++ b/internal/install/commands/handoff.md
@@ -2,7 +2,7 @@
 description: Checkpoint this session into Director — flush pending decisions/open-items and emit a self-sufficient handoff so a fresh session can fully rehydrate. Use when PAUSING work you will resume; for a finished, merged workstream use /director:complete instead.
 ---
 
-You are checkpointing THIS session into Director (the coordination LOG) so a fresh session — you after a compaction, or a peer — can pick up exactly where you left off. The next session rehydrates from Director's injected Ground Truth (CHARTER + decisions + open-items + latest handoff); anything not in the LOG is lost. If this workstream is actually FINISHED and merged, stop and run `/director:complete` instead — a done workstream needs a close-out, not a baton. Otherwise do this now, in order:
+You are checkpointing THIS session into Director (the coordination LOG) so a fresh session — you after a compaction, or a peer — can pick up exactly where you left off. The next session rehydrates from Director's injected Ground Truth (CHARTER + open-items + latest handoff + a decision index); anything not in the LOG is lost. If this workstream is actually FINISHED and merged, stop and run `/director:complete` instead — a done workstream needs a close-out, not a baton. Otherwise do this now, in order:
 
 1. **Flush this session's durable items** — emit each as its own event, capturing everything not already in the LOG (do not assume earlier turns emitted them):
    - every decision made → `director emit --type decision --area <area> "<what + the why>"`

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -21,10 +21,13 @@ import (
 // latest handoff per workstream); it is not yet size-bounded. A bounded snapshot
 // (top-N with overflow, like status' Needs-you band) is the §15.5 fast-follow.
 //
-// Sections, in fixed order:
-//   - active decisions (ULID order)
+// Sections, in fixed order — actionable state first, so anything that
+// truncates the digest (the harness's inline hook-output budget, a human
+// skimming) costs deferrable decision rationale, never the open loops or the
+// baton:
 //   - open-set, with risk:escalate marked (ULID order)
 //   - latest handoff per workstream (sorted by workstream key)
+//   - active decisions (ULID order)
 //
 // Empty sections still print their header with a "(none)" line so the absence of
 // work is itself a stable, diffable fact rather than a missing section.
@@ -32,15 +35,6 @@ func Digest(proj Projection, repoKey string) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "# director render — %s\n", repoKey)
-
-	b.WriteString("\n## decisions\n")
-	if len(proj.Decisions) == 0 {
-		b.WriteString("(none)\n")
-	} else {
-		for _, d := range proj.Decisions {
-			fmt.Fprintf(&b, "- %s %s\n", d.ID, oneLine(d.Body))
-		}
-	}
 
 	b.WriteString("\n## open-items\n")
 	if len(proj.OpenItems) == 0 {
@@ -58,6 +52,15 @@ func Digest(proj Projection, repoKey string) string {
 		for _, ws := range sortedKeys(proj.LatestHandoff) {
 			h := proj.LatestHandoff[ws]
 			fmt.Fprintf(&b, "- %s [%s] %s\n", h.ID, ws, oneLine(h.Body))
+		}
+	}
+
+	b.WriteString("\n## decisions\n")
+	if len(proj.Decisions) == 0 {
+		b.WriteString("(none)\n")
+	} else {
+		for _, d := range proj.Decisions {
+			fmt.Fprintf(&b, "- %s %s\n", d.ID, oneLine(d.Body))
 		}
 	}
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -17,9 +17,15 @@ import (
 // the same event set always renders byte-identically (§13 t4). repoKey titles the
 // digest so a multi-project injection stays unambiguous.
 //
-// v1 renders the COMPLETE active set (every active decision, every open item, the
-// latest handoff per workstream); it is not yet size-bounded. A bounded snapshot
-// (top-N with overflow, like status' Needs-you band) is the §15.5 fast-follow.
+// The digest is size-bounded per LINE, not per section (§15.5): every entry of
+// the COMPLETE active set is present, but each body is capped to a headline —
+// nothing is dropped, the full body is one deterministic hop away via
+// `director show <ulid>`. Caps are generous where the content is actionable
+// (open-items, the handoff baton) and tight where it is deferrable rationale
+// (decisions, whose durable home is the living docs, not the log body). This is
+// what keeps the SessionStart injection safely under the harness's inline
+// hook-output budget as a project's log grows (the un-capped digest was
+// observed at 36KB after one month of dogfood — demoted to a 2KB preview).
 //
 // Sections, in fixed order — actionable state first, so anything that
 // truncates the digest (the harness's inline hook-output budget, a human
@@ -32,6 +38,21 @@ import (
 // Empty sections still print their header with a "(none)" line so the absence of
 // work is itself a stable, diffable fact rather than a missing section.
 func Digest(proj Projection, repoKey string) string {
+	return digest(proj, repoKey, false)
+}
+
+// DigestCompact is the hook's deterministic degradation step: identical to
+// Digest except the decisions section collapses to a single count-plus-pointer
+// line. It exists for the case where even the line-capped digest pushes the
+// SessionStart injection over its byte budget — decisions are the one section
+// whose full set is deferrable (rationale, not open loops or the baton), and
+// the collapsed line itself tells the model where the elided content lives, so
+// the elision is never silent.
+func DigestCompact(proj Projection, repoKey string) string {
+	return digest(proj, repoKey, true)
+}
+
+func digest(proj Projection, repoKey string, collapseDecisions bool) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "# director render — %s\n", repoKey)
@@ -41,7 +62,7 @@ func Digest(proj Projection, repoKey string) string {
 		b.WriteString("(none)\n")
 	} else {
 		for _, o := range proj.OpenItems {
-			fmt.Fprintf(&b, "- %s %s%s\n", o.ID, escalateTag(o.Risk), oneLine(o.Body))
+			fmt.Fprintf(&b, "- %s %s%s\n", o.ID, escalateTag(o.Risk), headline(o.Body, openItemBodyRunes))
 		}
 	}
 
@@ -51,16 +72,19 @@ func Digest(proj Projection, repoKey string) string {
 	} else {
 		for _, ws := range sortedKeys(proj.LatestHandoff) {
 			h := proj.LatestHandoff[ws]
-			fmt.Fprintf(&b, "- %s [%s] %s\n", h.ID, ws, oneLine(h.Body))
+			fmt.Fprintf(&b, "- %s [%s] %s\n", h.ID, ws, headline(h.Body, handoffBodyRunes))
 		}
 	}
 
 	b.WriteString("\n## decisions\n")
-	if len(proj.Decisions) == 0 {
+	switch {
+	case len(proj.Decisions) == 0:
 		b.WriteString("(none)\n")
-	} else {
+	case collapseDecisions:
+		fmt.Fprintf(&b, "(%d active decisions elided for size — run `director render` for the index, `director show <ulid>` for a full body)\n", len(proj.Decisions))
+	default:
 		for _, d := range proj.Decisions {
-			fmt.Fprintf(&b, "- %s %s\n", d.ID, oneLine(d.Body))
+			fmt.Fprintf(&b, "- %s %s%s\n", d.ID, areaTag(d.Area), headline(d.Body, decisionHeadlineRunes))
 		}
 	}
 
@@ -146,4 +170,42 @@ func oneLine(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
 	return strings.TrimSpace(s)
+}
+
+// Per-line digest caps (§15.5), in runes. Sized to context economy, not to the
+// harness's inline hook-output limit — that limit is undocumented and has been
+// observed to drift, so it must never be load-bearing. Generous where content
+// is actionable, tight where it is deferrable:
+//   - a decision line is an INDEX entry (ULID + area + headline); its full
+//     rationale lives one hop away in `director show`, and its durable home is
+//     the living docs anyway (CHARTER/ADRs), not the log body
+//   - an open-item must carry enough of the loop to act on without a pull
+//   - the handoff is the resume baton; cutting it defeats its purpose
+const (
+	decisionHeadlineRunes = 160
+	openItemBodyRunes     = 300
+	handoffBodyRunes      = 500
+)
+
+// headline collapses a body to one line and caps it at max runes, marking a cut
+// with "…" so a capped line is visibly a headline, never mistaken for the full
+// text. Rune-safe: a cap mid-UTF-8-sequence would corrupt the byte-identical
+// digest grammar.
+func headline(s string, max int) string {
+	s = oneLine(s)
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return strings.TrimSpace(string(runes[:max])) + "…"
+}
+
+// areaTag prefixes a decision's area onto its index line — the area is what
+// lets a session scan the index for the decisions relevant to the code it is
+// about to touch. Empty areas render nothing rather than an empty bracket.
+func areaTag(area string) string {
+	if area == "" {
+		return ""
+	}
+	return "[" + area + "] "
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -193,6 +193,11 @@ const (
 // digest grammar.
 func headline(s string, max int) string {
 	s = oneLine(s)
+	if len(s) <= max {
+		// Byte length ≤ max implies rune count ≤ max — the common under-cap
+		// case returns without the []rune allocation.
+		return s
+	}
 	runes := []rune(s)
 	if len(runes) <= max {
 		return s

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/colinsurprenant/director/internal/event"
 )
@@ -57,6 +58,18 @@ func TestDigestThroughStore(t *testing.T) {
 	d2 := Digest(Fold(read2), "widget")
 	if d1 != d2 {
 		t.Fatalf("digest differed across two reads of the same store:\n%s\n---\n%s", d1, d2)
+	}
+
+	// Section order must hold on a POPULATED digest too, not just the empty
+	// skeleton — a future refactor that branches per-section could reorder one
+	// path without touching the other.
+	last := -1
+	for _, header := range []string{"## open-items", "## handoffs", "## decisions"} {
+		at := strings.Index(d1, header)
+		if at < 0 || at < last {
+			t.Fatalf("populated digest section %q missing or out of order (want open-items, handoffs, decisions):\n%s", header, d1)
+		}
+		last = at
 	}
 
 	// The escalate open-item must be marked in the digest.
@@ -134,4 +147,71 @@ func lastIDOf(events []event.Event) string {
 		}
 	}
 	return last
+}
+
+// TestDigestLineCaps locks the §15.5 per-line bounding: a decision body over the
+// headline cap renders cut (with the "…" marker and its area tag), while the cap
+// is rune-safe under multibyte text — a byte-boundary cut would corrupt the
+// byte-identical digest grammar.
+func TestDigestLineCaps(t *testing.T) {
+	long := strings.Repeat("décision — ", 60) // multibyte, ~660 runes
+	proj := Fold([]event.Event{
+		{ID: mint(t), SchemaVersion: event.SchemaVersion, Type: event.KindDecision, Workstream: "ws1", Area: "hooks", Body: long},
+	})
+	d := Digest(proj, "widget")
+
+	line := ""
+	for _, l := range strings.Split(d, "\n") {
+		if strings.HasPrefix(l, "- ") && strings.Contains(l, "[hooks]") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("digest missing the decision index line with its area tag:\n%s", d)
+	}
+	if !strings.HasSuffix(line, "…") {
+		t.Errorf("over-cap decision body should end with the cut marker:\n%s", line)
+	}
+	// "- " + 26-rune ULID + " " + "[hooks] " + capped headline + "…"
+	if got, max := len([]rune(line)), 2+26+1+len("[hooks] ")+decisionHeadlineRunes+1; got > max {
+		t.Errorf("decision line exceeds the headline cap: %d runes:\n%s", got, line)
+	}
+	if !utf8.ValidString(d) {
+		t.Errorf("digest contains invalid UTF-8 after capping (byte-boundary cut?)")
+	}
+
+	// Under-cap bodies pass through unmarked.
+	short := Digest(Fold([]event.Event{
+		{ID: mint(t), SchemaVersion: event.SchemaVersion, Type: event.KindDecision, Workstream: "ws1", Body: "small decision"},
+	}), "widget")
+	if !strings.Contains(short, "- ") || strings.Contains(short, "…") {
+		t.Errorf("under-cap body must render whole, without a cut marker:\n%s", short)
+	}
+}
+
+// TestDigestCompact locks the deterministic degradation step: identical to the
+// full digest except decisions collapse to one count-plus-pointer line, and the
+// actionable sections (open-items, handoffs) are untouched.
+func TestDigestCompact(t *testing.T) {
+	events, _ := richSet(t)
+	proj := Fold(events)
+	full := Digest(proj, "widget")
+	compact := DigestCompact(proj, "widget")
+
+	if !strings.Contains(compact, "2 active decisions elided for size") {
+		t.Errorf("compact digest should announce the elision with the count:\n%s", compact)
+	}
+	if strings.Contains(compact, "decision B") {
+		t.Errorf("compact digest must not carry decision bodies:\n%s", compact)
+	}
+	wantPrefix := full[:strings.Index(full, "## decisions")]
+	if !strings.HasPrefix(compact, wantPrefix) {
+		t.Errorf("compact digest must be byte-identical to the full digest above the decisions section:\n--- full ---\n%s\n--- compact ---\n%s", full, compact)
+	}
+
+	// No active decisions → nothing to collapse; compact == full.
+	empty := Fold(nil)
+	if DigestCompact(empty, "widget") != Digest(empty, "widget") {
+		t.Errorf("compact of a decision-less projection should equal the full digest")
+	}
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -187,6 +187,26 @@ func TestDigestLineCaps(t *testing.T) {
 	if !strings.Contains(short, "- ") || strings.Contains(short, "…") {
 		t.Errorf("under-cap body must render whole, without a cut marker:\n%s", short)
 	}
+
+	// Each section gets ITS OWN cap — a transposition of the constants (e.g.
+	// handoffs capped at the open-item bound) must fail here, not pass silently.
+	filler := strings.Repeat("x", 1200) // over every cap; space-free so the cut is never trimmed shorter
+	capped := Digest(Fold([]event.Event{
+		{ID: mint(t), SchemaVersion: event.SchemaVersion, Type: event.KindOpenItem, Workstream: "ws1", Status: event.StatusOpen, Body: filler},
+		{ID: mint(t), SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws1", Body: filler},
+	}), "widget")
+	for _, l := range strings.Split(capped, "\n") {
+		if !strings.HasPrefix(l, "- ") {
+			continue
+		}
+		runes, isHandoff := len([]rune(l)), strings.Contains(l, "[ws1]")
+		switch {
+		case isHandoff && runes != 2+26+1+len("[ws1] ")+handoffBodyRunes+1:
+			t.Errorf("handoff line not cut at handoffBodyRunes (%d runes):\n%s", runes, l)
+		case !isHandoff && runes != 2+26+1+openItemBodyRunes+1:
+			t.Errorf("open-item line not cut at openItemBodyRunes (%d runes):\n%s", runes, l)
+		}
+	}
 }
 
 // TestDigestCompact locks the deterministic degradation step: identical to the
@@ -204,7 +224,11 @@ func TestDigestCompact(t *testing.T) {
 	if strings.Contains(compact, "decision B") {
 		t.Errorf("compact digest must not carry decision bodies:\n%s", compact)
 	}
-	wantPrefix := full[:strings.Index(full, "## decisions")]
+	idx := strings.Index(full, "## decisions")
+	if idx < 0 {
+		t.Fatalf("full digest missing the decisions heading:\n%s", full)
+	}
+	wantPrefix := full[:idx]
 	if !strings.HasPrefix(compact, wantPrefix) {
 		t.Errorf("compact digest must be byte-identical to the full digest above the decisions section:\n--- full ---\n%s\n--- compact ---\n%s", full, compact)
 	}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -69,10 +69,20 @@ func TestDigestThroughStore(t *testing.T) {
 // fully-populated skeleton — every section header present with "(none)".
 func TestDigestEmptyLogStable(t *testing.T) {
 	d := Digest(Fold(nil), "empty")
-	for _, header := range []string{"## decisions", "## open-items", "## handoffs"} {
-		if !strings.Contains(d, header) {
+	// Fixed section order is survival order: actionable state (open-set, baton)
+	// first, deferrable decision rationale last, so a truncated delivery of the
+	// injected digest costs rationale, never open loops.
+	last := -1
+	for _, header := range []string{"## open-items", "## handoffs", "## decisions"} {
+		at := strings.Index(d, header)
+		if at < 0 {
 			t.Errorf("empty digest missing header %q:\n%s", header, d)
+			continue
 		}
+		if at < last {
+			t.Errorf("digest section %q out of order (want open-items, handoffs, decisions):\n%s", header, d)
+		}
+		last = at
 	}
 	if strings.Count(d, "(none)") != 3 {
 		t.Errorf("empty digest expected three (none) sections, got:\n%s", d)

--- a/skills/director/SKILL.md
+++ b/skills/director/SKILL.md
@@ -98,8 +98,12 @@ a bounded **digest** of current state. That block is your **authoritative curren
   project state to "reconfirm" what you were just handed.
 - Re-deriving burns the exact context budget the digest was sized to save — and accelerates the
   next compaction. Perfect context that you ignore and rediscover is no better than no context.
+- The digest is an **INDEX**: every line is a capped headline, not the full text. The sanctioned
+  deeper read is `director show <ulid>` — one event in full, one deterministic hop from any
+  headline. Before touching an area, pull the full bodies of its listed decisions rather than
+  guessing past a headline.
 - Reach for the underlying log/docs only to go **deeper** than the digest on a specific question,
   or when escalation requires a fresh authoritative read (a render can be stale — but that is a
-  targeted scan, not a wholesale re-derivation of what you already hold).
+  targeted `show`/scan, not a wholesale re-derivation of what you already hold).
 
 Take the injected CHARTER + digest as true, start from there, and add to the LOG as you go.


### PR DESCRIPTION
## Problem

Claude Code silently demotes hook output above an undocumented size threshold to a persisted file, injecting only a 2KB head preview. This repo's un-capped Ground-Truth injection grew to 36KB after one month of dogfooding and hit that demotion: the digest, emit protocol, and acknowledge block never entered the session's context — push degraded to pull, and the session ran memory-zero until the human intervened. Caught live on 2026-07-03 (this is Director's own premise failing on Director's own repo).

The documented threshold (50K chars, W14 changelog) does not match observed behavior (36KB demoted), so the harness limit can never be load-bearing.

## Fix — two layers

**L0 — make truncated delivery loud and self-healing** (`1aaea74`)
- The preamble gains a DELIVERY CHECK contract on its second line: a truncated/persisted rendering means the state did not arrive — Read the full file first. The head is the only position guaranteed to survive a demotion, so the contract rides there.
- Payload reordered by survival priority: contract → emit protocol → CHARTER → digest; digest sections reordered to open-items, handoffs, decisions last — truncation now costs deferrable rationale, never open loops or the baton.

**L1 — bound the payload itself** (`7d120ed`, follow-ups `44c01aa`)
- Per-line digest caps (rune-safe, `…` cut marker): decisions become an index line (`ULID [area] headline`, 160 runes), open-items cap at 300, handoffs at 500. Nothing is dropped — the full body is one deterministic hop away.
- New read-only `director show <ulid>` verb: one event in full, body verbatim, `id.Parse`-canonicalized input matching `resolve`'s contract. No event kind, no boundary command, nothing written — the locked write surface is untouched.
- The hook self-measures against a 16KB budget (sized to context economy, deliberately not derived from the drifting harness limit). Over budget it degrades deterministically (`DigestCompact`: decisions collapse to a count+pointer line) and health-logs a grooming signal; it never cuts the open-set or the baton.
- The injected protocol teaches the pull path: digest = index, `show` = full text.

## Verification

- `go test ./... -race -count=1` green; `vet`/`gofmt` clean; digest determinism (§13 t4) verified unchanged — both digests are pure functions of the projection.
- Live against this repo's real log: injection went **39.5KB → 15.3KB**, delivered inline again.
- Two `/ce:review` passes (one per layer), both APPROVE; all findings addressed in `44c01aa`.

## Notes for the reviewer

- `director show` is a new verb against the frozen-surface decision (01KWHS2M7A). Argued within the freeze's spirit: read-only projection, no event kind, no boundary command, writes nothing.
- L2 (a `director promote` ceremony so promoted rationale renders as a doc pointer) is tracked in the LOG as the follow-up that buys long-term headroom — this repo already sits at 15.3KB of the 16KB budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
