### PR TITLE
fix(event-log): store scan fails loud on a non-dir project path (Windows)

### DIFF
--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -162,7 +162,7 @@ func (s *Store) Tail(n int) ([]Event, error) {
 func (s *Store) scan(fn func(Event) error) error {
 	f, err := os.Open(s.Path())
 	if err != nil {
-		if os.IsNotExist(err) {
+		if logTrulyAbsent(s.Path(), err) {
 			return nil
 		}
 		return fmt.Errorf("store: open log %s: %w", s.Path(), err)
@@ -191,4 +191,27 @@ func (s *Store) scan(fn func(Event) error) error {
 		return fmt.Errorf("store: read log %s: %w", s.Path(), err)
 	}
 	return nil
+}
+
+// logTrulyAbsent reports whether a failed Open(path) means the log file does not
+// exist yet — the only case scan may treat as an empty log. os.IsNotExist alone
+// is not portable: on Windows, Open through a path component that exists as a
+// regular FILE also reports not-exist (ERROR_PATH_NOT_FOUND), where unix reports
+// ENOTDIR and fails loud. A silently-empty read of the system-of-record is the
+// §9 "silence reads as healthy" / LIE-TEST failure class, so a not-exist openErr
+// is only a precondition: the log is genuinely absent only if its parent
+// resolves to a real directory (or is itself absent). A parent that exists as a
+// non-directory is a broken surface and must fail loud on both platforms. Stat,
+// not Lstat, classifies the parent because Open follows symlinks — a symlinked
+// project directory is a valid parent, not a broken one. This is the file-open
+// twin of fleet.dirTrulyAbsent, which does the same for a directory read.
+func logTrulyAbsent(path string, openErr error) bool {
+	if !os.IsNotExist(openErr) {
+		return false
+	}
+	info, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		return os.IsNotExist(err)
+	}
+	return info.IsDir()
 }

--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -199,19 +199,31 @@ func (s *Store) scan(fn func(Event) error) error {
 // regular FILE also reports not-exist (ERROR_PATH_NOT_FOUND), where unix reports
 // ENOTDIR and fails loud. A silently-empty read of the system-of-record is the
 // §9 "silence reads as healthy" / LIE-TEST failure class, so a not-exist openErr
-// is only a precondition: the log is genuinely absent only if its parent
-// resolves to a real directory (or is itself absent). A parent that exists as a
-// non-directory is a broken surface and must fail loud on both platforms. Stat,
-// not Lstat, classifies the parent because Open follows symlinks — a symlinked
-// project directory is a valid parent, not a broken one. This is the file-open
-// twin of fleet.dirTrulyAbsent, which does the same for a directory read.
+// is only a precondition: the log is genuinely absent only if its parent is a
+// real directory (reachable through symlinks) or nothing at all. A parent that
+// exists as a non-directory — a regular file, or a dangling symlink — is a
+// broken surface and must fail loud on both platforms.
+//
+// Stat (which follows symlinks) classifies a present parent, so a symlinked
+// project directory stays valid. When Stat itself reports not-exist, an Lstat
+// tiebreak separates a genuinely-absent parent from a dangling symlink (Lstat
+// does not follow the link): a link whose target is gone is a broken surface,
+// not an absent one. This mirrors fleet.dirTrulyAbsent's treatment of dangling
+// symlinks, adapted from a directory read to a file open.
 func logTrulyAbsent(path string, openErr error) bool {
 	if !os.IsNotExist(openErr) {
 		return false
 	}
-	info, err := os.Stat(filepath.Dir(path))
-	if err != nil {
-		return os.IsNotExist(err)
+	parent := filepath.Dir(path)
+	info, err := os.Stat(parent)
+	if err == nil {
+		return info.IsDir()
 	}
-	return info.IsDir()
+	if !os.IsNotExist(err) {
+		return false
+	}
+	if _, lerr := os.Lstat(parent); lerr == nil {
+		return false // link exists, target gone → broken surface, fail loud
+	}
+	return true // nothing there at all → genuinely fresh
 }

--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -196,45 +196,51 @@ func (s *Store) scan(fn func(Event) error) error {
 // logTrulyAbsent reports whether a failed Open(path) means the log file does not
 // exist yet — the only case scan may treat as an empty log. os.IsNotExist alone
 // is not portable: on Windows, Open through a path component that exists as a
-// regular FILE also reports not-exist (ERROR_PATH_NOT_FOUND), where unix reports
-// ENOTDIR and fails loud. A silently-empty read of the system-of-record is the
-// §9 "silence reads as healthy" / LIE-TEST failure class, so a not-exist openErr
-// is only a precondition. The log is genuinely absent only when BOTH the parent
-// and the log path itself check out as truly nothing:
+// regular FILE (or a dangling symlink) also reports not-exist
+// (ERROR_PATH_NOT_FOUND), where unix reports ENOTDIR and fails loud. A silently-
+// empty read of the system-of-record is the §9 "silence reads as healthy" /
+// LIE-TEST failure class, so a not-exist openErr is only a precondition. The log
+// is genuinely absent only when neither the log path nor any ancestor is a
+// broken non-directory:
 //
-//   - the parent must be a real directory (reachable through symlinks) or itself
-//     absent; a parent that exists as a non-directory — a regular file or a
-//     dangling symlink — is a broken surface and fails loud;
-//   - within a real parent, the log path itself must be genuinely nothing; a
-//     dangling symlink AT the log path (Open followed it to a missing target) is
-//     a broken surface, not an empty log, and fails loud.
+//   - the log path itself must be nothing; if Lstat still finds an entry there,
+//     Open followed a dangling symlink to a missing target — a broken surface;
+//   - walking up from the log's parent, the nearest component that EXISTS must
+//     be a real directory (Stat follows symlinks, so a symlinked project dir is
+//     valid); a component that exists as a regular file or a dangling symlink is
+//     a broken surface. A chain that is genuinely absent to the filesystem root
+//     is a fresh repo.
 //
-// Stat (which follows symlinks) classifies a present entry, so a symlinked
-// project directory stays valid; Lstat (which does not) is the tiebreak that
-// separates a genuinely-absent name from a dangling symlink. This mirrors
-// fleet.dirTrulyAbsent's dangling-symlink stance, adapted from a directory read
-// to a file open — but guards both the parent and the log path, since here the
-// classified name (parent) is one level up from the opened one (the log file).
+// Any re-check error other than not-exist (EACCES, ELOOP, …) fails loud rather
+// than being read as absence. This goes deeper than fleet.dirTrulyAbsent, which
+// classifies only its own directory: here the opened path (the log file) sits
+// below the components that can be broken, and on Windows every broken ancestor
+// collapses to ERROR_PATH_NOT_FOUND, so a one-level check would read a broken
+// hub as empty.
 func logTrulyAbsent(path string, openErr error) bool {
 	if !os.IsNotExist(openErr) {
 		return false
 	}
-	parent := filepath.Dir(path)
-	info, err := os.Stat(parent)
-	if err == nil {
-		if !info.IsDir() {
-			return false // parent exists as a non-directory → broken surface
+	if _, err := os.Lstat(path); err == nil {
+		return false // dangling symlink at the log path → broken surface
+	} else if !os.IsNotExist(err) {
+		return false // re-check failed for a non-absence reason → fail loud
+	}
+	for dir := filepath.Dir(path); ; {
+		if info, err := os.Stat(dir); err == nil {
+			return info.IsDir() // nearest existing ancestor: absent iff a real dir
+		} else if !os.IsNotExist(err) {
+			return false // Stat failed for a non-absence reason → fail loud
 		}
-		if _, lerr := os.Lstat(path); lerr == nil {
-			return false // log path is a dangling symlink → broken surface
+		if _, lerr := os.Lstat(dir); lerr == nil {
+			return false // dangling symlink at this level → broken surface
+		} else if !os.IsNotExist(lerr) {
+			return false // Lstat failed for a non-absence reason → fail loud
 		}
-		return true // real parent, log path genuinely absent → fresh
+		if parent := filepath.Dir(dir); parent != dir {
+			dir = parent
+		} else {
+			return true // climbed to the root, nothing existed → genuinely fresh
+		}
 	}
-	if !os.IsNotExist(err) {
-		return false // Stat failed for a non-absence reason → fail loud
-	}
-	if _, lerr := os.Lstat(parent); lerr == nil {
-		return false // parent is a dangling symlink → broken surface
-	}
-	return true // parent genuinely absent → fresh
 }

--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -199,17 +199,22 @@ func (s *Store) scan(fn func(Event) error) error {
 // regular FILE also reports not-exist (ERROR_PATH_NOT_FOUND), where unix reports
 // ENOTDIR and fails loud. A silently-empty read of the system-of-record is the
 // §9 "silence reads as healthy" / LIE-TEST failure class, so a not-exist openErr
-// is only a precondition: the log is genuinely absent only if its parent is a
-// real directory (reachable through symlinks) or nothing at all. A parent that
-// exists as a non-directory — a regular file, or a dangling symlink — is a
-// broken surface and must fail loud on both platforms.
+// is only a precondition. The log is genuinely absent only when BOTH the parent
+// and the log path itself check out as truly nothing:
 //
-// Stat (which follows symlinks) classifies a present parent, so a symlinked
-// project directory stays valid. When Stat itself reports not-exist, an Lstat
-// tiebreak separates a genuinely-absent parent from a dangling symlink (Lstat
-// does not follow the link): a link whose target is gone is a broken surface,
-// not an absent one. This mirrors fleet.dirTrulyAbsent's treatment of dangling
-// symlinks, adapted from a directory read to a file open.
+//   - the parent must be a real directory (reachable through symlinks) or itself
+//     absent; a parent that exists as a non-directory — a regular file or a
+//     dangling symlink — is a broken surface and fails loud;
+//   - within a real parent, the log path itself must be genuinely nothing; a
+//     dangling symlink AT the log path (Open followed it to a missing target) is
+//     a broken surface, not an empty log, and fails loud.
+//
+// Stat (which follows symlinks) classifies a present entry, so a symlinked
+// project directory stays valid; Lstat (which does not) is the tiebreak that
+// separates a genuinely-absent name from a dangling symlink. This mirrors
+// fleet.dirTrulyAbsent's dangling-symlink stance, adapted from a directory read
+// to a file open — but guards both the parent and the log path, since here the
+// classified name (parent) is one level up from the opened one (the log file).
 func logTrulyAbsent(path string, openErr error) bool {
 	if !os.IsNotExist(openErr) {
 		return false
@@ -217,13 +222,19 @@ func logTrulyAbsent(path string, openErr error) bool {
 	parent := filepath.Dir(path)
 	info, err := os.Stat(parent)
 	if err == nil {
-		return info.IsDir()
+		if !info.IsDir() {
+			return false // parent exists as a non-directory → broken surface
+		}
+		if _, lerr := os.Lstat(path); lerr == nil {
+			return false // log path is a dangling symlink → broken surface
+		}
+		return true // real parent, log path genuinely absent → fresh
 	}
 	if !os.IsNotExist(err) {
-		return false
+		return false // Stat failed for a non-absence reason → fail loud
 	}
 	if _, lerr := os.Lstat(parent); lerr == nil {
-		return false // link exists, target gone → broken surface, fail loud
+		return false // parent is a dangling symlink → broken surface
 	}
-	return true // nothing there at all → genuinely fresh
+	return true // parent genuinely absent → fresh
 }

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -289,6 +289,30 @@ func TestReadProjectPathAsSymlinkedDirIsEmpty(t *testing.T) {
 	}
 }
 
+// TestReadLogFileAsDanglingSymlinkErrors: the log file itself being a symlink to
+// a nonexistent target is a broken surface, not an absent log. Open follows the
+// link to a missing target (not-exist) and the parent is a real directory, so
+// logTrulyAbsent must Lstat the log path itself to catch the dangling link and
+// fail loud — parity with fleet.dirTrulyAbsent, which Lstats its exact target.
+func TestReadLogFileAsDanglingSymlinkErrors(t *testing.T) {
+	skipIfNoSymlinks(t)
+	store := NewStore(t.TempDir(), "dangling-log-repo")
+	logPath := store.Path()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(t.TempDir(), "gone"), logPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ReadAll(); err == nil {
+		t.Fatal("ReadAll on a log file that is a dangling symlink must error, not read as empty")
+	}
+	if _, err := store.Tail(5); err == nil {
+		t.Fatal("Tail on a log file that is a dangling symlink must error, not read as empty")
+	}
+}
+
 // TestAppendRejectsInvalid confirms the store validates before writing: an
 // invalid event must surface the error and leave the log empty (no partial line).
 func TestAppendRejectsInvalid(t *testing.T) {

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -3,10 +3,21 @@ package event
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 )
+
+// skipIfNoSymlinks skips a test that must create a symlink: on Windows that
+// needs privileges, so the symlink-classification branches are verified on unix
+// only (the regular-file branch, which needs no symlink, still runs everywhere).
+func skipIfNoSymlinks(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on Windows")
+	}
+}
 
 // newEvent builds a minimally-valid note event for store tests. It reuses the
 // mustID helper defined in event_test.go (same package).
@@ -224,6 +235,54 @@ func TestReadProjectDirWithoutLogIsEmpty(t *testing.T) {
 	all, err := store.ReadAll()
 	if err != nil {
 		t.Fatalf("ReadAll on an existing-but-empty project dir: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("ReadAll returned %d events, want 0", len(all))
+	}
+}
+
+// TestReadProjectPathAsDanglingSymlinkErrors: a <hub>/projects/<repoKey> that is
+// a symlink to a nonexistent target is a broken surface, not an absent log —
+// it must error, never read as empty. os.Stat follows the link and reports
+// not-exist; logTrulyAbsent's Lstat tiebreak keeps it failing loud (mirroring
+// fleet.dirTrulyAbsent's dangling-symlink stance).
+func TestReadProjectPathAsDanglingSymlinkErrors(t *testing.T) {
+	skipIfNoSymlinks(t)
+	store := NewStore(t.TempDir(), "dangling-repo")
+	projectDir := filepath.Dir(store.Path())
+	if err := os.MkdirAll(filepath.Dir(projectDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(t.TempDir(), "gone"), projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ReadAll(); err == nil {
+		t.Fatal("ReadAll on a project path that is a dangling symlink must error, not read as empty")
+	}
+	if _, err := store.Tail(5); err == nil {
+		t.Fatal("Tail on a project path that is a dangling symlink must error, not read as empty")
+	}
+}
+
+// TestReadProjectPathAsSymlinkedDirIsEmpty guards the valid-symlink branch: a
+// project dir reached through a symlink to a REAL, empty directory is a fresh
+// project and reads empty, not an error — the case a naive Lstat classification
+// would wrongly fail loud.
+func TestReadProjectPathAsSymlinkedDirIsEmpty(t *testing.T) {
+	skipIfNoSymlinks(t)
+	store := NewStore(t.TempDir(), "symlinked-repo")
+	projectDir := filepath.Dir(store.Path())
+	if err := os.MkdirAll(filepath.Dir(projectDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := store.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll through a symlinked project dir: %v", err)
 	}
 	if len(all) != 0 {
 		t.Fatalf("ReadAll returned %d events, want 0", len(all))

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -313,6 +313,71 @@ func TestReadLogFileAsDanglingSymlinkErrors(t *testing.T) {
 	}
 }
 
+// TestReadAncestorAsFileErrors: a broken component ABOVE the project dir — here
+// <hub>/projects existing as a regular file — must fail loud, not read as empty.
+// logTrulyAbsent walks ancestors rather than checking only the immediate parent:
+// unix fails loud at Open (ENOTDIR), but on Windows every broken ancestor
+// collapses to ERROR_PATH_NOT_FOUND, so a one-level check would read the broken
+// hub as an empty log.
+func TestReadAncestorAsFileErrors(t *testing.T) {
+	hub := t.TempDir()
+	store := NewStore(hub, "repo")
+	projectsDir := filepath.Dir(filepath.Dir(store.Path())) // <hub>/projects
+	if err := os.WriteFile(projectsDir, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ReadAll(); err == nil {
+		t.Fatal("ReadAll with an ancestor that is a regular file must error, not read as empty")
+	}
+	if _, err := store.Tail(5); err == nil {
+		t.Fatal("Tail with an ancestor that is a regular file must error, not read as empty")
+	}
+}
+
+// TestReadAncestorAsDanglingSymlinkErrors: an ancestor (<hub>/projects) that is a
+// symlink to a missing target is a broken surface. Open and both re-checks
+// report not-exist because the dangling ancestor cannot be traversed, so the
+// ancestor walk must find the dangling link via Lstat at its own level and fail
+// loud rather than folding it into "absent".
+func TestReadAncestorAsDanglingSymlinkErrors(t *testing.T) {
+	skipIfNoSymlinks(t)
+	hub := t.TempDir()
+	store := NewStore(hub, "repo")
+	projectsDir := filepath.Dir(filepath.Dir(store.Path())) // <hub>/projects
+	if err := os.Symlink(filepath.Join(t.TempDir(), "gone"), projectsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ReadAll(); err == nil {
+		t.Fatal("ReadAll with a dangling-symlink ancestor must error, not read as empty")
+	}
+	if _, err := store.Tail(5); err == nil {
+		t.Fatal("Tail with a dangling-symlink ancestor must error, not read as empty")
+	}
+}
+
+// TestReadAncestorAsSymlinkedDirIsEmpty guards the valid side of the ancestor
+// walk: an ancestor reached through a symlink to a REAL directory is fine, and a
+// genuinely-absent log below it reads empty, not an error.
+func TestReadAncestorAsSymlinkedDirIsEmpty(t *testing.T) {
+	skipIfNoSymlinks(t)
+	hub := t.TempDir()
+	store := NewStore(hub, "repo")
+	projectsDir := filepath.Dir(filepath.Dir(store.Path())) // <hub>/projects
+	if err := os.Symlink(t.TempDir(), projectsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := store.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll through a symlinked ancestor dir: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("ReadAll returned %d events, want 0", len(all))
+	}
+}
+
 // TestAppendRejectsInvalid confirms the store validates before writing: an
 // invalid event must surface the error and leave the log empty (no partial line).
 func TestAppendRejectsInvalid(t *testing.T) {

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -182,6 +183,50 @@ func TestReadMissingLog(t *testing.T) {
 	}
 	if len(tail) != 0 {
 		t.Fatalf("Tail on missing log returned %d events, want 0", len(tail))
+	}
+}
+
+// TestReadProjectPathAsFileErrors: a <hub>/projects/<repoKey> path that exists as
+// a regular FILE (where the project directory belongs) must surface as a real
+// error, never as an empty log — a silently-empty read of the system-of-record
+// is the §9/LIE-TEST failure class. Portable classification via logTrulyAbsent:
+// unix Open hits ENOTDIR and fails loud already; Windows hits
+// ERROR_PATH_NOT_FOUND and, without the parent-dir re-check, would misread it as
+// "no log yet" (twin of fleet.TestDoneWorkstreamFleetPathAsFileErrors).
+func TestReadProjectPathAsFileErrors(t *testing.T) {
+	store := NewStore(t.TempDir(), "broken-repo")
+	projectDir := filepath.Dir(store.Path()) // <hub>/projects/broken-repo
+	if err := os.MkdirAll(filepath.Dir(projectDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectDir, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ReadAll(); err == nil {
+		t.Fatal("ReadAll on a project path that is a regular file must error, not read as empty")
+	}
+	if _, err := store.Tail(5); err == nil {
+		t.Fatal("Tail on a project path that is a regular file must error, not read as empty")
+	}
+}
+
+// TestReadProjectDirWithoutLogIsEmpty guards the other side of logTrulyAbsent's
+// parent-dir re-check: when the project directory exists but the log file has
+// not been written yet, the read is empty, not an error. A real, empty project
+// must not be misclassified as a broken surface.
+func TestReadProjectDirWithoutLogIsEmpty(t *testing.T) {
+	store := NewStore(t.TempDir(), "empty-project")
+	if err := os.MkdirAll(filepath.Dir(store.Path()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := store.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll on an existing-but-empty project dir: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("ReadAll returned %d events, want 0", len(all))
 	}
 }
 


### PR DESCRIPTION
## What

`store.scan` (behind `ReadAll`/`Tail`) treated any `os.IsNotExist` error from `os.Open` as "empty log, return nil". Correct for a genuinely-fresh repo — but on **Windows** a path component that exists as a regular *file* (where the project directory belongs) reports `ERROR_PATH_NOT_FOUND`, which classifies as not-exist. So a broken hub surface would **silently read the system-of-record as empty** — the §9 "silence reads as healthy" / LIE-TEST failure class. Unix already fails loud there (`ENOTDIR`).

## Fix

Add `logTrulyAbsent(path, openErr)`: a not-exist `Open` error counts as an absent log only when the parent resolves to a **real directory** (or is itself absent). A non-directory parent is a broken surface and now fails loud on **both** platforms. `Stat` (not `Lstat`) classifies the parent because `Open` follows symlinks, so a symlinked project directory stays valid. This is the file-open twin of the existing `fleet.dirTrulyAbsent`.

## Tests

- `TestReadProjectPathAsFileErrors` — parent-as-file must error via both `ReadAll` and `Tail` (twin of `fleet.TestDoneWorkstreamFleetPathAsFileErrors`). Unix proves the invariant via `ENOTDIR`; Windows CI is where the fix earns its keep.
- `TestReadProjectDirWithoutLogIsEmpty` — the other branch: an existing-but-empty project dir reads empty, not an error.
- `TestReadMissingLog` (unchanged) — absent parent still reads empty.

## Scope

`store.go` only. The same-class but low-stakes `install.go`/`codex.go` sites (install-time, and the misclassification direction there is safe) are intentionally left out; `stop.go`/`handoffnudge.go` already fail loud on any open error.

## Context

Closes the `risk:escalate` residue that `ce:review` of #24 flagged on the event-log surface — the Windows not-exist misclassification one level up from the fleet dir-read that #24 fixed. Real since #22 shipped Windows binaries.

Gate green locally: `go build ./... && go vet ./... && gofmt -l . && go test ./... -race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
