### PR TITLE
fix(fleet,hooks): UTC-normalize fleet timestamps at the write boundary; quiet already-archived stop

### DIFF
--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -92,7 +92,9 @@ func Heartbeat(hub, workstream, uuid string, now time.Time) error {
 	} else if err != nil {
 		return err
 	}
-	row.Heartbeat = now.Format(heartbeatLayout)
+	// Normalized to UTC at the write boundary so rows never carry mixed-offset
+	// timestamps, regardless of what zone the caller's clock is in.
+	row.Heartbeat = now.UTC().Format(heartbeatLayout)
 	return writeRow(path, row)
 }
 
@@ -117,7 +119,7 @@ func Done(hub, workstream, uuid string, now time.Time) error {
 func archiveRow(hub, src string, row Row, now time.Time) error {
 	row.Status = StatusDone
 
-	destDir := filepath.Join(hub, fleetDir, archiveDir, now.Format(archiveDateLayout))
+	destDir := filepath.Join(hub, fleetDir, archiveDir, now.UTC().Format(archiveDateLayout))
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("fleet: create archive dir: %w", err)
 	}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -143,6 +143,42 @@ func TestLifecycleDoneMissingRow(t *testing.T) {
 	}
 }
 
+// TestLifecycleTimestampsNormalizedToUTC locks the write-boundary guarantee: a
+// caller passing a zoned clock to Heartbeat/Done still produces UTC-stamped
+// rows and UTC-dated archive buckets, whatever zone the caller's clock is in.
+// (Register still trusts its caller's pre-formatted heartbeat string — that
+// gap is tracked as its own open-item.)
+func TestLifecycleTimestampsNormalizedToUTC(t *testing.T) {
+	hub := t.TempDir()
+	ws, uuid := "widget-main-abc123", "uuid-1"
+	// 23:00 June 8 at -05:00 is June 9 in UTC, so zone handling shows in both
+	// the stored offset and the archive date bucket.
+	zoned := time.Date(2026, 6, 8, 23, 0, 0, 0, time.FixedZone("UTC-5", -5*3600))
+
+	if err := Heartbeat(hub, ws, uuid, zoned); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	got := readRowOrFail(t, rowPath(hub, ws, uuid))
+	hb, err := time.Parse(heartbeatLayout, got.Heartbeat)
+	if err != nil {
+		t.Fatalf("parse heartbeat %q: %v", got.Heartbeat, err)
+	}
+	if _, offset := hb.Zone(); offset != 0 {
+		t.Errorf("heartbeat %q carries a zone offset, want UTC", got.Heartbeat)
+	}
+	if !hb.Equal(zoned) {
+		t.Errorf("normalization changed the instant: %v != %v", hb, zoned)
+	}
+
+	if err := Done(hub, ws, uuid, zoned); err != nil {
+		t.Fatalf("Done: %v", err)
+	}
+	archived := filepath.Join(hub, fleetDir, archiveDir, "2026-06-09", rowFile(ws, uuid))
+	if _, err := os.Stat(archived); err != nil {
+		t.Errorf("archive bucket should use the UTC date (2026-06-09): %v", err)
+	}
+}
+
 // TestLifecycleDoneWorkstreamArchivesAllRows: the cross-workstream close-out
 // archives EVERY live row of the target (a dead sibling's session uuids are
 // unknowable, and a partial archive leaves the ghost alive) while another

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -705,6 +705,42 @@ func TestEmitGuardAllowsWhenEmitted(t *testing.T) {
 	}
 }
 
+// TestStopAlreadyArchivedRowIsQuietSuccess: a repeated Stop with no tool call
+// in between (the daily steady state — the previous Stop already archived the
+// row) must land in health/ as ok=true, never as failure spam. The first Stop
+// archives the live row; the second finds nothing and stays quiet.
+func TestStopAlreadyArchivedRowIsQuietSuccess(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	transcript := writeTranscript(t, assistantLine("Nothing notable this turn."))
+
+	ws, err := identity.Resolve(repo)
+	if err != nil {
+		t.Fatalf("identity.Resolve: %v", err)
+	}
+	// Same uuid as stopInput's session_id, so both Stops target this row.
+	if err := fleet.Heartbeat(hub, ws.ID, "s-real", time.Now()); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+
+	in := stopInput(repo, transcript, false)
+	for i := 0; i < 2; i++ {
+		var out bytes.Buffer
+		if code := Dispatch(EventStop, strings.NewReader(in), &out, hub); code != 0 {
+			t.Fatalf("stop %d: exit code = %d, want 0", i+1, code)
+		}
+	}
+	health := readHealth(t, hub)
+	// Exactly once: the first Stop must find and archive the live row (no quiet
+	// line), only the second hits the benign no-row path.
+	if n := strings.Count(health, "fleet done: no live row"); n != 1 {
+		t.Fatalf("quiet no-live-row line count = %d, want 1; health log:\n%s", n, health)
+	}
+	if strings.Contains(health, "ok=false") {
+		t.Errorf("a benign repeated stop must not produce failure lines, got:\n%s", health)
+	}
+}
+
 // TestEmitGuardProseMentionBlocks verifies a turn that only TALKS about emitting
 // (prose mention, no actual tool call) is not treated as having emitted — a
 // decision-like turn that never ran `director emit` still blocks (L2 false-negative

--- a/internal/hook/stop.go
+++ b/internal/hook/stop.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -138,9 +139,13 @@ func markFleetDone(in Input, hub string) {
 		return
 	}
 	if err := fleet.Done(hub, ws.ID, sessionUUID(in), time.Now()); err != nil {
-		// ErrRowNotFound is an expected, benign outcome (nothing to archive);
-		// log it at the same loud level so the timeline stays complete but it
-		// never blocks the stop.
+		// An already-gone row (archived by a previous Stop with no tool call
+		// since, or never registered) is the steady state for repeated stops —
+		// log it as quiet success so ok=false lines in health/ stay meaningful.
+		if errors.Is(err, fleet.ErrRowNotFound) {
+			logSuccess(hub, EventStop, in.SessionID, "fleet done: no live row (already archived or never registered)")
+			return
+		}
 		logFailure(hub, EventStop, in.SessionID, fmt.Sprintf("fleet done: %v", err))
 	}
 }


### PR DESCRIPTION
Two health-hygiene fixes from the open-set (Director log items 01KWMR9RMC, 01KWMR9RMS).

## UTC normalization at the fleet write boundary

`fleet.Heartbeat` and `archiveRow` now call `.UTC()` where the timestamp is formatted, so fleet rows and archive date buckets never carry mixed-offset timestamps regardless of the caller's clock.

The previous convention was "callers pass UTC" — and it had already drifted twice (`posttooluse.go` and `stop.go` both passed local `time.Now()`, which also meant `fleet/archive/<date>/` buckets were local-dated). Normalizing at the boundary retires the bug class instead of patching the two callers.

## Quiet already-archived stop

`markFleetDone` now logs `fleet.ErrRowNotFound` as `ok=true` ("fleet done: no live row (already archived or never registered)") instead of an `ok=false` failure line. A repeated Stop with no tool call in between is the expected daily steady state and was producing failure spam in `health/` — exactly the wallpaper the abandonment kill-criteria warn about. Real failures (corrupt rows, I/O) still log loud, and the CLI `done` paths keep their nonzero exits.

## Tests

- `TestLifecycleTimestampsNormalizedToUTC` — zoned clock (23:00 at −05:00, crossing UTC midnight) → zero-offset stored heartbeat, same instant, UTC-dated archive bucket.
- `TestStopAlreadyArchivedRowIsQuietSuccess` — register → Stop → Stop through the full `Dispatch` path; the quiet line appears exactly once and no `ok=false` lines are produced.

Both were verified to fail on pre-fix code. An independent review pass (ce:code-reviewer) approved; its findings are applied (honest log-line wording, test exercises the advertised steady state, softened test comment). Its one substantive follow-up — `Register` still trusts a caller-formatted heartbeat string — is filed as Director open-item 01KWQ94Q9G rather than expanded into this batch.

`go test ./... -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
