### PR TITLE
Recency-immune digest elision + concurrent-session signal

### DIFF
--- a/internal/fleet/liveness.go
+++ b/internal/fleet/liveness.go
@@ -148,9 +148,12 @@ func List(hub string, now time.Time, idleAfter, dormantAfter time.Duration, bran
 // collapsed entries can't provide: the SessionStart hook uses it to count the
 // OTHER sessions live on this checkout (excluding its own uuid), so the signal
 // stays precise even for a session that never registered a row (a throwaway's
-// uuid simply matches nothing). Corrupt rows and unparseable heartbeats are
-// skipped with List's leniency — a concurrency hint must never fail a session
-// start. A missing fleet dir yields an empty result, not an error.
+// uuid simply matches nothing). A row's lifetime bounds what "live" can mean
+// here: Stop archives it at each allowed turn end, so a fresh row is a session
+// mid-turn or a recent ungraceful death — never a sibling idling at its prompt.
+// Corrupt rows and unparseable heartbeats are skipped with List's leniency — a
+// concurrency hint must never fail a session start. A missing fleet dir yields
+// an empty result, not an error.
 func LiveSessions(hub, workstream string, now time.Time, within time.Duration) ([]string, error) {
 	dir := filepath.Join(hub, fleetDir)
 	files, err := os.ReadDir(dir)

--- a/internal/fleet/liveness.go
+++ b/internal/fleet/liveness.go
@@ -41,6 +41,12 @@ type Liveness struct {
 	Handle     string    `json:"handle,omitempty"`   // newest-heartbeat session
 	Heartbeat  time.Time `json:"heartbeat"`          // newest across the workstream's rows
 	Sessions   int       `json:"sessions"`           // live rows collapsed into this entry
+	// ActiveSessions counts the rows whose OWN heartbeat is younger than the idle
+	// TTL — the concurrent-session signal. > 1 means several sessions are working
+	// this workstream (same checkout) right now, so their handoffs interleave
+	// under one label. Distinct from Sessions, which also counts stale rows a
+	// crashed session never archived.
+	ActiveSessions int `json:"active_sessions"`
 }
 
 // List reads every live row under <hub>/fleet/ (the archive dir is ignored),
@@ -77,6 +83,7 @@ func List(hub string, now time.Time, idleAfter, dormantAfter time.Duration, bran
 		newest   Row
 		newestHB time.Time
 		count    int
+		active   int
 	}
 	byWorkstream := make(map[string]*agg)
 
@@ -111,22 +118,67 @@ func List(hub string, now time.Time, idleAfter, dormantAfter time.Duration, bran
 			a.newest = row
 			a.newestHB = hb
 		}
+		// Freshness of THIS row, not the collapsed newest: the concurrency signal
+		// is "how many sessions are heartbeating right now". A future-dated
+		// heartbeat clamps to fresh, matching derive().
+		if age := now.Sub(hb); age < idleAfter {
+			a.active++
+		}
 	}
 
 	out := make([]Liveness, 0, len(byWorkstream))
 	for ws, a := range byWorkstream {
 		out = append(out, Liveness{
-			Workstream: ws,
-			State:      derive(a.newestHB, now, idleAfter, dormantAfter, branchAlive(a.newest)),
-			UUID:       a.newest.UUID,
-			RepoKey:    a.newest.RepoKey,
-			Handle:     a.newest.Handle,
-			Heartbeat:  a.newestHB,
-			Sessions:   a.count,
+			Workstream:     ws,
+			State:          derive(a.newestHB, now, idleAfter, dormantAfter, branchAlive(a.newest)),
+			UUID:           a.newest.UUID,
+			RepoKey:        a.newest.RepoKey,
+			Handle:         a.newest.Handle,
+			Heartbeat:      a.newestHB,
+			Sessions:       a.count,
+			ActiveSessions: a.active,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Workstream < out[j].Workstream })
 	return out, skipped, nil
+}
+
+// LiveSessions returns the session UUIDs of workstream's rows whose heartbeat is
+// younger than within, sorted for a stable result. It is the per-row view List's
+// collapsed entries can't provide: the SessionStart hook uses it to count the
+// OTHER sessions live on this checkout (excluding its own uuid), so the signal
+// stays precise even for a session that never registered a row (a throwaway's
+// uuid simply matches nothing). Corrupt rows and unparseable heartbeats are
+// skipped with List's leniency — a concurrency hint must never fail a session
+// start. A missing fleet dir yields an empty result, not an error.
+func LiveSessions(hub, workstream string, now time.Time, within time.Duration) ([]string, error) {
+	dir := filepath.Join(hub, fleetDir)
+	files, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fleet: read fleet dir: %w", err)
+	}
+	var uuids []string
+	for _, e := range files {
+		if e.IsDir() || filepath.Ext(e.Name()) != rowExt {
+			continue
+		}
+		row, err := readRow(filepath.Join(dir, e.Name()))
+		if err != nil || row.Workstream != workstream {
+			continue
+		}
+		hb, err := time.Parse(heartbeatLayout, row.Heartbeat)
+		if err != nil {
+			continue
+		}
+		if now.Sub(hb) < within {
+			uuids = append(uuids, row.UUID)
+		}
+	}
+	sort.Strings(uuids)
+	return uuids, nil
 }
 
 // derive computes a single workstream's State. A gone branch reads gone no

--- a/internal/fleet/liveness_test.go
+++ b/internal/fleet/liveness_test.go
@@ -155,6 +155,60 @@ func TestLivenessCollapsesByWorkstream(t *testing.T) {
 	if got.State != StateActive {
 		t.Errorf("collapsed state = %q, want %q (newest wins)", got.State, StateActive)
 	}
+	// Only the fresh row counts as concurrently active — the stale one is a
+	// leftover, not a live session, so no concurrency signal fires here.
+	if got.ActiveSessions != 1 {
+		t.Errorf("active sessions = %d, want 1 (stale rows are not concurrent)", got.ActiveSessions)
+	}
+}
+
+// TestLivenessCountsActiveSessions: two rows heartbeating within the idle TTL
+// read as 2 concurrently-active sessions — the same-checkout collision signal —
+// while a third stale row still counts toward Sessions only.
+func TestLivenessCountsActiveSessions(t *testing.T) {
+	hub := t.TempDir()
+	now := fixedTime
+	ws := "ws-shared"
+	registerAt(t, hub, ws, "u-a", "@a", now.Add(-1*time.Minute))
+	registerAt(t, hub, ws, "u-b", "@b", now.Add(-2*time.Minute))
+	registerAt(t, hub, ws, "u-stale", "@stale", now.Add(-20*time.Minute))
+
+	got := onlyEntry(t, hub, now, alive)
+	if got.Sessions != 3 {
+		t.Errorf("sessions = %d, want 3", got.Sessions)
+	}
+	if got.ActiveSessions != 2 {
+		t.Errorf("active sessions = %d, want 2", got.ActiveSessions)
+	}
+}
+
+// TestLiveSessions locks the per-row view behind the SessionStart concurrency
+// hint: only rows of the asked workstream with a heartbeat younger than the
+// window, uuids sorted, corrupt rows skipped, missing fleet dir empty-not-error.
+func TestLiveSessions(t *testing.T) {
+	hub := t.TempDir()
+	now := fixedTime
+	registerAt(t, hub, "ws-shared", "u-b", "@b", now.Add(-1*time.Minute))
+	registerAt(t, hub, "ws-shared", "u-a", "@a", now.Add(-2*time.Minute))
+	registerAt(t, hub, "ws-shared", "u-stale", "@stale", now.Add(-20*time.Minute))
+	registerAt(t, hub, "ws-other", "u-o", "@o", now.Add(-1*time.Minute))
+	// A corrupt row must be skipped, never fail the listing.
+	if err := os.WriteFile(filepath.Join(hub, "fleet", "corrupt.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LiveSessions(hub, "ws-shared", now, idleTTL)
+	if err != nil {
+		t.Fatalf("LiveSessions: %v", err)
+	}
+	if len(got) != 2 || got[0] != "u-a" || got[1] != "u-b" {
+		t.Errorf("live sessions = %v, want [u-a u-b] (fresh rows of ws-shared only, sorted)", got)
+	}
+
+	empty, err := LiveSessions(t.TempDir(), "ws-shared", now, idleTTL)
+	if err != nil || len(empty) != 0 {
+		t.Errorf("missing fleet dir should yield an empty result, got %v, %v", empty, err)
+	}
 }
 
 func TestLivenessSortedByWorkstream(t *testing.T) {

--- a/internal/fleet/liveness_test.go
+++ b/internal/fleet/liveness_test.go
@@ -182,6 +182,24 @@ func TestLivenessCountsActiveSessions(t *testing.T) {
 	}
 }
 
+// TestLivenessActiveSessionsZeroWhenAllStale: leftovers from ungraceful exits
+// (rows never archived) age out of the concurrency signal even though the rows
+// still exist — Sessions counts them, ActiveSessions must read 0, never 2.
+func TestLivenessActiveSessionsZeroWhenAllStale(t *testing.T) {
+	hub := t.TempDir()
+	now := fixedTime
+	registerAt(t, hub, "ws-stale", "u-a", "@a", now.Add(-10*time.Minute))
+	registerAt(t, hub, "ws-stale", "u-b", "@b", now.Add(-20*time.Minute))
+
+	got := onlyEntry(t, hub, now, alive)
+	if got.Sessions != 2 {
+		t.Errorf("sessions = %d, want 2", got.Sessions)
+	}
+	if got.ActiveSessions != 0 {
+		t.Errorf("active sessions = %d, want 0 (stale leftovers must not signal concurrency)", got.ActiveSessions)
+	}
+}
+
 // TestLiveSessions locks the per-row view behind the SessionStart concurrency
 // hint: only rows of the asked workstream with a heartbeat younger than the
 // window, uuids sorted, corrupt rows skipped, missing fleet dir empty-not-error.
@@ -194,6 +212,12 @@ func TestLiveSessions(t *testing.T) {
 	registerAt(t, hub, "ws-other", "u-o", "@o", now.Add(-1*time.Minute))
 	// A corrupt row must be skipped, never fail the listing.
 	if err := os.WriteFile(filepath.Join(hub, "fleet", "corrupt.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// So must a well-formed row whose heartbeat doesn't parse — the other
+	// lenient-skip branch.
+	if err := os.WriteFile(filepath.Join(hub, "fleet", "badhb.json"),
+		[]byte(`{"workstream":"ws-shared","uuid":"u-badhb","heartbeat":"not-a-time"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1408,6 +1408,13 @@ func TestSessionStartBudgetCollapsesAllWhenKeptBandOverflows(t *testing.T) {
 	// Bulk the ACTIONABLE section close to the budget so rung 1's ~2KB kept
 	// band (10 × ~200B lines) still overflows while rung 2 fits: ~40 open-items
 	// × ~300-char bodies ≈ 13KB of open-set + ~2.5KB fixed blocks.
+	//
+	// Measured margins (2026-07-06): full ≈ 20.8KB, rung 1 ≈ 17.9KB (~1.5KB
+	// over, as required), rung 2 ≈ 15.9KB — only ~512B of headroom under the
+	// 16,384B budget. If this test starts failing with "STILL over budget"
+	// after a fixed block (emitProtocol, preamble, banner) grows, the FIXTURE
+	// has drifted out of its window — re-tune the open-item count downward;
+	// don't suspect the ladder.
 	openBody := strings.Repeat("open loop ", 29) // ~290 chars, under the 300-rune cap
 	for i := 0; i < 40; i++ {
 		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindOpenItem, Area: "sync", Body: openBody}); err != nil {
@@ -1498,5 +1505,42 @@ func TestSessionStartConcurrentSessionNote(t *testing.T) {
 	b, c, p := strings.Index(ctxB, "## Acknowledge on entry"), strings.Index(ctxB, "## Concurrent sessions"), strings.Index(ctxB, "## Director protocol")
 	if b < 0 || c < 0 || p < 0 || !(b < c && c < p) {
 		t.Errorf("concurrency note must sit between banner and protocol (banner@%d, note@%d, protocol@%d):\n%.2000s", b, c, p, ctxB)
+	}
+}
+
+// TestSessionStartConcurrentNoteForThrowaway locks the uuid-exclusion path for a
+// session that never registers a row: a throwaway (no session_id — a subagent)
+// falls back to the manual uuid for exclusion, which matches no row, so a real
+// session's fresh row still counts as a sibling and the note appears. Deliberate:
+// the throwaway inherits the same working tree, so the interleave warning is
+// true for it too. (Corollary, accepted: a hand-run CLI registration under the
+// manual uuid would be excluded here — the fallback ids collide by design.)
+func TestSessionStartConcurrentNoteForThrowaway(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "") // pin the manual fallback, whatever ran the suite
+
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+
+	store := event.NewStore(hub, ws.RepoKey)
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindNote, Area: "x", Body: "managed"}); err != nil {
+		t.Fatalf("seed note: %v", err)
+	}
+
+	// A real session registers its row first.
+	inA := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	if code := Dispatch(EventSessionStart, strings.NewReader(inA), &bytes.Buffer{}, hub); code != 0 {
+		t.Fatalf("real session start exit = %d", code)
+	}
+
+	// The throwaway starts on the same checkout: no session_id in the payload.
+	inB := `{"cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var outB bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(inB), &outB, hub); code != 0 {
+		t.Fatalf("throwaway session start exit = %d", code)
+	}
+	ctxB := injectedContext(t, outB.String())
+	if !strings.Contains(ctxB, "· ⚠ 1 concurrent session(s) on this checkout") {
+		t.Errorf("throwaway should see the real session as a sibling:\n%.2000s", ctxB)
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1383,8 +1383,8 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 		t.Errorf("degraded payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
 	}
 	health := readHealth(t, hub)
-	if !strings.Contains(health, "older decisions collapsed to count+pointer, newest kept") {
-		t.Errorf("budget overflow should be health-logged naming the first rung, got:\n%s", health)
+	if !strings.Contains(health, "older decisions collapsed to count+pointer, newest 1 kept") {
+		t.Errorf("budget overflow should be health-logged naming the first rung with its kept count, got:\n%s", health)
 	}
 	// Pin WHICH rung ran: the kept-newest band must suffice here — rung 2 (ALL
 	// collapsed) or the last-resort "actionable sections alone are over"
@@ -1392,6 +1392,51 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 	// test believes.
 	if strings.Contains(health, "ALL decisions collapsed") || strings.Contains(health, "STILL over budget") {
 		t.Errorf("fixture should land on the first rung only:\n%s", health)
+	}
+}
+
+// TestSessionStartBudgetSkipsEmptyKeptBand: when the workstream's latest
+// handoff postdates every decision (the common shape — the handoff comes last),
+// rung 1 would keep nothing and degenerate byte-for-byte to the full collapse.
+// The hook must take (and health-log) rung 2 directly — never claim a kept
+// band that is empty (Copilot review on PR #21).
+func TestSessionStartBudgetSkipsEmptyKeptBand(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+
+	store := event.NewStore(hub, ws.RepoKey)
+	body := strings.Repeat("rationale ", 30)
+	for i := 0; i < 120; i++ {
+		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindDecision, Area: "hooks", Body: body}); err != nil {
+			t.Fatalf("seed decision %d: %v", i, err)
+		}
+	}
+	// The handoff lands AFTER every decision: the anchor is above them all, so
+	// zero decisions are post-resume-point news.
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindHandoff, Area: "hooks", Body: "resume point"}); err != nil {
+		t.Fatalf("seed handoff: %v", err)
+	}
+
+	in := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	ctx := injectedContext(t, out.String())
+
+	if !strings.Contains(ctx, "(120 active decisions elided for size") {
+		t.Errorf("empty kept band should inject the full-collapse line:\n%.2000s", ctx)
+	}
+	if len(ctx) > injectionBudgetBytes {
+		t.Errorf("collapsed payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
+	}
+	health := readHealth(t, hub)
+	if !strings.Contains(health, "ALL decisions collapsed to count+pointer") {
+		t.Errorf("empty kept band should be health-logged as rung 2, got:\n%s", health)
+	}
+	if strings.Contains(health, "kept") {
+		t.Errorf("health must not claim a kept band when nothing was kept:\n%s", health)
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1329,11 +1329,12 @@ func stopInput(cwd, transcript string, stopHookActive bool) string {
 }
 
 // TestSessionStartBudgetDegradesDeterministically locks the §15.5 self-measure:
-// a log whose line-capped digest still pushes the payload over the injection
-// budget degrades to DigestCompact — decisions collapse to a count+pointer line,
-// open-items and handoffs survive untouched — and the overflow lands in health/
-// as a grooming signal. The harness's own demotion threshold must never be the
-// first thing that notices growth.
+// a log whose line-capped digest pushes the payload over the injection budget
+// degrades down the ladder's FIRST rung — older decisions collapse to a
+// count+pointer line, the newest survive as index lines, open-items and
+// handoffs survive untouched — and the overflow lands in health/ as a grooming
+// signal. The harness's own demotion threshold must never be the first thing
+// that notices growth.
 func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 	hub := t.TempDir()
 	repo := gitRepo(t, "widget", "main")
@@ -1346,6 +1347,15 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 			t.Fatalf("seed decision %d: %v", i, err)
 		}
 	}
+	// A handoff BETWEEN the bulk and the newest decision anchors the recency
+	// band: the one decision after it is post-resume-point news and must
+	// survive the elision; the 120 before it must not.
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindHandoff, Area: "hooks", Body: "resume point"}); err != nil {
+		t.Fatalf("seed handoff: %v", err)
+	}
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindDecision, Area: "hooks", Body: "the sibling course correction must survive"}); err != nil {
+		t.Fatalf("seed post-handoff decision: %v", err)
+	}
 	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindOpenItem, Area: "sync", Body: "the open loop must survive degradation"}); err != nil {
 		t.Fatalf("seed open-item: %v", err)
 	}
@@ -1357,11 +1367,14 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 	}
 	ctx := injectedContext(t, out.String())
 
-	if !strings.Contains(ctx, "120 active decisions elided for size") {
-		t.Errorf("over-budget injection should collapse decisions with the count:\n%.2000s", ctx)
+	if !strings.Contains(ctx, "(120 older decision(s) elided for size — the newest 1 follow") {
+		t.Errorf("over-budget injection should elide only the pre-handoff decisions:\n%.2000s", ctx)
+	}
+	if !strings.Contains(ctx, "the sibling course correction must survive") {
+		t.Errorf("a decision newer than the workstream's latest handoff must survive degradation:\n%.2000s", ctx)
 	}
 	if strings.Contains(ctx, "rationale rationale") {
-		t.Errorf("collapsed injection must not carry decision bodies")
+		t.Errorf("elided injection must not carry pre-handoff decision bodies")
 	}
 	if !strings.Contains(ctx, "the open loop must survive degradation") {
 		t.Errorf("degradation must never eat the open-set:\n%.2000s", ctx)
@@ -1370,13 +1383,120 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 		t.Errorf("degraded payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
 	}
 	health := readHealth(t, hub)
-	if !strings.Contains(health, "injection budget") {
-		t.Errorf("budget overflow should be health-logged as a grooming signal, got:\n%s", health)
+	if !strings.Contains(health, "older decisions collapsed to count+pointer, newest kept") {
+		t.Errorf("budget overflow should be health-logged naming the first rung, got:\n%s", health)
 	}
-	// Pin WHICH branch ran: the compact fallback must suffice here — the
-	// last-resort "actionable sections alone are over" sentinel firing would
-	// mean the fixture (or the degradation) is not what this test believes.
+	// Pin WHICH rung ran: the kept-newest band must suffice here — rung 2 (ALL
+	// collapsed) or the last-resort "actionable sections alone are over"
+	// sentinel firing would mean the fixture (or the ladder) is not what this
+	// test believes.
+	if strings.Contains(health, "ALL decisions collapsed") || strings.Contains(health, "STILL over budget") {
+		t.Errorf("fixture should land on the first rung only:\n%s", health)
+	}
+}
+
+// TestSessionStartBudgetCollapsesAllWhenKeptBandOverflows locks the ladder's
+// SECOND rung: when even the kept-newest band leaves the payload over budget,
+// every decision collapses to the count+pointer line — and the actionable
+// sections are still never eaten.
+func TestSessionStartBudgetCollapsesAllWhenKeptBandOverflows(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+
+	store := event.NewStore(hub, ws.RepoKey)
+	// Bulk the ACTIONABLE section close to the budget so rung 1's ~2KB kept
+	// band (10 × ~200B lines) still overflows while rung 2 fits: ~40 open-items
+	// × ~300-char bodies ≈ 13KB of open-set + ~2.5KB fixed blocks.
+	openBody := strings.Repeat("open loop ", 29) // ~290 chars, under the 300-rune cap
+	for i := 0; i < 40; i++ {
+		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindOpenItem, Area: "sync", Body: openBody}); err != nil {
+			t.Fatalf("seed open-item %d: %v", i, err)
+		}
+	}
+	body := strings.Repeat("rationale ", 30)
+	for i := 0; i < 25; i++ { // all newer than any handoff → all candidates for the kept band
+		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindDecision, Area: "hooks", Body: body}); err != nil {
+			t.Fatalf("seed decision %d: %v", i, err)
+		}
+	}
+
+	in := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	ctx := injectedContext(t, out.String())
+
+	if !strings.Contains(ctx, "25 active decisions elided for size") {
+		t.Errorf("rung 2 should collapse ALL decisions with the count:\n%.2000s", ctx)
+	}
+	if strings.Contains(ctx, "rationale rationale") {
+		t.Errorf("rung 2 must not carry any decision bodies")
+	}
+	if !strings.Contains(ctx, "open loop open loop") {
+		t.Errorf("degradation must never eat the open-set:\n%.2000s", ctx)
+	}
+	if len(ctx) > injectionBudgetBytes {
+		t.Errorf("rung-2 payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
+	}
+	health := readHealth(t, hub)
+	if !strings.Contains(health, "ALL decisions collapsed to count+pointer") {
+		t.Errorf("rung 2 should be health-logged by name, got:\n%s", health)
+	}
 	if strings.Contains(health, "STILL over budget") {
-		t.Errorf("fixture should overflow on decisions only, not on actionable sections:\n%s", health)
+		t.Errorf("fixture should fit once all decisions collapse:\n%s", health)
+	}
+}
+
+// TestSessionStartConcurrentSessionNote: a SECOND live session starting on the
+// SAME checkout gets the ⚠ marker on its acknowledgment banner (the human-visible
+// signal, at the exact moment the collision becomes true) plus the model-facing
+// note explaining that handoffs interleave and the resume point may be a
+// sibling's — riding the head, before the protocol. The first session, alone at
+// its start, gets neither.
+func TestSessionStartConcurrentSessionNote(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+
+	// Adopted-repo gate: the banner/protocol blocks only inject for a managed repo.
+	store := event.NewStore(hub, ws.RepoKey)
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindNote, Area: "x", Body: "managed"}); err != nil {
+		t.Fatalf("seed note: %v", err)
+	}
+
+	// First session: no sibling rows yet — no marker, no note.
+	inA := `{"session_id":"s-one","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var outA bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(inA), &outA, hub); code != 0 {
+		t.Fatalf("first session start exit = %d", code)
+	}
+	ctxA := injectedContext(t, outA.String())
+	if strings.Contains(ctxA, "concurrent session(s)") || strings.Contains(ctxA, "## Concurrent sessions") {
+		t.Errorf("a lone session must not get the concurrency signal:\n%.2000s", ctxA)
+	}
+
+	// Second session, same checkout: sees s-one's fresh row.
+	inB := `{"session_id":"s-two","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var outB bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(inB), &outB, hub); code != 0 {
+		t.Fatalf("second session start exit = %d", code)
+	}
+	ctxB := injectedContext(t, outB.String())
+	if !strings.Contains(ctxB, "· ⚠ 1 concurrent session(s) on this checkout") {
+		t.Errorf("second session's banner should carry the ⚠ concurrency marker:\n%.2000s", ctxB)
+	}
+	if !strings.Contains(ctxB, "## Concurrent sessions on this checkout") {
+		t.Errorf("second session should get the model-facing concurrency note:\n%.2000s", ctxB)
+	}
+	if !strings.Contains(ctxB, "suggest a separate worktree") {
+		t.Errorf("the note should nudge toward the worktree convention:\n%.2000s", ctxB)
+	}
+	// Head placement: the note changes how everything below it must be read, so
+	// it rides between the banner and the protocol.
+	b, c, p := strings.Index(ctxB, "## Acknowledge on entry"), strings.Index(ctxB, "## Concurrent sessions"), strings.Index(ctxB, "## Director protocol")
+	if b < 0 || c < 0 || p < 0 || !(b < c && c < p) {
+		t.Errorf("concurrency note must sit between banner and protocol (banner@%d, note@%d, protocol@%d):\n%.2000s", b, c, p, ctxB)
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1480,7 +1480,7 @@ func TestSessionStartConcurrentSessionNote(t *testing.T) {
 		t.Fatalf("first session start exit = %d", code)
 	}
 	ctxA := injectedContext(t, outA.String())
-	if strings.Contains(ctxA, "concurrent session(s)") || strings.Contains(ctxA, "## Concurrent sessions") {
+	if strings.Contains(ctxA, "other live session(s)") || strings.Contains(ctxA, "## Concurrent sessions") {
 		t.Errorf("a lone session must not get the concurrency signal:\n%.2000s", ctxA)
 	}
 
@@ -1491,7 +1491,7 @@ func TestSessionStartConcurrentSessionNote(t *testing.T) {
 		t.Fatalf("second session start exit = %d", code)
 	}
 	ctxB := injectedContext(t, outB.String())
-	if !strings.Contains(ctxB, "· ⚠ 1 concurrent session(s) on this checkout") {
+	if !strings.Contains(ctxB, "· ⚠ 1 other live session(s) on this checkout") {
 		t.Errorf("second session's banner should carry the ⚠ concurrency marker:\n%.2000s", ctxB)
 	}
 	if !strings.Contains(ctxB, "## Concurrent sessions on this checkout") {
@@ -1540,7 +1540,7 @@ func TestSessionStartConcurrentNoteForThrowaway(t *testing.T) {
 		t.Fatalf("throwaway session start exit = %d", code)
 	}
 	ctxB := injectedContext(t, outB.String())
-	if !strings.Contains(ctxB, "· ⚠ 1 concurrent session(s) on this checkout") {
+	if !strings.Contains(ctxB, "· ⚠ 1 other live session(s) on this checkout") {
 		t.Errorf("throwaway should see the real session as a sibling:\n%.2000s", ctxB)
 	}
 }

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -89,7 +89,7 @@ func handleSessionStart(in Input, out io.Writer, hub string) error {
 		}
 	}
 
-	ctx, err := buildGroundTruth(hub, ws.RepoKey, ws.ID, in.SessionID, isCodexTranscript(in.TranscriptPath))
+	ctx, err := buildGroundTruth(hub, ws.RepoKey, ws.ID, in.SessionID, sessionUUID(in), isCodexTranscript(in.TranscriptPath))
 	if err != nil {
 		logFailure(hub, EventSessionStart, in.SessionID, fmt.Sprintf("build ground truth: %v", err))
 		return nil
@@ -150,14 +150,18 @@ const injectionBudgetBytes = 16 * 1024
 // the project CHARTER (graceful when absent), and the deterministic digest
 // folded from the LOG. Under budget — the normal case — the digest is
 // byte-for-byte the `director render` / `--verify` output, so what the session
-// is handed is exactly what the cockpit shows. Over injectionBudgetBytes it is
-// the DigestCompact variant instead (decisions collapsed to a count+pointer
-// line): still deterministic, but deliberately NOT the render output — the
-// divergence is announced in the digest itself and health-logged. sessionID
-// is only for health-logging a close-out-nudge failure (which is fail-open,
-// never blocking the injection). codex switches the protocol/nudge command
-// names to Codex's skill-mention namespace (see codexCommandNames).
-func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) (string, error) {
+// is handed is exactly what the cockpit shows. Over injectionBudgetBytes it
+// degrades down a deterministic ladder: first DigestCompact (older decisions
+// collapse to a count+pointer line, the newest — anchored to this workstream's
+// latest handoff, i.e. the ones no prior session of this workstream has seen —
+// survive), then DigestCollapsed (every decision collapses). Both rungs are
+// deliberately NOT the render output — the divergence is announced in the
+// digest itself and health-logged. sessionID is only for health-logging a
+// nudge/concurrency failure (both fail-open, never blocking the injection);
+// uuid is this session's fleet-row key, used to exclude its own row from the
+// concurrent-session count. codex switches the protocol/nudge command names to
+// Codex's skill-mention namespace (see codexCommandNames).
+func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid string, codex bool) (string, error) {
 	store := event.NewStore(hub, repoKey)
 	events, err := store.ReadAll()
 	if err != nil {
@@ -173,7 +177,7 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 	// Compute the managed-only blocks once, outside the assembler: closeOutNudge
 	// reads the fleet and health-logs its own failure, so a budget re-assembly
 	// must not run it twice.
-	var protocol, nudge, banner, resume string
+	var protocol, nudge, banner, concurrent, resume string
 	if managed {
 		protocol = codexCommandNames(emitProtocol, codex)
 		n, err := closeOutNudge(hub, repoKey, workstreamID, proj, time.Now().UTC())
@@ -184,7 +188,24 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 		} else if n != "" {
 			nudge = codexCommandNames(n, codex)
 		}
-		banner = startupBanner(workstreamID, proj)
+		// Sibling sessions live on this same workstream (same checkout) RIGHT NOW.
+		// "Live" is heartbeat younger than the idle TTL — the same definition the
+		// cockpit derives active from. Fail open like the nudge: a fleet read
+		// problem costs the hint, never the Ground Truth.
+		siblings := 0
+		if uuids, err := fleet.LiveSessions(hub, workstreamID, time.Now().UTC(), render.IdleAfter); err != nil {
+			logFailure(hub, EventSessionStart, sessionID, fmt.Sprintf("concurrent-session check: %v", err))
+		} else {
+			for _, u := range uuids {
+				if u != uuid {
+					siblings++
+				}
+			}
+		}
+		banner = startupBanner(workstreamID, proj, siblings)
+		if siblings > 0 {
+			concurrent = concurrencyNote(siblings, workstreamID)
+		}
 		resume = resumePoint(workstreamID, proj)
 	}
 
@@ -205,6 +226,13 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 		if managed {
 			b.WriteString(banner)
 			b.WriteString("\n")
+			// The concurrency note rides high (right after the banner) because it
+			// changes how the model must read everything below it — the resume
+			// point and this checkout's uncommitted state may be a sibling's.
+			if concurrent != "" {
+				b.WriteString(concurrent)
+				b.WriteString("\n")
+			}
 			b.WriteString(protocol)
 			b.WriteString("\n")
 		}
@@ -234,16 +262,28 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID string, codex bool) 
 
 	ctx := assemble(render.Digest(proj, repoKey))
 	if len(ctx) > injectionBudgetBytes {
-		// Deterministic degradation: collapse the decisions section (the one
-		// deferrable section) and say so loudly in health/ — over-budget growth
-		// is a grooming signal (§15.5 / L2 promotion), not a silent state.
+		// Deterministic degradation ladder, loud in health/ at every rung —
+		// over-budget growth is a grooming signal (§15.5 / L2 promotion), not a
+		// silent state. Rung 1 collapses only the OLDER decisions: the ones newer
+		// than this workstream's latest handoff are precisely what a rehydrating
+		// session has not seen (a sibling's course correction lives there), so
+		// they are the last decision content sacrificed.
 		full := len(ctx)
-		ctx = assemble(render.DigestCompact(proj, repoKey))
-		detail := fmt.Sprintf("injection budget: full payload %dB > %dB — decisions collapsed to count+pointer (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, len(ctx))
+		anchor := ""
+		if h, ok := proj.LatestHandoff[workstreamID]; ok {
+			anchor = h.ID
+		}
+		ctx = assemble(render.DigestCompact(proj, repoKey, anchor))
+		detail := fmt.Sprintf("injection budget: full payload %dB > %dB — older decisions collapsed to count+pointer, newest kept (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, len(ctx))
 		if len(ctx) > injectionBudgetBytes {
-			// Still over on open-items + handoffs alone: never eat the actionable
-			// sections — inject as-is and make the overflow visible.
-			detail += " — STILL over budget on actionable sections alone; the open-set needs grooming"
+			// Rung 2: every decision collapses.
+			ctx = assemble(render.DigestCollapsed(proj, repoKey))
+			detail = fmt.Sprintf("injection budget: full payload %dB > %dB — ALL decisions collapsed to count+pointer (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, len(ctx))
+			if len(ctx) > injectionBudgetBytes {
+				// Still over on open-items + handoffs alone: never eat the actionable
+				// sections — inject as-is and make the overflow visible.
+				detail += " — STILL over budget on actionable sections alone; the open-set needs grooming"
+			}
 		}
 		logFailure(hub, EventSessionStart, sessionID, detail)
 	}
@@ -339,7 +379,12 @@ func closeOutNudge(hub, repoKey, currentWS string, proj render.Projection, now t
 // It is placed immediately after the preamble so a harness persisted-output
 // preview (head-anchored, ~2KB observed) still carries it: the banner must be
 // printable BEFORE the full-file read the DELIVERY CHECK may demand.
-func startupBanner(workstreamID string, proj render.Projection) string {
+//
+// siblings > 0 appends the concurrent-session marker to the relayed line — the
+// banner is the one line the HUMAN is guaranteed to see, so the checkout
+// collision surfaces to them at the exact moment it becomes true, not only in
+// the cockpit.
+func startupBanner(workstreamID string, proj render.Projection, siblings int) string {
 	needYou := 0
 	for _, o := range proj.OpenItems {
 		if o.Risk == event.RiskEscalate {
@@ -347,7 +392,21 @@ func startupBanner(workstreamID string, proj render.Projection) string {
 		}
 	}
 	banner := fmt.Sprintf("▸ Director: %s · %d open-item(s), %d need-you", workstreamID, len(proj.OpenItems), needYou)
+	if siblings > 0 {
+		banner += fmt.Sprintf(" · ⚠ %d concurrent session(s) on this checkout", siblings)
+	}
 	return "## Acknowledge on entry\nBegin your VERY FIRST reply to the human with this line verbatim (then answer normally), so they can see Director rehydrated:\n" + banner + "\n"
+}
+
+// concurrencyNote is the model-facing counterpart of the banner's ⚠ marker: it
+// spells out what sharing a checkout with a live sibling session means for how
+// the rest of the injected block must be read. Awareness only — Director nudges
+// toward the worktree convention, it never gates (§ non-goals: not a methodology).
+func concurrencyNote(siblings int, workstreamID string) string {
+	return fmt.Sprintf("## Concurrent sessions on this checkout\n"+
+		"%d other live session(s) are working this same checkout right now, under the same workstream id [%s]. "+
+		"Their handoffs interleave with yours — the resume point below may be a sibling's position, not yours — and uncommitted changes in this tree may be theirs; verify before building on either. "+
+		"If the parallel work is more than a quick exchange, suggest a separate worktree to the human.\n", siblings, workstreamID)
 }
 
 // resumePoint names THIS workstream's own latest handoff as the resume anchor.

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -279,9 +279,18 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid string, codex 
 		if h, ok := proj.LatestHandoff[workstreamID]; ok {
 			anchor = h.ID
 		}
-		ctx = assemble(render.DigestCompact(proj, repoKey, anchor))
-		detail := fmt.Sprintf("injection budget: full payload %dB > %dB — older decisions collapsed to count+pointer, newest kept (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, len(ctx))
-		if len(ctx) > injectionBudgetBytes {
+		// Rung 1 only exists when it keeps something: with 0 post-anchor
+		// decisions DigestCompact degenerates to DigestCollapsed byte-for-byte,
+		// and logging it as "newest kept" would misname the rung on the very
+		// diagnostic surface the tests pin — skip straight to rung 2 instead of
+		// assembling the same digest twice.
+		var detail string
+		kept := render.KeptDecisions(proj, anchor)
+		if kept > 0 {
+			ctx = assemble(render.DigestCompact(proj, repoKey, anchor))
+			detail = fmt.Sprintf("injection budget: full payload %dB > %dB — older decisions collapsed to count+pointer, newest %d kept (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, kept, len(ctx))
+		}
+		if kept == 0 || len(ctx) > injectionBudgetBytes {
 			// Rung 2: every decision collapses.
 			ctx = assemble(render.DigestCollapsed(proj, repoKey))
 			detail = fmt.Sprintf("injection budget: full payload %dB > %dB — ALL decisions collapsed to count+pointer (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, len(ctx))

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -188,10 +188,16 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid string, codex 
 		} else if n != "" {
 			nudge = codexCommandNames(n, codex)
 		}
-		// Sibling sessions live on this same workstream (same checkout) RIGHT NOW.
-		// "Live" is heartbeat younger than the idle TTL — the same definition the
-		// cockpit derives active from. Fail open like the nudge: a fleet read
-		// problem costs the hint, never the Ground Truth.
+		// Sibling sessions live on this same workstream (same checkout). "Live"
+		// is a row with a heartbeat younger than the idle TTL — but note what a
+		// row's lifetime actually is: PostToolUse heartbeats materialize it and
+		// every allowed Stop archives it (stop.go), so a live row means a sibling
+		// is MID-TURN right now, or died ungracefully within the TTL. A sibling
+		// sitting at its prompt between turns has no row and is NOT detected —
+		// the signal is honest but narrow; widening it is a row-lifecycle design
+		// question (archive on session end rather than per-turn Stop), not a
+		// window-tuning one. Fail open like the nudge: a fleet read problem
+		// costs the hint, never the Ground Truth.
 		siblings := 0
 		if uuids, err := fleet.LiveSessions(hub, workstreamID, time.Now().UTC(), render.IdleAfter); err != nil {
 			logFailure(hub, EventSessionStart, sessionID, fmt.Sprintf("concurrent-session check: %v", err))

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -398,8 +398,11 @@ func startupBanner(workstreamID string, proj render.Projection, siblings int) st
 		}
 	}
 	banner := fmt.Sprintf("▸ Director: %s · %d open-item(s), %d need-you", workstreamID, len(proj.OpenItems), needYou)
+	// "other" is load-bearing: the banner counts SIBLINGS (self excluded), while
+	// the cockpit's ×N counts every fresh row — the same collision reads "1
+	// other" here and "×2" there, and the wording must make both frames legible.
 	if siblings > 0 {
-		banner += fmt.Sprintf(" · ⚠ %d concurrent session(s) on this checkout", siblings)
+		banner += fmt.Sprintf(" · ⚠ %d other live session(s) on this checkout", siblings)
 	}
 	return "## Acknowledge on entry\nBegin your VERY FIRST reply to the human with this line verbatim (then answer normally), so they can see Director rehydrated:\n" + banner + "\n"
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -38,21 +38,50 @@ import (
 // Empty sections still print their header with a "(none)" line so the absence of
 // work is itself a stable, diffable fact rather than a missing section.
 func Digest(proj Projection, repoKey string) string {
-	return digest(proj, repoKey, false)
+	return digest(proj, repoKey, len(proj.Decisions))
 }
 
-// DigestCompact is the hook's deterministic degradation step: identical to
-// Digest except the decisions section collapses to a single count-plus-pointer
-// line. It exists for the case where even the line-capped digest pushes the
-// SessionStart injection over its byte budget — decisions are the one section
-// whose full set is deferrable (rationale, not open loops or the latest handoff), and
-// the collapsed line itself tells the model where the elided content lives, so
-// the elision is never silent.
-func DigestCompact(proj Projection, repoKey string) string {
-	return digest(proj, repoKey, true)
+// DigestCompact is the hook's FIRST deterministic degradation step: identical
+// to Digest except only the NEWEST decisions survive individually — those whose
+// id is above sinceID (this workstream's latest handoff: anything decided after
+// the session's last recorded position is by definition unseen by it), capped
+// at recentDecisionsKept — while the older tail collapses to a count-plus-pointer
+// line. The newest decisions are precisely the ones a rehydrating session is
+// most likely to be missing (a sibling's course correction landed the splash
+// deferral reversal in exactly this band, and the all-or-nothing collapse hid
+// it — incident note 01KWW146C7), so they are the last decision content to go.
+// sinceID == "" (a workstream with no handoff yet) keeps the newest
+// recentDecisionsKept outright. Decisions are ULID-ascending, so "above sinceID"
+// is always a trailing suffix and the kept set is always "the newest N".
+func DigestCompact(proj Projection, repoKey, sinceID string) string {
+	kept := 0
+	for _, d := range proj.Decisions {
+		if d.ID > sinceID {
+			kept++
+		}
+	}
+	if kept > recentDecisionsKept {
+		kept = recentDecisionsKept
+	}
+	return digest(proj, repoKey, kept)
 }
 
-func digest(proj Projection, repoKey string, collapseDecisions bool) string {
+// DigestCollapsed is the LAST degradation step: every decision collapses to the
+// count-plus-pointer line. It exists for the case where even DigestCompact's
+// kept-newest band pushes the SessionStart injection over its byte budget —
+// decisions are the one section whose set is deferrable (rationale, not open
+// loops or the latest handoff), and the collapsed line itself tells the model
+// where the elided content lives, so the elision is never silent.
+func DigestCollapsed(proj Projection, repoKey string) string {
+	return digest(proj, repoKey, 0)
+}
+
+// digest renders the sections, keeping the newest keepDecisions decisions as
+// individual index lines and collapsing any older remainder to the
+// count-plus-pointer elision line. Digest passes the full count (no elision);
+// DigestCollapsed passes 0 (everything elided); DigestCompact passes the
+// recency-anchored band between them.
+func digest(proj Projection, repoKey string, keepDecisions int) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "# director render — %s\n", repoKey)
@@ -76,14 +105,22 @@ func digest(proj Projection, repoKey string, collapseDecisions bool) string {
 		}
 	}
 
+	// Defensive clamp so an over-count caller degrades to the full section
+	// rather than slicing out of range.
+	if keepDecisions > len(proj.Decisions) {
+		keepDecisions = len(proj.Decisions)
+	}
 	b.WriteString("\n## decisions\n")
 	switch {
 	case len(proj.Decisions) == 0:
 		b.WriteString("(none)\n")
-	case collapseDecisions:
+	case keepDecisions == 0:
 		fmt.Fprintf(&b, "(%d active decisions elided for size — run `director render` for the index, `director show <ulid>` for a full body)\n", len(proj.Decisions))
 	default:
-		for _, d := range proj.Decisions {
+		if elided := len(proj.Decisions) - keepDecisions; elided > 0 {
+			fmt.Fprintf(&b, "(%d older decision(s) elided for size — the newest %d follow; run `director render` for the full index, `director show <ulid>` for a full body)\n", elided, keepDecisions)
+		}
+		for _, d := range proj.Decisions[len(proj.Decisions)-keepDecisions:] {
 			fmt.Fprintf(&b, "- %s %s%s\n", d.ID, areaTag(d.Area), headline(d.Body, decisionHeadlineRunes))
 		}
 	}
@@ -186,6 +223,12 @@ const (
 	openItemBodyRunes     = 300
 	handoffBodyRunes      = 500
 )
+
+// recentDecisionsKept bounds DigestCompact's kept-newest band. A decision index
+// line runs ≤ ~200B (ULID + area + capped headline), so the band re-adds at most
+// ~2KB to an over-budget payload — small against the 16KB injection budget, and
+// the hook still has DigestCollapsed as the next rung when even that overflows.
+const recentDecisionsKept = 10
 
 // headline collapses a body to one line and caps it at max runes, marking a cut
 // with "…" so a capped line is visibly a headline, never mistaken for the full

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -54,6 +54,15 @@ func Digest(proj Projection, repoKey string) string {
 // recentDecisionsKept outright. Decisions are ULID-ascending, so "above sinceID"
 // is always a trailing suffix and the kept set is always "the newest N".
 func DigestCompact(proj Projection, repoKey, sinceID string) string {
+	return digest(proj, repoKey, KeptDecisions(proj, sinceID))
+}
+
+// KeptDecisions reports how many decisions DigestCompact would keep for
+// sinceID — the count-and-cap in one place, so a caller choosing between
+// degradation rungs (the SessionStart hook) sees exactly what the compact
+// digest will do: 0 means DigestCompact degenerates to DigestCollapsed, and
+// the caller should take (and log) that rung directly.
+func KeptDecisions(proj Projection, sinceID string) int {
 	kept := 0
 	for _, d := range proj.Decisions {
 		if d.ID > sinceID {
@@ -63,7 +72,7 @@ func DigestCompact(proj Projection, repoKey, sinceID string) string {
 	if kept > recentDecisionsKept {
 		kept = recentDecisionsKept
 	}
-	return digest(proj, repoKey, kept)
+	return kept
 }
 
 // DigestCollapsed is the LAST degradation step: every decision collapses to the

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -281,6 +281,13 @@ func TestDigestCompactKeepsNewestSinceAnchor(t *testing.T) {
 		t.Errorf("an anchor above every decision should degrade to the full collapse")
 	}
 
+	// The boundary is STRICT: an anchor exactly equal to the newest decision's
+	// own id keeps nothing — "newer" means after the anchor, never at it. A
+	// regression to >= would slip past every other case in this suite.
+	if DigestCompact(proj, "widget", ids.supersedeA) != DigestCollapsed(proj, "widget") {
+		t.Errorf("an anchor equal to the newest decision id must not keep that decision")
+	}
+
 	// No anchor (workstream without a handoff): everything is unseen, so with
 	// fewer decisions than the cap the compact digest equals the full one.
 	if DigestCompact(proj, "widget", "") != Digest(proj, "widget") {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -209,33 +210,118 @@ func TestDigestLineCaps(t *testing.T) {
 	}
 }
 
-// TestDigestCompact locks the deterministic degradation step: identical to the
-// full digest except decisions collapse to one count-plus-pointer line, and the
+// TestDigestCollapsed locks the LAST degradation rung: identical to the full
+// digest except every decision collapses to one count-plus-pointer line, and the
 // actionable sections (open-items, handoffs) are untouched.
-func TestDigestCompact(t *testing.T) {
+func TestDigestCollapsed(t *testing.T) {
 	events, _ := richSet(t)
 	proj := Fold(events)
 	full := Digest(proj, "widget")
-	compact := DigestCompact(proj, "widget")
+	collapsed := DigestCollapsed(proj, "widget")
 
-	if !strings.Contains(compact, "2 active decisions elided for size") {
-		t.Errorf("compact digest should announce the elision with the count:\n%s", compact)
+	if !strings.Contains(collapsed, "2 active decisions elided for size") {
+		t.Errorf("collapsed digest should announce the elision with the count:\n%s", collapsed)
 	}
-	if strings.Contains(compact, "decision B") {
-		t.Errorf("compact digest must not carry decision bodies:\n%s", compact)
+	if strings.Contains(collapsed, "decision B") {
+		t.Errorf("collapsed digest must not carry decision bodies:\n%s", collapsed)
 	}
 	idx := strings.Index(full, "## decisions")
 	if idx < 0 {
 		t.Fatalf("full digest missing the decisions heading:\n%s", full)
 	}
 	wantPrefix := full[:idx]
-	if !strings.HasPrefix(compact, wantPrefix) {
+	if !strings.HasPrefix(collapsed, wantPrefix) {
+		t.Errorf("collapsed digest must be byte-identical to the full digest above the decisions section:\n--- full ---\n%s\n--- collapsed ---\n%s", full, collapsed)
+	}
+
+	// No active decisions → nothing to collapse; collapsed == full.
+	empty := Fold(nil)
+	if DigestCollapsed(empty, "widget") != Digest(empty, "widget") {
+		t.Errorf("collapsed of a decision-less projection should equal the full digest")
+	}
+}
+
+// TestDigestCompactKeepsNewestSinceAnchor locks the FIRST degradation rung: a
+// decision newer than the anchor (the workstream's latest handoff — decided
+// after the session's last recorded position, so unseen by it) survives as an
+// index line, while the older tail collapses to the count-plus-pointer line.
+// This is the incident-01KWW146C7 guarantee: the all-or-nothing collapse hid a
+// sibling's course correction; the recency band must not.
+func TestDigestCompactKeepsNewestSinceAnchor(t *testing.T) {
+	events, ids := richSet(t)
+	proj := Fold(events)
+	// richSet's active decisions are decB then supersedeA (ULID-ascending);
+	// handoffWS1b sits between them, making it a real anchor: supersedeA is
+	// post-anchor news, decB is pre-anchor rationale.
+	compact := DigestCompact(proj, "widget", ids.handoffWS1b)
+
+	if !strings.Contains(compact, "supersedes A") {
+		t.Errorf("decision newer than the anchor must survive as an index line:\n%s", compact)
+	}
+	if strings.Contains(compact, "decision B") {
+		t.Errorf("decision older than the anchor must be elided:\n%s", compact)
+	}
+	if !strings.Contains(compact, "(1 older decision(s) elided for size — the newest 1 follow") {
+		t.Errorf("partial elision must announce what was dropped and what follows:\n%s", compact)
+	}
+	// The actionable sections above ## decisions are untouched.
+	full := Digest(proj, "widget")
+	idx := strings.Index(full, "## decisions")
+	if idx < 0 {
+		t.Fatalf("full digest missing the decisions heading:\n%s", full)
+	}
+	if !strings.HasPrefix(compact, full[:idx]) {
 		t.Errorf("compact digest must be byte-identical to the full digest above the decisions section:\n--- full ---\n%s\n--- compact ---\n%s", full, compact)
 	}
 
-	// No active decisions → nothing to collapse; compact == full.
-	empty := Fold(nil)
-	if DigestCompact(empty, "widget") != Digest(empty, "widget") {
-		t.Errorf("compact of a decision-less projection should equal the full digest")
+	// An anchor newer than every decision keeps nothing — identical to the
+	// full collapse.
+	newest := mint(t)
+	if DigestCompact(proj, "widget", newest) != DigestCollapsed(proj, "widget") {
+		t.Errorf("an anchor above every decision should degrade to the full collapse")
+	}
+
+	// No anchor (workstream without a handoff): everything is unseen, so with
+	// fewer decisions than the cap the compact digest equals the full one.
+	if DigestCompact(proj, "widget", "") != Digest(proj, "widget") {
+		t.Errorf("anchorless compact under the cap should equal the full digest")
+	}
+}
+
+// TestDigestCompactCapsKeptBand: even when many decisions are newer than the
+// anchor, at most recentDecisionsKept survive — the newest ones — so the kept
+// band can re-add ~2KB at most to an over-budget payload.
+func TestDigestCompactCapsKeptBand(t *testing.T) {
+	n := recentDecisionsKept + 3
+	events := make([]event.Event, 0, n)
+	var lastBody string
+	for i := 0; i < n; i++ {
+		lastBody = fmt.Sprintf("decision number %d", i)
+		events = append(events, event.Event{
+			ID: mint(t), SchemaVersion: event.SchemaVersion,
+			Type: event.KindDecision, Workstream: "ws1", Body: lastBody,
+		})
+	}
+	proj := Fold(events)
+	compact := DigestCompact(proj, "widget", "")
+
+	want := fmt.Sprintf("(3 older decision(s) elided for size — the newest %d follow", recentDecisionsKept)
+	if !strings.Contains(compact, want) {
+		t.Errorf("cap overflow must elide the oldest and say so; want %q in:\n%s", want, compact)
+	}
+	if !strings.Contains(compact, lastBody) {
+		t.Errorf("the newest decision must survive the cap:\n%s", compact)
+	}
+	for i := 0; i < 3; i++ {
+		if strings.Contains(compact, fmt.Sprintf("decision number %d\n", i)) {
+			t.Errorf("decision %d is older than the cap window and must be elided:\n%s", i, compact)
+		}
+	}
+
+	// Determinism holds on the compact form too: same set, any order, same bytes.
+	for _, seed := range []int64{1, 7, 99} {
+		if got := DigestCompact(Fold(shuffled(events, seed)), "widget", ""); got != compact {
+			t.Fatalf("compact digest changed under input shuffle seed %d", seed)
+		}
 	}
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -288,6 +288,15 @@ func TestDigestCompactKeepsNewestSinceAnchor(t *testing.T) {
 		t.Errorf("an anchor equal to the newest decision id must not keep that decision")
 	}
 
+	// KeptDecisions is the rung-selection view of the same rule — it must agree
+	// with what DigestCompact renders, since the hook trusts it to pick a rung.
+	if got := KeptDecisions(proj, ids.handoffWS1b); got != 1 {
+		t.Errorf("KeptDecisions(anchor between the two) = %d, want 1", got)
+	}
+	if got := KeptDecisions(proj, newest); got != 0 {
+		t.Errorf("KeptDecisions(anchor above all) = %d, want 0", got)
+	}
+
 	// No anchor (workstream without a handoff): everything is unseen, so with
 	// fewer decisions than the cap the compact digest equals the full one.
 	if DigestCompact(proj, "widget", "") != Digest(proj, "widget") {

--- a/internal/render/status.go
+++ b/internal/render/status.go
@@ -70,8 +70,16 @@ func Status(hub string, now time.Time) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			// ×N marks several concurrently-live sessions sharing one workstream
+			// (same checkout — their handoffs interleave under one label); a lone
+			// session renders the bare state, so the marker only appears when the
+			// hygiene signal is real.
+			state := string(l.State)
+			if l.ActiveSessions > 1 {
+				state = fmt.Sprintf("%s ×%d", state, l.ActiveSessions)
+			}
 			fmt.Fprintf(&b, "%s · %s · %s · %s\n",
-				handleOf(l), l.State, recency(now, l.Heartbeat), blocked)
+				handleOf(l), state, recency(now, l.Heartbeat), blocked)
 		}
 	}
 	// Surface any skipped corrupt rows rather than dropping them silently (§9).

--- a/internal/render/status_test.go
+++ b/internal/render/status_test.go
@@ -58,6 +58,44 @@ func TestStatusBlockedOn(t *testing.T) {
 	}
 }
 
+// TestStatusMarksConcurrentSessions: several sessions heartbeating one
+// workstream at once render as "active ×N" — the same-checkout hygiene signal —
+// while stale leftover rows don't inflate the count and a lone session keeps
+// the bare state.
+func TestStatusMarksConcurrentSessions(t *testing.T) {
+	hub := t.TempDir()
+	seedProject(t, hub, "repo1", nil)
+
+	mk := func(uuid string, hbAge time.Duration) {
+		t.Helper()
+		if err := fleet.Register(hub, fleet.Row{
+			Workstream: "ws1", UUID: uuid, RepoKey: "repo1", Handle: "@ws1",
+		}, statusNow.Add(-hbAge)); err != nil {
+			t.Fatalf("register %s: %v", uuid, err)
+		}
+	}
+	mk("u-a", time.Minute)
+	mk("u-b", 2*time.Minute)
+	mk("u-stale", IdleAfter+time.Hour) // never archived; must not count
+
+	registerRow(t, hub, "ws2", "repo1", time.Minute) // lone session, bare state
+
+	out, err := Status(hub, statusNow)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 cockpit lines, got %d:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "· active ×2 ·") {
+		t.Errorf("concurrent workstream should read active ×2: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "· active ·") || strings.Contains(lines[1], "×") {
+		t.Errorf("lone-session workstream should keep the bare state: %q", lines[1])
+	}
+}
+
 // TestStatusBlockedOnPerWorkstream confirms that when two workstreams share one
 // repo log, each cockpit line shows only ITS OWN escalations — not the union (M4).
 func TestStatusBlockedOnPerWorkstream(t *testing.T) {

--- a/internal/render/status_test.go
+++ b/internal/render/status_test.go
@@ -80,19 +80,61 @@ func TestStatusMarksConcurrentSessions(t *testing.T) {
 
 	registerRow(t, hub, "ws2", "repo1", time.Minute) // lone session, bare state
 
+	// ws3: only stale leftovers — the whole workstream reads idle, and an idle
+	// line never carries the marker (ActiveSessions is 0 there by definition).
+	for _, uuid := range []string{"u-x", "u-y"} {
+		if err := fleet.Register(hub, fleet.Row{
+			Workstream: "ws3", UUID: uuid, RepoKey: "repo1", Handle: "@ws3",
+		}, statusNow.Add(-IdleAfter-time.Hour)); err != nil {
+			t.Fatalf("register ws3/%s: %v", uuid, err)
+		}
+	}
+
 	out, err := Status(hub, statusNow)
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 cockpit lines, got %d:\n%s", len(lines), out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 cockpit lines, got %d:\n%s", len(lines), out)
 	}
 	if !strings.Contains(lines[0], "· active ×2 ·") {
 		t.Errorf("concurrent workstream should read active ×2: %q", lines[0])
 	}
 	if !strings.Contains(lines[1], "· active ·") || strings.Contains(lines[1], "×") {
 		t.Errorf("lone-session workstream should keep the bare state: %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "· idle ·") || strings.Contains(lines[2], "×") {
+		t.Errorf("all-stale workstream should read bare idle: %q", lines[2])
+	}
+}
+
+// TestStatusMarksConcurrentSessionsOnGone pins that the ×N marker composes with
+// non-active states: two sessions still heartbeating a checkout whose branch is
+// gone read "gone ×2". Deliberate — that is two live sessions needing wind-down,
+// and hiding the count there would understate exactly the collision the marker
+// exists to surface.
+func TestStatusMarksConcurrentSessionsOnGone(t *testing.T) {
+	hub := t.TempDir()
+	seedProject(t, hub, "repo1", nil)
+
+	// Branch+Dir pointing at a vanished worktree derive gone (BranchAlive treats
+	// the show-ref failure as branch-gone) even with fresh heartbeats.
+	for _, uuid := range []string{"u-a", "u-b"} {
+		if err := fleet.Register(hub, fleet.Row{
+			Workstream: "ws1", UUID: uuid, RepoKey: "repo1", Handle: "@ws1",
+			Branch: "feature", Dir: filepath.Join(hub, "vanished-worktree"),
+		}, statusNow.Add(-time.Minute)); err != nil {
+			t.Fatalf("register %s: %v", uuid, err)
+		}
+	}
+
+	out, err := Status(hub, statusNow)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !strings.Contains(out, "· gone ×2 ·") {
+		t.Errorf("gone workstream with two fresh sessions should read gone ×2:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Dogfooding incident 2026-07-06 (log note `01KWW146C7`): a session greeted the user with stale ground truth — "splash page: deferred behind L2" — while the reversing decision sat in the log. Two read-side failures compounded: the over-budget digest collapsed **all** decisions (hiding exactly the newest one), and two live sessions shared one checkout with no signal that their handoffs interleave.

## Changes

**1. Digest degradation is now a ladder** (`render`, `hook`)
- Rung 1 — `DigestCompact(proj, repoKey, sinceID)`: keeps decisions newer than this workstream's latest handoff (unseen-by-definition), capped at the newest 10 (~2KB), collapses only the older tail with an explicit `(N older decision(s) elided … the newest K follow …)` line.
- Rung 2 — `DigestCollapsed`: the old all-collapse behavior, byte-for-byte, only when the kept band still overflows. Each rung health-logged by name.
- Determinism (§13 t4) preserved: the anchor is a ULID from the log itself; one shared rendering path proves byte-identity for all three digest forms.

**2. Concurrent sessions on one checkout are loud** (`fleet`, `hook`, `render`)
- `fleet.Liveness.ActiveSessions` counts fresh-heartbeat rows (idle-TTL window — stale crash leftovers excluded); new `fleet.LiveSessions` gives the per-row view.
- Second session on a shared checkout gets `▸ Director: … · ⚠ N concurrent session(s) on this checkout` on the human-visible ack banner, plus a model-facing note (handoffs interleave, the resume point may be a sibling's, prefer a worktree). Fail-open, never gates.
- `director status` renders `active ×N` (composes with `gone ×N`, pinned by test).

## Review

`ce:review` pass on d6d2954: no blockers, no regressions; all should-fixes and coverage gaps applied in 266d2a0 (strict `>` anchor boundary test, `gone ×N` pin, stale/zero/throwaway paths, rung-2 fixture margins documented).

Known limitation, recorded as open-item `01KWWC7Q4P`: fleet rows are archived at every allowed Stop, so the signal detects a sibling **mid-turn** (or a recent ungraceful exit), not one idling at its prompt. Widening that is a row-lifecycle design question, deliberately out of scope here.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` — all green.
- End-to-end smoke via the real binary: two SessionStart dispatches on one checkout produce the banner marker, the note, and `active ×2` in status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
