### PR TITLE
fix(install): reclaim shared shims on codex-only uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Install paths and runtime knobs, common to both agents unless a default says oth
 
 | Variable | Default | Selects |
 |---|---|---|
+| `DIRECTOR_SETTINGS_PATH` | `~/.claude/settings.json` | the Claude Code settings file `install` merges into (also the probe that decides whether an uninstall may reclaim the shared shims) |
 | `DIRECTOR_HOOKS_DIR` | `~/.claude/director/hooks` | where `install` writes the shims and the settings entries point; override to relocate them |
 | `DIRECTOR_COMMANDS_DIR` | `~/.claude/commands/director` | where `install` writes the `/director:*` slash commands |
 | `DIRECTOR_CODEX_HOOKS_PATH` | `~/.codex/hooks.json` | the Codex hooks file `install --codex` merges into |

--- a/cmd/director/installcmd.go
+++ b/cmd/director/installcmd.go
@@ -58,7 +58,7 @@ func runInstall(args []string) int {
 		fmt.Fprintf(os.Stderr, "install: %v\n", err)
 		return 1
 	}
-	fmt.Printf("installed Director hooks into %s\n", path)
+	fmt.Printf("installed Director hooks into %s (set DIRECTOR_SETTINGS_PATH to override)\n", path)
 	hooksDir, err := install.DefaultHooksDir()
 	if err != nil {
 		// Install already resolved and wrote to this same dir, so this is unreachable

--- a/cmd/director/installcmd.go
+++ b/cmd/director/installcmd.go
@@ -80,8 +80,9 @@ func runInstall(args []string) int {
 
 // runUninstall removes only Director's tagged hook entries, leaving hand-rolled
 // and other-plugin (GSD) hooks intact (§5.4), plus the Director-owned shims
-// (CC) or skill directories (--codex). The shared shims survive a --codex uninstall:
-// a Claude Code install may still reference them.
+// (CC) or skill directories (--codex). The shared shims survive either uninstall
+// form only while the OTHER agent's install still references them; once neither
+// does, they are reclaimed.
 func runUninstall(args []string) int {
 	path, codex, code := installTargetFlags("uninstall", args)
 	if path == "" {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,7 @@ director install
 ```
 
 ```text
-installed Director hooks into /Users/you/.claude/settings.json
+installed Director hooks into /Users/you/.claude/settings.json (set DIRECTOR_SETTINGS_PATH to override)
   shims written to /Users/you/.claude/director/hooks (set DIRECTOR_HOOKS_DIR to override)
   commands written to /Users/you/.claude/commands/director (/director:adopt, /director:complete, /director:handoff; set DIRECTOR_COMMANDS_DIR to override)
 ```
@@ -125,9 +125,9 @@ The rest of this guide uses the Claude Code command names (`/director:adopt` etc
 as its `$director-*` skill twin — same command, same behavior.
 
 `director uninstall --codex` removes only the tagged entries and the three skill directories. The hook
-shims are shared between the two agents: a `--codex` uninstall leaves them for a Claude Code install,
-and the plain `director uninstall` leaves them while a Codex install still references them — so
-uninstalling one agent never silently breaks the other.
+shims are shared between the two agents: either uninstall form leaves them in place while the other
+agent's install still references them, and reclaims them once neither does — so uninstalling one agent
+never silently breaks the other, and uninstalling the last one leaves no shim files behind.
 
 ---
 

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -98,9 +98,12 @@ func InstallCodex(hooksPath string) error {
 // UninstallCodex removes Director's tagged entries from hooksPath and the
 // Director-owned skill directories. A missing hooks file means no Codex install
 // to undo — touch nothing, mirroring the CC Uninstall. The shared shims are
-// spared while the default CC settings.json still carries Director-managed
-// entries (a Claude Code install may still reference them) and reclaimed when
-// none remain — the mirror of the CC Uninstall's codexInstallPresent gate.
+// spared while EITHER default install still references them: the default CC
+// settings.json carrying Director-managed entries (the mirror of the CC
+// Uninstall's codexInstallPresent gate), or the default Codex hooks.json still
+// carrying them — a custom `--settings <path>` uninstall must not strand the
+// default install's shims. On the default-path uninstall the entries were just
+// stripped above, so the codex probe reads "absent" and the reclaim proceeds.
 // Without the reclaim, a Codex-only machine would keep the shim files forever:
 // the CC uninstall form no-ops on its missing settings.json, so nothing else
 // ever removes them.
@@ -114,7 +117,7 @@ func UninstallCodex(hooksPath string) error {
 	if skillsDir, err := DefaultCodexSkillsDir(); err == nil {
 		removeCodexSkills(skillsDir)
 	}
-	if !claudeInstallPresent() {
+	if !claudeInstallPresent() && !codexInstallPresent() {
 		if hooksDir, err := DefaultHooksDir(); err == nil {
 			removeShims(hooksDir)
 		}
@@ -123,8 +126,9 @@ func UninstallCodex(hooksPath string) error {
 }
 
 // codexInstallPresent reports whether the default Codex hooks file still
-// carries Director-managed entries — the signal the CC Uninstall uses to spare
-// the shared shims. Best-effort and fail-safe in the conservative direction is
+// carries Director-managed entries — the signal the CC Uninstall (and a
+// custom-`--settings` UninstallCodex) uses to spare the shared shims.
+// Best-effort and fail-safe in the conservative direction is
 // NOT wanted here: an unreadable/missing hooks.json reads as "no Codex
 // install", because refusing to remove shims on every read hiccup would make
 // the CC uninstall permanently leaky. Only a positive managed-entry sighting

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -98,9 +98,12 @@ func InstallCodex(hooksPath string) error {
 // UninstallCodex removes Director's tagged entries from hooksPath and the
 // Director-owned skill directories. A missing hooks file means no Codex install
 // to undo — touch nothing, mirroring the CC Uninstall. The shared shims are
-// deliberately LEFT in place either way: a Claude Code install may still
-// reference them, and `director uninstall` (the CC form) removes them when no
-// Codex install remains.
+// spared while the default CC settings.json still carries Director-managed
+// entries (a Claude Code install may still reference them) and reclaimed when
+// none remain — the mirror of the CC Uninstall's codexInstallPresent gate.
+// Without the reclaim, a Codex-only machine would keep the shim files forever:
+// the CC uninstall form no-ops on its missing settings.json, so nothing else
+// ever removes them.
 func UninstallCodex(hooksPath string) error {
 	if _, err := os.Stat(hooksPath); os.IsNotExist(err) {
 		return nil
@@ -110,6 +113,11 @@ func UninstallCodex(hooksPath string) error {
 	}
 	if skillsDir, err := DefaultCodexSkillsDir(); err == nil {
 		removeCodexSkills(skillsDir)
+	}
+	if !claudeInstallPresent() {
+		if hooksDir, err := DefaultHooksDir(); err == nil {
+			removeShims(hooksDir)
+		}
 	}
 	return nil
 }
@@ -133,36 +141,7 @@ func codexInstallPresent() bool {
 	if err != nil {
 		return false
 	}
-	root, err := loadSettings(hooksPath)
-	if err != nil {
-		return false
-	}
-	hooks, ok := typedMap(root, "hooks")
-	if !ok {
-		return false
-	}
-	for event := range hooks {
-		groups, ok := typedArray(hooks, event)
-		if !ok {
-			continue
-		}
-		for _, g := range groups {
-			group := asMap(g)
-			if group == nil {
-				continue
-			}
-			cmds, ok := typedArray(group, "hooks")
-			if !ok {
-				continue
-			}
-			for _, c := range cmds {
-				if isManaged(c) {
-					return true
-				}
-			}
-		}
-	}
-	return false
+	return managedEntriesPresent(hooksPath)
 }
 
 // codexSkillName maps an embedded command filename to its skill name:

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -31,13 +31,19 @@ const codexFixture = `{
 
 // setupCodex points the installer's Codex skills target at a throwaway dir and
 // returns a fresh hooks.json path (missing until InstallCodex creates it) plus
-// the shims/skills dirs for assertions.
+// the shims/skills dirs for assertions. The default CC settings.json is also
+// isolated — to a path with NO file behind it, so the baseline is a codex-only
+// machine (UninstallCodex's claudeInstallPresent probe must never read the
+// developer's real ~/.claude/settings.json); tests that want a coexisting CC
+// install write one at os.Getenv(settingsPathEnv).
 func setupCodex(t *testing.T, fixture string) (hooksPath, hooksDir, skillsDir string) {
 	t.Helper()
 	hooksDir = filepath.Join(t.TempDir(), "hooks")
 	t.Setenv(hooksDirEnv, hooksDir)
 	skillsDir = filepath.Join(t.TempDir(), "skills")
 	t.Setenv(codexSkillsDirEnv, skillsDir)
+	t.Setenv(settingsPathEnv, filepath.Join(t.TempDir(), "settings.json"))
+	t.Setenv(commandsDirEnv, filepath.Join(t.TempDir(), "commands"))
 	hooksPath = filepath.Join(t.TempDir(), "hooks.json")
 	if fixture != "" {
 		if err := os.WriteFile(hooksPath, []byte(fixture), 0o644); err != nil {
@@ -124,8 +130,11 @@ func TestInstallCodexWritesSkills(t *testing.T) {
 }
 
 // TestUninstallCodexRemovesOnlyItsOwn: uninstall strips the tagged entries and
-// the skill dirs but preserves the user's hook, foreign skills, and — unlike
-// the CC uninstall — the shared shims, which a CC install may still reference.
+// the skill dirs but preserves the user's hook and foreign skills. This is the
+// codex-ONLY machine (no CC settings.json exists), so the shared shims are
+// reclaimed too — nothing references them anymore, and the CC uninstall form
+// no-ops on its missing settings.json, so leaving them would strand the three
+// shim files forever.
 func TestUninstallCodexRemovesOnlyItsOwn(t *testing.T) {
 	hooksPath, hooksDir, skillsDir := setupCodex(t, codexFixture)
 	if err := InstallCodex(hooksPath); err != nil {
@@ -160,8 +169,61 @@ func TestUninstallCodexRemovesOnlyItsOwn(t *testing.T) {
 	if _, err := os.Stat(foreign); err != nil {
 		t.Errorf("foreign skill removed by uninstall: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(hooksDir, "sessionstart.sh")); !os.IsNotExist(err) {
+		t.Errorf("codex-only machine: uninstall must reclaim the shared shims (err=%v)", err)
+	}
+}
+
+// TestUninstallCodexSparesShimsWhenCCPresent is the coexistence half of the
+// shim reclaim: while the default CC settings.json still carries
+// Director-managed entries, the codex uninstall leaves the shared shims in
+// place — removing them would silently kill coordination on Claude Code (the
+// mirror of TestUninstallSparesShimsWhenCodexPresent).
+func TestUninstallCodexSparesShimsWhenCCPresent(t *testing.T) {
+	hooksPath, hooksDir, _ := setupCodex(t, "")
+	if err := Install(os.Getenv(settingsPathEnv)); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := InstallCodex(hooksPath); err != nil {
+		t.Fatalf("InstallCodex: %v", err)
+	}
+
+	if err := UninstallCodex(hooksPath); err != nil {
+		t.Fatalf("UninstallCodex: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(hooksDir, "sessionstart.sh")); err != nil {
-		t.Errorf("shared shims must survive a codex uninstall (CC may reference them): %v", err)
+		t.Errorf("codex uninstall removed shims a CC install still references: %v", err)
+	}
+}
+
+// TestUninstallCodexReclaimsShimsWhenCCSettingsHasNoManagedEntries: a CC
+// settings.json that EXISTS but carries no Director-managed entries (Claude
+// Code in use, Director never installed there — or already uninstalled) must
+// not spare the shims; only a positive managed-entry sighting does.
+func TestUninstallCodexReclaimsShimsWhenCCSettingsHasNoManagedEntries(t *testing.T) {
+	hooksPath, hooksDir, _ := setupCodex(t, "")
+	settings := os.Getenv(settingsPathEnv)
+	if err := os.WriteFile(settings, []byte(codexFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InstallCodex(hooksPath); err != nil {
+		t.Fatalf("InstallCodex: %v", err)
+	}
+
+	if err := UninstallCodex(hooksPath); err != nil {
+		t.Fatalf("UninstallCodex: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hooksDir, "sessionstart.sh")); !os.IsNotExist(err) {
+		t.Errorf("settings.json without managed entries must not spare the shims (err=%v)", err)
+	}
+	// The foreign settings.json itself is untouched — the reclaim only ever
+	// READS it.
+	b, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != codexFixture {
+		t.Errorf("codex uninstall mutated the CC settings file it only probes:\n%s", b)
 	}
 }
 

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -10,8 +10,9 @@ import (
 // codex_test.go exercises the Codex delivery target: the same tagged merge
 // against ~/.codex/hooks.json (reusing the CC fixture — the two files share the
 // {"hooks": {...}} structure), the skill materialization with its naming and
-// cross-reference transforms, and the asymmetric uninstall (skills removed,
-// shared shims left for a possible CC install).
+// cross-reference transforms, and the conditional uninstall (skills removed,
+// shared shims spared only while a CC or default Codex install still
+// references them, reclaimed once neither does).
 
 // codexFixture pins the coexistence guarantee on a hooks.json that already
 // carries a user's own hook.
@@ -35,7 +36,10 @@ const codexFixture = `{
 // isolated — to a path with NO file behind it, so the baseline is a codex-only
 // machine (UninstallCodex's claudeInstallPresent probe must never read the
 // developer's real ~/.claude/settings.json); tests that want a coexisting CC
-// install write one at os.Getenv(settingsPathEnv).
+// install write one at os.Getenv(settingsPathEnv). The default Codex hooks
+// path is pinned to the returned hooksPath (never the developer's real
+// ~/.codex/hooks.json), so these tests exercise the default-path uninstall;
+// the custom --settings form points UninstallCodex at a different file.
 func setupCodex(t *testing.T, fixture string) (hooksPath, hooksDir, skillsDir string) {
 	t.Helper()
 	hooksDir = filepath.Join(t.TempDir(), "hooks")
@@ -45,6 +49,7 @@ func setupCodex(t *testing.T, fixture string) (hooksPath, hooksDir, skillsDir st
 	t.Setenv(settingsPathEnv, filepath.Join(t.TempDir(), "settings.json"))
 	t.Setenv(commandsDirEnv, filepath.Join(t.TempDir(), "commands"))
 	hooksPath = filepath.Join(t.TempDir(), "hooks.json")
+	t.Setenv(codexHooksPathEnv, hooksPath)
 	if fixture != "" {
 		if err := os.WriteFile(hooksPath, []byte(fixture), 0o644); err != nil {
 			t.Fatal(err)
@@ -224,6 +229,29 @@ func TestUninstallCodexReclaimsShimsWhenCCSettingsHasNoManagedEntries(t *testing
 	}
 	if string(b) != codexFixture {
 		t.Errorf("codex uninstall mutated the CC settings file it only probes:\n%s", b)
+	}
+}
+
+// TestUninstallCodexSparesShimsWhenDefaultCodexInstallPresent: a custom
+// `--settings <path>` uninstall while the DEFAULT hooks.json still carries a
+// Director install (and no CC install exists) must leave the shared shims —
+// removing them would strand the default install's trusted entries. Only the
+// default-path uninstall, which strips those entries first, reclaims.
+func TestUninstallCodexSparesShimsWhenDefaultCodexInstallPresent(t *testing.T) {
+	defaultPath, hooksDir, _ := setupCodex(t, "")
+	if err := InstallCodex(defaultPath); err != nil {
+		t.Fatalf("InstallCodex (default path): %v", err)
+	}
+	customPath := filepath.Join(t.TempDir(), "custom-hooks.json")
+	if err := InstallCodex(customPath); err != nil {
+		t.Fatalf("InstallCodex (custom path): %v", err)
+	}
+
+	if err := UninstallCodex(customPath); err != nil {
+		t.Fatalf("UninstallCodex: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hooksDir, "sessionstart.sh")); err != nil {
+		t.Errorf("custom-path uninstall removed shims the default codex install still references: %v", err)
 	}
 }
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -318,7 +318,9 @@ func removeManagedEntries(path string) error {
 
 // claudeInstallPresent reports whether the default CC settings file still
 // carries Director-managed entries — the mirror image of codexInstallPresent,
-// and the signal UninstallCodex uses to spare the shared shims. Same fail-open
+// and one of the two signals UninstallCodex uses to spare the shared shims
+// (the other being codexInstallPresent itself, for the custom-`--settings`
+// form). Same fail-open
 // stance and KNOWN LIMIT as its mirror (see codexInstallPresent): a missing or
 // unreadable settings.json reads as "no CC install", so only a positive
 // managed-entry sighting spares the shims — anything else would leave a

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -60,6 +60,12 @@ const hooksDirEnv = "DIRECTOR_HOOKS_DIR"
 // markdown is materialized. When unset, DefaultCommandsDir is used.
 const commandsDirEnv = "DIRECTOR_COMMANDS_DIR"
 
+// settingsPathEnv lets a caller (and the tests) redirect the default CC
+// settings.json, mirroring DIRECTOR_CODEX_HOOKS_PATH. The CLI's --settings flag
+// already overrides the install/uninstall target; this env var additionally
+// redirects the cross-target claudeInstallPresent probe.
+const settingsPathEnv = "DIRECTOR_SETTINGS_PATH"
+
 // managedEntry describes one hook Director installs: which CC event it attaches
 // to, the matcher (empty = all), and the shim filename under the hooks dir.
 type managedEntry struct {
@@ -79,9 +85,13 @@ var directorEntries = []managedEntry{
 }
 
 // DefaultSettingsPath resolves the standard user settings file,
-// ~/.claude/settings.json. Callers that want a different target (a project
-// settings file, a test fixture) pass an explicit path to Install/Uninstall.
+// ~/.claude/settings.json. DIRECTOR_SETTINGS_PATH overrides the location.
+// Callers that want a different target (a project settings file, a test
+// fixture) pass an explicit path to Install/Uninstall.
 func DefaultSettingsPath() (string, error) {
+	if p := os.Getenv(settingsPathEnv); p != "" {
+		return p, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("install: resolve home dir: %w", err)
@@ -304,6 +314,59 @@ func removeManagedEntries(path string) error {
 		root["hooks"] = hooks
 	}
 	return writeSettings(path, root)
+}
+
+// claudeInstallPresent reports whether the default CC settings file still
+// carries Director-managed entries — the mirror image of codexInstallPresent,
+// and the signal UninstallCodex uses to spare the shared shims. Same fail-open
+// stance and KNOWN LIMIT as its mirror (see codexInstallPresent): a missing or
+// unreadable settings.json reads as "no CC install", so only a positive
+// managed-entry sighting spares the shims — anything else would leave a
+// Codex-only machine leaking shim files forever.
+func claudeInstallPresent() bool {
+	settingsPath, err := DefaultSettingsPath()
+	if err != nil {
+		return false
+	}
+	return managedEntriesPresent(settingsPath)
+}
+
+// managedEntriesPresent reports whether the hooks file at path carries any
+// Director-managed command object — the shared scan behind codexInstallPresent
+// and claudeInstallPresent. Read errors and foreign shapes read as "not
+// present": both callers want the fail-open direction (see codexInstallPresent
+// for why fail-safe would make shim removal permanently leaky).
+func managedEntriesPresent(path string) bool {
+	root, err := loadSettings(path)
+	if err != nil {
+		return false
+	}
+	hooks, ok := typedMap(root, "hooks")
+	if !ok {
+		return false
+	}
+	for event := range hooks {
+		groups, ok := typedArray(hooks, event)
+		if !ok {
+			continue
+		}
+		for _, g := range groups {
+			group := asMap(g)
+			if group == nil {
+				continue
+			}
+			cmds, ok := typedArray(group, "hooks")
+			if !ok {
+				continue
+			}
+			for _, c := range cmds {
+				if isManaged(c) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // writeShims materializes the embedded hook shims into hooksDir, creating the dir

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -50,6 +50,10 @@ func writeFixture(t *testing.T, contents string) (path, hooksDir string) {
 	t.Setenv(codexSkillsDirEnv, filepath.Join(t.TempDir(), "skills"))
 	dir := t.TempDir()
 	path = filepath.Join(dir, "settings.json")
+	// Point the default CC settings at the fixture itself, so UninstallCodex's
+	// claudeInstallPresent probe sees the same install state the test builds
+	// (and never the developer's real ~/.claude/settings.json).
+	t.Setenv(settingsPathEnv, path)
 	if contents != "" {
 		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## What / why

A Codex-only uninstall used to leave the three shared shim files under the hooks dir forever: `UninstallCodex` never removed them (a Claude Code install might reference them), and the CC uninstall form no-ops on its missing `settings.json`, so nothing else ever reclaimed them (open-item 01KWMVX96Z2FQMYNYSMPSSWZ26). This PR makes the shim lifecycle symmetric: either uninstall form spares the shims only while the other agent's install still references them, and reclaims them once neither does.

## Implementation

Fixed the codex-only shim residue: UninstallCodex now reclaims the 3 shared shim files under the hooks dir when the default Claude Code settings.json carries no Director-managed entries, mirroring the existing codexInstallPresent gate in the CC Uninstall. Added claudeInstallPresent plus a shared managedEntriesPresent scan (extracted verbatim from codexInstallPresent, same fail-open stance), and a DIRECTOR_SETTINGS_PATH env override on DefaultSettingsPath (mirror of DIRECTOR_CODEX_HOOKS_PATH) so the probe is test-isolatable. Merge/strip semantics of settings.json are untouched — only shim FILE removal timing changed. Tests cover codex-only (missing settings.json, shims reclaimed), codex+CC (shims spared), and settings.json present without managed entries (shims reclaimed, probed file byte-identical).

## Review round (all five findings taken)

- **Coexistence gap closed**: the reclaim now gates on `!claudeInstallPresent() && !codexInstallPresent()`, so a custom `--settings <path>` codex uninstall no longer removes shims the default `~/.codex/hooks.json` install still references (default-path uninstall strips entries first, so its probe reads absent and the reclaim still happens). New test pins the custom-path spare; `setupCodex` now isolates `DIRECTOR_CODEX_HOOKS_PATH`.
- **Doc drift**: `docs/getting-started.md` shim-survival paragraph rewritten to the new symmetric wording; sample install output updated.
- **README**: `DIRECTOR_SETTINGS_PATH` added to the env-var table.
- **Stale test header**: `codex_test.go` file-level comment no longer describes the old asymmetric uninstall.
- **Confirmation symmetry**: the CC install confirmation now names the `DIRECTOR_SETTINGS_PATH` override, matching the codex form.

## Test plan

- Gate: `go test ./... -race` green (all packages, including the new uninstall coexistence tests).

Closes Director open-item 01KWMVX96Z2FQMYNYSMPSSWZ26 (director resolve on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
