### PR TITLE
fix(hook): head-anchor the acknowledgment banner in the SessionStart injection

### DIFF
--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -518,6 +518,13 @@ func TestSessionStartCloseOutNudgeForGoneSibling(t *testing.T) {
 	gitIn(t, repo, "worktree", "remove", "--force", wtDir)
 	gitIn(t, repo, "branch", "-D", "feature")
 
+	// Give the MAIN workstream a handoff so this fixture carries both tail
+	// blocks (resume + nudge) and can lock their relative order.
+	mainWS := mustResolve(t, repo)
+	if _, err := event.Emit(store, mainWS.ID, event.EmitParams{Type: event.KindHandoff, Area: "x", Body: "doing X, next Y"}); err != nil {
+		t.Fatalf("seed main handoff: %v", err)
+	}
+
 	in2 := `{"session_id":"s-main","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
 	var out bytes.Buffer
 	if code := Dispatch(EventSessionStart, strings.NewReader(in2), &out, hub); code != 0 {
@@ -532,6 +539,11 @@ func TestSessionStartCloseOutNudgeForGoneSibling(t *testing.T) {
 	}
 	if !strings.Contains(got, "1 open item(s)") {
 		t.Errorf("nudge should carry the sibling's open count:\n%s", got)
+	}
+	// Within the tail, survival order still applies: the session-critical
+	// resume anchor must precede the advisory (and per-sibling growing) nudge.
+	if r, n := strings.Index(got, "## Resume point"), strings.Index(got, "## Close-out pending"); r < 0 || n < 0 || r > n {
+		t.Errorf("resume point must precede the close-out nudge (resume@%d, nudge@%d):\n%s", r, n, got)
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -296,8 +296,19 @@ func TestSessionStartInjectsGroundTruth(t *testing.T) {
 	if !strings.Contains(ctx, "▸ Director:") {
 		t.Errorf("adopted-repo injection missing the startup acknowledgment banner:\n%s", ctx)
 	}
+	// The banner must ride the HEAD (after the preamble, before the protocol):
+	// a harness persisted-output preview keeps only the first ~2KB, and the
+	// banner is useless for the first reply if it sits in the dropped tail.
+	if b, p := strings.Index(ctx, "## Acknowledge on entry"), strings.Index(ctx, "## Director protocol"); b < 0 || p < 0 || b > p {
+		t.Errorf("acknowledgment banner must precede the emit protocol (banner@%d, protocol@%d):\n%s", b, p, ctx)
+	}
 	if !strings.Contains(ctx, "Resume point") {
 		t.Errorf("injection missing the resume-point anchor for the current workstream:\n%s", ctx)
+	}
+	// The resume point references the digest above it, so it must FOLLOW the
+	// digest — it is the one banner-adjacent block that stays in the tail.
+	if r, d := strings.Index(ctx, "## Resume point"), strings.Index(ctx, "# director render"); r < 0 || d < 0 || r < d {
+		t.Errorf("resume point must follow the render digest it references (resume@%d, digest@%d):\n%s", r, d, ctx)
 	}
 	if !strings.Contains(ctx, "commitment to act") {
 		t.Errorf("injected protocol should clarify that emit RECORDS (not a commitment to act):\n%s", ctx)
@@ -340,6 +351,15 @@ func TestSessionStartProtocolScopedToAdopted(t *testing.T) {
 	}
 	if strings.Contains(got, "## Director protocol") {
 		t.Errorf("un-adopted repo must NOT get the emit protocol (would nag unrelated repos):\n%s", got)
+	}
+	// The banner and resume point are managed-gated for the same reason as the
+	// protocol; lock their absence too so a refactor can't move their writes
+	// outside the managed guard unnoticed.
+	if strings.Contains(got, "## Acknowledge on entry") {
+		t.Errorf("un-adopted repo must NOT get the acknowledgment banner:\n%s", got)
+	}
+	if strings.Contains(got, "## Resume point") {
+		t.Errorf("un-adopted repo must NOT get a resume point:\n%s", got)
 	}
 }
 
@@ -446,6 +466,11 @@ func TestSessionStartCodexCommandNames(t *testing.T) {
 	}
 	if strings.Contains(got, "/director:complete") || strings.Contains(got, "/director:handoff") {
 		t.Errorf("codex session must not be told CC command names:\n%s", got)
+	}
+	// This fixture is managed (seeded note) but has NO handoff for the
+	// workstream — the resume-point block must be absent, not empty-headed.
+	if strings.Contains(got, "## Resume point") {
+		t.Errorf("no handoff for this workstream, so no resume point should be injected:\n%s", got)
 	}
 
 	// The same start with a CC-shaped transcript path keeps the CC names.

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -177,7 +177,7 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 	// Compute the managed-only blocks once, outside the assembler: closeOutNudge
 	// reads the fleet and health-logs its own failure, so a budget re-assembly
 	// must not run it twice.
-	var protocol, nudge, banner string
+	var protocol, nudge, banner, resume string
 	if managed {
 		protocol = codexCommandNames(emitProtocol, codex)
 		n, err := closeOutNudge(hub, repoKey, workstreamID, proj, time.Now().UTC())
@@ -189,18 +189,26 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 			nudge = codexCommandNames(n, codex)
 		}
 		banner = startupBanner(workstreamID, proj)
+		resume = resumePoint(workstreamID, proj)
 	}
 
 	// Assembly order is survival order: any truncation (harness demotion, a
 	// human skimming) eats the tail first, so the blocks a session cannot
-	// work without ride highest — preamble+contract, then the write-side
-	// protocol, then identity (CHARTER), then the digest, whose own sections
-	// put deferrable decision rationale last.
+	// work without ride highest — preamble+contract, then the acknowledgment
+	// banner (needed for the FIRST LINE of the first reply, so it must sit in
+	// the head a persisted-output preview keeps — tail placement made the
+	// banner conditional on the model completing the file read, observed live
+	// 2026-07-04), then the write-side protocol, then identity (CHARTER), then
+	// the digest, whose own sections put deferrable decision rationale last.
+	// The resume-point anchor rides after the digest because it points INTO it
+	// ("the handoff labeled [...] above").
 	assemble := func(digest string) string {
 		var b strings.Builder
 		b.WriteString(groundTruthPreamble)
 		b.WriteString("\n\n")
 		if managed {
+			b.WriteString(banner)
+			b.WriteString("\n")
 			b.WriteString(protocol)
 			b.WriteString("\n")
 		}
@@ -217,8 +225,10 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 				b.WriteString("\n")
 				b.WriteString(nudge)
 			}
-			b.WriteString("\n")
-			b.WriteString(banner)
+			if resume != "" {
+				b.WriteString("\n")
+				b.WriteString(resume)
+			}
 		}
 		return b.String()
 	}
@@ -327,6 +337,9 @@ func closeOutNudge(hub, repoKey, currentWS string, proj render.Projection, now t
 // the first line of its first reply — a visible signal that the session rehydrated,
 // since the injection is otherwise silent. The line is pre-computed here (workstream
 // + open-item counts) so the model relays it rather than re-deriving the counts.
+// It is placed immediately after the preamble so a harness persisted-output
+// preview (head-anchored, ~2KB observed) still carries it: the banner must be
+// printable BEFORE the full-file read the DELIVERY CHECK may demand.
 func startupBanner(workstreamID string, proj render.Projection) string {
 	needYou := 0
 	for _, o := range proj.OpenItems {
@@ -335,14 +348,19 @@ func startupBanner(workstreamID string, proj render.Projection) string {
 		}
 	}
 	banner := fmt.Sprintf("▸ Director: %s · %d open-item(s), %d need-you", workstreamID, len(proj.OpenItems), needYou)
-	out := "## Acknowledge on entry\nBegin your VERY FIRST reply to the human with this line verbatim (then answer normally), so they can see Director rehydrated:\n" + banner + "\n"
-	// Name THIS workstream's own latest handoff as the resume anchor. Several
-	// workstreams can share one repo log, so the digest's handoffs section lists one
-	// per workstream — without this, the model must guess which is its continuation.
-	if _, ok := proj.LatestHandoff[workstreamID]; ok {
-		out += "Resume point: the handoff labeled [" + workstreamID + "] above is YOUR last position — resume from it; the other handoffs are sibling workstreams' positions, for awareness only.\n"
+	return "## Acknowledge on entry\nBegin your VERY FIRST reply to the human with this line verbatim (then answer normally), so they can see Director rehydrated:\n" + banner + "\n"
+}
+
+// resumePoint names THIS workstream's own latest handoff as the resume anchor.
+// Several workstreams can share one repo log, so the digest's handoffs section
+// lists one per workstream — without this, the model must guess which is its
+// continuation. Kept separate from startupBanner (which rides the payload head)
+// because it references the digest above it and so must follow it.
+func resumePoint(workstreamID string, proj render.Projection) string {
+	if _, ok := proj.LatestHandoff[workstreamID]; !ok {
+		return ""
 	}
-	return out
+	return "## Resume point\nThe handoff labeled [" + workstreamID + "] in the digest above is YOUR last position — resume from it; the other handoffs are sibling workstreams' positions, for awareness only.\n"
 }
 
 // charterExists reports whether the repo has been adopted — a non-empty CHARTER.md

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -221,13 +221,16 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 		// the render output.
 		b.WriteString(digest)
 		if managed {
-			if nudge != "" {
-				b.WriteString("\n")
-				b.WriteString(nudge)
-			}
+			// Resume before nudge: within the tail, survival order still applies —
+			// the resume anchor is session-critical while the close-out nudge is
+			// advisory and grows a line per gone sibling.
 			if resume != "" {
 				b.WriteString("\n")
 				b.WriteString(resume)
+			}
+			if nudge != "" {
+				b.WriteString("\n")
+				b.WriteString(nudge)
 			}
 		}
 		return b.String()


### PR DESCRIPTION
## Problem

The `## Acknowledge on entry` block (the pre-computed `▸ Director: …` banner the model must print as the first line of its first reply) rode at the **tail** of the Ground-Truth payload — exactly the part the harness drops when it persists an oversized hook output and injects only a ~2KB head preview. On that persisted path the banner became conditional on the model completing the DELIVERY CHECK full-file read: observed live 2026-07-04, where the banner led the *second* message instead of the first (open-item `01KWQ7CC`).

This also contradicted the payload's own survival-order principle: blocks a session cannot work without ride highest, and the ack instruction is needed for the first reply.

## Fix

- Move the `## Acknowledge on entry` block to the head, immediately after the preamble — the banner now lands at byte ~582 of a live 15KB payload, inside the observed preview window, so it is printable before (or regardless of) the full-file read.
- Split the resume-point line into its own `## Resume point` tail block: it references "the handoff labeled […] in the digest above", so it must follow the digest. `resumePoint()` returns empty when the workstream has no handoff.
- Managed-only gating, the over-budget double-assembly invariant (blocks computed once outside `assemble`), the codex command rewrite scope, and digest byte-fidelity are all unchanged.

## Tests

- Ordering assertions in `TestSessionStartInjectsGroundTruth`: banner-before-protocol and resume-after-digest, in the established anti-vacuity form (missing marker fails the assertion itself).
- Un-adopted repo test now locks the **absence** of both repositioned blocks, so a refactor can't move them outside the `managed` guard unnoticed.
- Codex test locks the no-handoff path (no `## Resume point` injected).
- `go test ./... -race` green (§13 gate).

## Review

`ce:code-reviewer` pass: APPROVE, no blockers; both actionable findings folded in (the absence assertions above). Repo-wide grep confirmed nothing consumes the old tail-inline `Resume point:` format.

Retest criterion (open-item `01KWQ7CC`, stays open until then): after merge + rebuild of the installed binary, the next session start must show the banner as the **first line of the first reply**, whatever the first prompt is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)