### PR TITLE
fix(fleet): LiveSessions gets the portable dir-read classification too

### DIFF
--- a/internal/fleet/liveness.go
+++ b/internal/fleet/liveness.go
@@ -157,10 +157,10 @@ func List(hub string, now time.Time, idleAfter, dormantAfter time.Duration, bran
 func LiveSessions(hub, workstream string, now time.Time, within time.Duration) ([]string, error) {
 	dir := filepath.Join(hub, fleetDir)
 	files, err := os.ReadDir(dir)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
 	if err != nil {
+		if dirTrulyAbsent(dir, err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("fleet: read fleet dir: %w", err)
 	}
 	var uuids []string

--- a/internal/fleet/liveness_test.go
+++ b/internal/fleet/liveness_test.go
@@ -331,4 +331,9 @@ func TestListFleetPathAsFileErrors(t *testing.T) {
 	if _, _, err := List(hub, fixedTime, idleTTL, dormantTTL, alive); err == nil {
 		t.Fatal("List on a fleet path that is a regular file must error, not read as an empty fleet")
 	}
+	// LiveSessions shares the surface and the contract: its caller fails open
+	// into health/, which a silent empty result would bypass.
+	if _, err := LiveSessions(hub, "any", fixedTime, idleTTL); err == nil {
+		t.Fatal("LiveSessions on a fleet path that is a regular file must error, not read as empty")
+	}
 }


### PR DESCRIPTION
Cross-PR blind spot found at the PR #22 merge: #21 (concurrency signal) and #22 (portable not-exist classification) developed in parallel, so `LiveSessions` was born with the exact `os.IsNotExist`-on-`ReadDir` pattern #22 eliminated — no textual conflict, clean merge, bug survived.

Same fix, same test twin as the sites #22 covered: a `<hub>/fleet` that exists as a regular file errors into the caller's health-logged fail-open path (the `sessionstart.go` concurrent-session check) instead of silently reading as "no siblings" on Windows.

Gate green locally (`go test ./... -race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
