### PR TITLE
fix(fleet): Register takes time.Time — the last fleet writer joins the UTC boundary

### DIFF
--- a/cmd/director/closeout_routing_test.go
+++ b/cmd/director/closeout_routing_test.go
@@ -27,9 +27,8 @@ func TestDoneWorkstreamRouting(t *testing.T) {
 		t.Fatalf("done --workstream with no rows = %d, want 2", got)
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339Nano)
 	for _, uuid := range []string{"uuid-A", "uuid-B"} {
-		if err := fleet.Register(hub, fleet.Row{Workstream: "dead-sibling", UUID: uuid, Heartbeat: now}); err != nil {
+		if err := fleet.Register(hub, fleet.Row{Workstream: "dead-sibling", UUID: uuid}, time.Now()); err != nil {
 			t.Fatalf("Register: %v", err)
 		}
 	}

--- a/cmd/director/fleetcmd.go
+++ b/cmd/director/fleetcmd.go
@@ -26,7 +26,6 @@ func runRegister(args []string) int {
 		fmt.Fprintf(os.Stderr, "register: %v\n", err)
 		return 1
 	}
-	now := time.Now().UTC()
 	row := fleet.Row{
 		Workstream: ws.ID,
 		UUID:       sessionUUID(),
@@ -34,9 +33,8 @@ func runRegister(args []string) int {
 		Handle:     ws.ID,
 		Branch:     ws.Branch,
 		Dir:        cwd,
-		Heartbeat:  now.Format(time.RFC3339Nano),
 	}
-	if err := fleet.Register(hub, row); err != nil {
+	if err := fleet.Register(hub, row, time.Now()); err != nil {
 		fmt.Fprintf(os.Stderr, "register: %v\n", err)
 		return 1
 	}

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -98,9 +98,8 @@ func Adopt(hub, dir string) (Result, error) {
 		UUID:       adoptUUID,
 		RepoKey:    ws.RepoKey,
 		Handle:     ws.ID,
-		Heartbeat:  time.Now().UTC().Format(time.RFC3339Nano),
 	}
-	if err := fleet.Register(hub, row); err != nil {
+	if err := fleet.Register(hub, row, time.Now()); err != nil {
 		return Result{}, fmt.Errorf("adopt: register fleet row: %w", err)
 	}
 

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -57,16 +57,15 @@ type Row struct {
 const StatusDone = "done"
 
 // Register creates or refreshes the row file for row's (workstream, uuid),
-// stamping its heartbeat from row.Heartbeat. The caller fills Workstream, UUID,
-// Handle, and Heartbeat; an empty Heartbeat is rejected so a row is never
-// written without the freshness signal liveness depends on.
-func Register(hub string, row Row) error {
+// stamping its heartbeat from now. The caller fills Workstream, UUID, Handle,
+// and the identity fields; the heartbeat is stamped here — like Heartbeat and
+// archiveRow, the write boundary formats the timestamp (normalized to UTC), so
+// no caller can produce a mixed-offset or malformed heartbeat.
+func Register(hub string, row Row, now time.Time) error {
 	if row.Workstream == "" || row.UUID == "" {
 		return fmt.Errorf("fleet: register requires workstream and uuid")
 	}
-	if row.Heartbeat == "" {
-		return fmt.Errorf("fleet: register requires a heartbeat")
-	}
+	row.Heartbeat = now.UTC().Format(heartbeatLayout)
 	dir := filepath.Join(hub, fleetDir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("fleet: create fleet dir: %w", err)

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -18,9 +18,11 @@ func TestLifecycleRegisterCreatesRow(t *testing.T) {
 		Workstream: "widget-main-abc123",
 		UUID:       "uuid-1",
 		Handle:     "@colin",
-		Heartbeat:  fixedTime.Format(heartbeatLayout),
+		// Deliberately garbage: Register stamps the heartbeat from its clock
+		// and must ignore whatever a caller left in the field.
+		Heartbeat: "junk-not-a-timestamp",
 	}
-	if err := Register(hub, row); err != nil {
+	if err := Register(hub, row, fixedTime); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -28,8 +30,8 @@ func TestLifecycleRegisterCreatesRow(t *testing.T) {
 	if got.Workstream != row.Workstream || got.UUID != row.UUID || got.Handle != row.Handle {
 		t.Errorf("row roundtrip mismatch: got %+v want %+v", got, row)
 	}
-	if got.Heartbeat != row.Heartbeat {
-		t.Errorf("heartbeat = %q, want %q", got.Heartbeat, row.Heartbeat)
+	if want := fixedTime.Format(heartbeatLayout); got.Heartbeat != want {
+		t.Errorf("heartbeat = %q, want the Register-stamped %q", got.Heartbeat, want)
 	}
 	if got.Status != "" {
 		t.Errorf("a live row must carry no status, got %q", got.Status)
@@ -43,7 +45,7 @@ func TestLifecycleRegisterCreatesRow(t *testing.T) {
 func TestRowFileDistinctForSluggingCollision(t *testing.T) {
 	hub := t.TempDir()
 	for _, ws := range []string{"a-b", "a_b"} {
-		if err := Register(hub, Row{Workstream: ws, UUID: "u", Heartbeat: fixedTime.Format(heartbeatLayout)}); err != nil {
+		if err := Register(hub, Row{Workstream: ws, UUID: "u"}, fixedTime); err != nil {
 			t.Fatalf("Register(%s): %v", ws, err)
 		}
 	}
@@ -59,12 +61,11 @@ func TestRowFileDistinctForSluggingCollision(t *testing.T) {
 func TestLifecycleRegisterRejectsMissingFields(t *testing.T) {
 	hub := t.TempDir()
 	cases := []Row{
-		{UUID: "u", Heartbeat: fixedTime.Format(heartbeatLayout)},       // no workstream
-		{Workstream: "w", Heartbeat: fixedTime.Format(heartbeatLayout)}, // no uuid
-		{Workstream: "w", UUID: "u"},                                    // no heartbeat
+		{UUID: "u"},       // no workstream
+		{Workstream: "w"}, // no uuid
 	}
 	for i, row := range cases {
-		if err := Register(hub, row); err == nil {
+		if err := Register(hub, row, fixedTime); err == nil {
 			t.Errorf("case %d: expected error for incomplete row %+v, got nil", i, row)
 		}
 	}
@@ -73,7 +74,7 @@ func TestLifecycleRegisterRejectsMissingFields(t *testing.T) {
 func TestLifecycleHeartbeatAdvancesTimestamp(t *testing.T) {
 	hub := t.TempDir()
 	ws, uuid := "widget-main-abc123", "uuid-1"
-	if err := Register(hub, Row{Workstream: ws, UUID: uuid, Heartbeat: fixedTime.Format(heartbeatLayout)}); err != nil {
+	if err := Register(hub, Row{Workstream: ws, UUID: uuid}, fixedTime); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -111,7 +112,7 @@ func TestLifecycleHeartbeatCreatesWhenAbsent(t *testing.T) {
 func TestLifecycleDoneArchivesNeverDeletes(t *testing.T) {
 	hub := t.TempDir()
 	ws, uuid := "widget-main-abc123", "uuid-1"
-	if err := Register(hub, Row{Workstream: ws, UUID: uuid, Heartbeat: fixedTime.Format(heartbeatLayout)}); err != nil {
+	if err := Register(hub, Row{Workstream: ws, UUID: uuid}, fixedTime); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -143,11 +144,10 @@ func TestLifecycleDoneMissingRow(t *testing.T) {
 	}
 }
 
-// TestLifecycleTimestampsNormalizedToUTC locks the write-boundary guarantee: a
-// caller passing a zoned clock to Heartbeat/Done still produces UTC-stamped
-// rows and UTC-dated archive buckets, whatever zone the caller's clock is in.
-// (Register still trusts its caller's pre-formatted heartbeat string — that
-// gap is tracked as its own open-item.)
+// TestLifecycleTimestampsNormalizedToUTC locks the write-boundary guarantee:
+// a caller passing a zoned clock to Register/Heartbeat/Done still produces
+// UTC-stamped rows and UTC-dated archive buckets — no fleet writer can carry
+// a mixed-offset timestamp, whatever zone the caller's clock is in.
 func TestLifecycleTimestampsNormalizedToUTC(t *testing.T) {
 	hub := t.TempDir()
 	ws, uuid := "widget-main-abc123", "uuid-1"
@@ -155,20 +155,30 @@ func TestLifecycleTimestampsNormalizedToUTC(t *testing.T) {
 	// the stored offset and the archive date bucket.
 	zoned := time.Date(2026, 6, 8, 23, 0, 0, 0, time.FixedZone("UTC-5", -5*3600))
 
+	assertUTCHeartbeat := func(step string) {
+		t.Helper()
+		got := readRowOrFail(t, rowPath(hub, ws, uuid))
+		hb, err := time.Parse(heartbeatLayout, got.Heartbeat)
+		if err != nil {
+			t.Fatalf("%s: parse heartbeat %q: %v", step, got.Heartbeat, err)
+		}
+		if _, offset := hb.Zone(); offset != 0 {
+			t.Errorf("%s: heartbeat %q carries a zone offset, want UTC", step, got.Heartbeat)
+		}
+		if !hb.Equal(zoned) {
+			t.Errorf("%s: normalization changed the instant: %v != %v", step, hb, zoned)
+		}
+	}
+
+	if err := Register(hub, Row{Workstream: ws, UUID: uuid}, zoned); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	assertUTCHeartbeat("Register")
+
 	if err := Heartbeat(hub, ws, uuid, zoned); err != nil {
 		t.Fatalf("Heartbeat: %v", err)
 	}
-	got := readRowOrFail(t, rowPath(hub, ws, uuid))
-	hb, err := time.Parse(heartbeatLayout, got.Heartbeat)
-	if err != nil {
-		t.Fatalf("parse heartbeat %q: %v", got.Heartbeat, err)
-	}
-	if _, offset := hb.Zone(); offset != 0 {
-		t.Errorf("heartbeat %q carries a zone offset, want UTC", got.Heartbeat)
-	}
-	if !hb.Equal(zoned) {
-		t.Errorf("normalization changed the instant: %v != %v", hb, zoned)
-	}
+	assertUTCHeartbeat("Heartbeat")
 
 	if err := Done(hub, ws, uuid, zoned); err != nil {
 		t.Fatalf("Done: %v", err)
@@ -187,11 +197,11 @@ func TestLifecycleDoneWorkstreamArchivesAllRows(t *testing.T) {
 	hub := t.TempDir()
 	ws := "widget-feature-abc123"
 	for _, uuid := range []string{"uuid-A", "uuid-B"} {
-		if err := Register(hub, Row{Workstream: ws, UUID: uuid, Heartbeat: fixedTime.Format(heartbeatLayout)}); err != nil {
+		if err := Register(hub, Row{Workstream: ws, UUID: uuid}, fixedTime); err != nil {
 			t.Fatalf("Register %s: %v", uuid, err)
 		}
 	}
-	if err := Register(hub, Row{Workstream: "other-main-def456", UUID: "uuid-C", Heartbeat: fixedTime.Format(heartbeatLayout)}); err != nil {
+	if err := Register(hub, Row{Workstream: "other-main-def456", UUID: "uuid-C"}, fixedTime); err != nil {
 		t.Fatalf("Register other: %v", err)
 	}
 
@@ -225,7 +235,7 @@ func TestLifecycleDoneWorkstreamArchivesAllRows(t *testing.T) {
 func TestLifecycleDoneWorkstreamSkipsCorruptAndArchivesDriftedName(t *testing.T) {
 	hub := t.TempDir()
 	ws := "widget-feature-abc123"
-	if err := Register(hub, Row{Workstream: ws, UUID: "uuid-A", Heartbeat: fixedTime.Format(heartbeatLayout)}); err != nil {
+	if err := Register(hub, Row{Workstream: ws, UUID: "uuid-A"}, fixedTime); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 	// A matching row living under a filename its identity does not hash to.
@@ -261,7 +271,7 @@ func TestLifecycleDoneWorkstreamNoRows(t *testing.T) {
 	if _, err := DoneWorkstream(hub, "nope", fixedTime); !errors.Is(err, ErrRowNotFound) {
 		t.Errorf("DoneWorkstream on empty hub: got %v, want ErrRowNotFound", err)
 	}
-	if err := Register(hub, Row{Workstream: "present", UUID: "u", Heartbeat: fixedTime.Format(heartbeatLayout)}); err != nil {
+	if err := Register(hub, Row{Workstream: "present", UUID: "u"}, fixedTime); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := DoneWorkstream(hub, "nope", fixedTime); !errors.Is(err, ErrRowNotFound) {
@@ -274,12 +284,12 @@ func TestLifecycleDoneWorkstreamNoRows(t *testing.T) {
 func TestLifecycleConcurrentUUIDsDoNotClobber(t *testing.T) {
 	hub := t.TempDir()
 	ws := "widget-main-abc123"
-	a := Row{Workstream: ws, UUID: "uuid-A", Handle: "@a", Heartbeat: fixedTime.Format(heartbeatLayout)}
-	b := Row{Workstream: ws, UUID: "uuid-B", Handle: "@b", Heartbeat: fixedTime.Format(heartbeatLayout)}
-	if err := Register(hub, a); err != nil {
+	a := Row{Workstream: ws, UUID: "uuid-A", Handle: "@a"}
+	b := Row{Workstream: ws, UUID: "uuid-B", Handle: "@b"}
+	if err := Register(hub, a, fixedTime); err != nil {
 		t.Fatalf("Register a: %v", err)
 	}
-	if err := Register(hub, b); err != nil {
+	if err := Register(hub, b, fixedTime); err != nil {
 		t.Fatalf("Register b: %v", err)
 	}
 

--- a/internal/fleet/liveness_test.go
+++ b/internal/fleet/liveness_test.go
@@ -24,8 +24,7 @@ func registerAt(t *testing.T, hub, ws, uuid, handle string, hb time.Time) {
 		Workstream: ws,
 		UUID:       uuid,
 		Handle:     handle,
-		Heartbeat:  hb.Format(heartbeatLayout),
-	}); err != nil {
+	}, hb); err != nil {
 		t.Fatalf("Register(%s/%s): %v", ws, uuid, err)
 	}
 }

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -112,9 +112,7 @@ func handleSessionStart(in Input, out io.Writer, hub string) error {
 // is stamped alongside the branch so liveness can check the branch still exists
 // and self-clean a merged-away worktree (§5.5).
 func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
-	// UTC to match every other fleet writer (register/heartbeat/adopt) so fleet/
-	// rows never carry mixed-offset timestamps.
-	now := time.Now().UTC()
+	now := time.Now()
 	row := fleet.Row{
 		Workstream: ws.ID,
 		UUID:       uuid,
@@ -122,13 +120,11 @@ func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
 		Handle:     ws.ID,
 		Branch:     ws.Branch,
 		Dir:        cwd,
-		Heartbeat:  now.Format(time.RFC3339Nano),
 	}
-	if err := fleet.Register(hub, row); err != nil {
+	// Register stamps the heartbeat from now itself, so no separate Heartbeat
+	// call is needed — one atomic row write covers registration and liveness.
+	if err := fleet.Register(hub, row, now); err != nil {
 		return fmt.Errorf("register: %w", err)
-	}
-	if err := fleet.Heartbeat(hub, ws.ID, uuid, now); err != nil {
-		return fmt.Errorf("heartbeat: %w", err)
 	}
 	return nil
 }

--- a/internal/render/status_test.go
+++ b/internal/render/status_test.go
@@ -20,9 +20,8 @@ func registerRow(t *testing.T, hub, ws, repoKey string, hbAge time.Duration) {
 		UUID:       "uuid-" + ws,
 		RepoKey:    repoKey,
 		Handle:     "@" + ws,
-		Heartbeat:  statusNow.Add(-hbAge).Format(time.RFC3339Nano),
 	}
-	if err := fleet.Register(hub, row); err != nil {
+	if err := fleet.Register(hub, row, statusNow.Add(-hbAge)); err != nil {
 		t.Fatalf("register %s: %v", ws, err)
 	}
 }
@@ -110,9 +109,8 @@ func TestStatusGoneShowsRemedy(t *testing.T) {
 		Handle:     "@ws1",
 		Branch:     "feature",
 		Dir:        filepath.Join(hub, "vanished-worktree"),
-		Heartbeat:  statusNow.Add(-time.Minute).Format(time.RFC3339Nano),
 	}
-	if err := fleet.Register(hub, row); err != nil {
+	if err := fleet.Register(hub, row, statusNow.Add(-time.Minute)); err != nil {
 		t.Fatalf("register ws1: %v", err)
 	}
 


### PR DESCRIPTION
Completes the UTC write-boundary work from #18: `Register` was the last fleet writer that trusted a caller-formatted timestamp (Director open-item 01KWQ94Q9G, from the #18 review).

## What changed

`fleet.Register` now takes the clock like every other fleet writer:

```go
func Register(hub string, row Row, now time.Time) error
```

It stamps `row.Heartbeat` itself, normalized to UTC at format time. A zoned or malformed heartbeat string is now unrepresentable rather than merely unlikely — the previous contract ("callers format UTC") was the same convention-in-callers'-heads that produced the mixed-offset drift #18 fixed for `Heartbeat`/`Done`.

- The three callers (`fleetcmd` register verb, `adopt`, `sessionstart` refreshFleet) drop their `Format` calls and pass `time.Now()`.
- `refreshFleet`'s follow-up `fleet.Heartbeat` call is removed: Register stamps the identical heartbeat from the same clock, so it was a redundant read-modify-write on every session start.
- The "empty heartbeat rejected" validation is deleted — nothing to reject anymore.

## Compatibility

Rows written by old binaries (including any with offset timestamps like `-04:00` still on disk) remain fully readable: liveness parses with `time.Parse(RFC3339Nano)`, which accepts any offset, and derives on instants, never strings. Verified explicitly during review. No migration.

## Tests

- `TestLifecycleTimestampsNormalizedToUTC` now covers Register alongside Heartbeat/Done: same zoned-clock (23:00 at −05:00) assertion set per writer — parseable, zero offset, instant preserved.
- `TestLifecycleRegisterCreatesRow` sets `Heartbeat: "junk-not-a-timestamp"` on the input row, pinning that Register overwrites caller values and malformed strings can't reach disk.
- Review pass (ce:code-reviewer) approved with independent verification: the new Register assertion fails on pre-change code; legacy offset rows parse and derive liveness identically on the new code.

`go test ./... -race -count=1` green across all packages; gofmt and vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
