### PR TITLE
feat(install): one-line curl|sh installer (installs + wires in one shot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,21 @@ jobs:
       - name: go test -race
         run: go test ./... -race
 
+  # The front-door install script is POSIX sh piped to `sh` (often dash). Lint it
+  # so a bashism can never regress the primary external entry point. shellcheck is
+  # preinstalled on ubuntu-latest; dash is /bin/sh there.
+  installer:
+    name: "installer (shellcheck · dash -n)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: shellcheck
+        run: shellcheck -s sh install.sh
+
+      - name: posix parse (dash)
+        run: dash -n install.sh
+
   # Windows portability check: build + full test suite under Windows filesystem
   # semantics (no unix permission bits, rename-over-open restrictions, CRLF git
   # defaults). vet/gofmt run once on the ubuntu gate; duplicating them here adds

--- a/README.md
+++ b/README.md
@@ -64,18 +64,24 @@ The design in four ideas — the full argument, including honest comparisons, is
 
 ## Install
 
-Prebuilt binaries for macOS, Linux, and Windows (amd64/arm64) are published on the [releases page](https://github.com/colinsurprenant/director/releases); [`docs/getting-started.md`](docs/getting-started.md) covers install-from-release.
+One command downloads the right prebuilt binary for your platform (checksum-verified), installs it to `~/.local/bin`, and wires it into Claude Code. Installed and wired, no second step (it tells you if `~/.local/bin` isn't on your `PATH` yet):
 
-> **On Windows?** Use [WSL](https://learn.microsoft.com/windows/wsl/) with the Linux binary: everything works there, hooks included. Native Windows is CLI-only for now: the binary is built and CI-tested, and every manual verb (`emit`, `render`, `status`, `brief`, `show`, `resolve`, …) works from PowerShell, but the hook shims are bash, so the ambient layer — session-start injection, heartbeats, boundary nudges — is not yet wired natively.
+```bash
+curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
+```
 
-Or build the binary and put it on your `PATH`:
+Wire Codex instead with `sh -s -- --codex` (or `--both`); install the binary only with `sh -s -- --no-wire`.
+
+> **On Windows?** Run the one-liner inside [WSL](https://learn.microsoft.com/windows/wsl/) with the Linux binary: everything works there, hooks included. Native Windows is CLI-only for now: the binary is built and CI-tested, and every manual verb (`emit`, `render`, `status`, `brief`, `show`, `resolve`, …) works from PowerShell, but the hook shims are bash, so the ambient layer — session-start injection, heartbeats, boundary nudges — is not yet wired natively.
+
+**Other ways in:** prebuilt binaries for macOS, Linux, and Windows (amd64/arm64) are on the [releases page](https://github.com/colinsurprenant/director/releases) ([`docs/getting-started.md`](docs/getting-started.md) covers install-from-release), `go install github.com/colinsurprenant/director/cmd/director@latest` builds from source (Go 1.25+), or build it yourself:
 
 ```bash
 go build -o bin/director ./cmd/director
 sudo install bin/director /usr/local/bin/director   # or copy it anywhere on PATH
 ```
 
-Then wire it into your agent — Claude Code, Codex, or both.
+Then wire it into your agent. The one-liner already wired Claude Code; the sections below spell out what that does, and how to add Codex.
 
 ### Wire into Claude Code
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+# install.sh — one-command install for Director (https://github.com/colinsurprenant/director).
+#
+# Downloads the right prebuilt binary for this platform, checksum-verifies it,
+# installs it to ~/.local/bin, and wires it into your agent — so a single
+# command leaves you *installed and wired*, not just holding a binary.
+#
+#   curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
+#
+# Options (pass through sh: `... | sh -s -- <opt>`), `--opt value` or `--opt=value`:
+#   --codex        wire OpenAI Codex instead of Claude Code
+#   --both         wire both agents
+#   --no-wire      install the binary only, wire nothing
+#   --version T    install release tag T (default: latest)
+#   --dir D        install the binary into D (default: ~/.local/bin)
+#   --help         print this and exit
+#
+# Environment overrides (flags win over these):
+#   DIRECTOR_VERSION       release tag to install (default: latest)
+#   DIRECTOR_INSTALL_DIR   directory for the binary (default: ~/.local/bin)
+#
+# The checksum verifies download *integrity* (truncation, CDN/proxy corruption of
+# the asset blob) — not supply-chain provenance: the asset and its checksums.txt
+# share the same GitHub-release trust root this script already relies on for TLS.
+# A signed-release upgrade (minisign/cosign) is a separate follow-up.
+#
+# Windows: run this inside WSL. The Linux binary works there, hooks included;
+# native Windows is unsupported (the hook shims are bash).
+
+set -eu
+
+REPO="colinsurprenant/director"
+WIRE="claude" # claude | codex | both | none
+VERSION="${DIRECTOR_VERSION:-}"
+# The ~/.local/bin default is applied AFTER arg parsing so that --dir /
+# DIRECTOR_INSTALL_DIR work even when HOME is unset (stripped envs, cron, sudo).
+INSTALL_DIR="${DIRECTOR_INSTALL_DIR:-}"
+
+# --- output --------------------------------------------------------------
+# Progress goes to stderr; the wired `director install` writes its own
+# confirmations to stdout.
+info() { printf '%s\n' "$*" >&2; }
+err() { printf 'director install: %s\n' "$*" >&2; }
+die() {
+	err "$*"
+	exit 1
+}
+
+usage() {
+	cat >&2 <<'EOF'
+Install Director (a coordination ledger for your coding-agent work).
+
+  curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
+
+Options (via `... | sh -s -- <opt>`):
+  --codex        wire OpenAI Codex instead of Claude Code
+  --both         wire both agents
+  --no-wire      install the binary only
+  --version T    install release tag T (default: latest)
+  --dir D        install into D (default: ~/.local/bin)
+  --help         show this
+EOF
+}
+
+# --- args ----------------------------------------------------------------
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--codex) WIRE=codex ;;
+	--both) WIRE=both ;;
+	--no-wire) WIRE=none ;;
+	--version)
+		[ $# -ge 2 ] || die "--version needs a value"
+		VERSION="$2"
+		shift
+		;;
+	--version=*) VERSION="${1#*=}" ;;
+	--dir)
+		[ $# -ge 2 ] || die "--dir needs a value"
+		INSTALL_DIR="$2"
+		shift
+		;;
+	--dir=*) INSTALL_DIR="${1#*=}" ;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*) die "unknown option: $1 (try --help)" ;;
+	esac
+	shift
+done
+
+# Apply the default install dir now that flags/env have spoken. Only here is HOME
+# needed, and only when no explicit dir was given — so --dir rescues a HOME-less
+# environment instead of aborting on an unbound variable.
+if [ -z "$INSTALL_DIR" ]; then
+	[ -n "${HOME:-}" ] || die "HOME is not set — pass --dir <path> or set DIRECTOR_INSTALL_DIR"
+	INSTALL_DIR="$HOME/.local/bin"
+fi
+INSTALL_DIR="${INSTALL_DIR%/}" # tolerate a trailing slash so the PATH check matches
+
+# --- platform ------------------------------------------------------------
+os="$(uname -s)"
+case "$os" in
+Linux) os=linux ;;
+Darwin) os=darwin ;;
+MINGW* | MSYS* | CYGWIN* | Windows_NT)
+	die "native Windows is not supported — run this inside WSL (https://learn.microsoft.com/windows/wsl/). The Linux binary works there, hooks included."
+	;;
+*) die "unsupported OS: $os" ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+x86_64 | amd64) arch=amd64 ;;
+arm64 | aarch64) arch=arm64 ;;
+*) die "unsupported architecture: $arch (prebuilt binaries cover amd64 and arm64)" ;;
+esac
+
+# --- fetch tooling -------------------------------------------------------
+if command -v curl >/dev/null 2>&1; then
+	DL=curl
+elif command -v wget >/dev/null 2>&1; then
+	DL=wget
+else
+	die "need curl or wget on PATH"
+fi
+
+# fetch URL -> stdout; download URL FILE -> write to FILE. Both fail non-zero on
+# an HTTP error (curl -f / wget default) so the callers' `|| die` fires.
+fetch() {
+	if [ "$DL" = curl ]; then curl -fsSL "$1"; else wget -qO- "$1"; fi
+}
+download() {
+	if [ "$DL" = curl ]; then curl -fsSL -o "$2" "$1"; else wget -qO "$2" "$1"; fi
+}
+
+# --- resolve version -----------------------------------------------------
+if [ -z "$VERSION" ]; then
+	info "Resolving the latest release…"
+	# Capture the API response in its own step so a network/rate-limit failure is
+	# attributable: a piped `fetch | sed` would mask it (no pipefail in POSIX sh).
+	resp="$(fetch "https://api.github.com/repos/$REPO/releases/latest")" ||
+		die "could not reach the GitHub API — set DIRECTOR_VERSION to a tag (e.g. v1.6.1)"
+	# Whitespace-tolerant, jq-free parse of the first tag_name (`sed 1q` is POSIX).
+	VERSION="$(printf '%s\n' "$resp" |
+		sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | sed 1q)"
+	[ -n "$VERSION" ] || die "could not parse a release tag from the GitHub API — set DIRECTOR_VERSION"
+fi
+
+asset="director_${VERSION}_${os}_${arch}.tar.gz"
+base="https://github.com/$REPO/releases/download/$VERSION"
+
+# --- download + verify + extract ----------------------------------------
+tmp="$(mktemp -d)"
+staged="" # same-dir staging copy of the binary; removed if we die mid-install
+cleanup() {
+	rm -rf "$tmp"
+	if [ -n "$staged" ]; then
+		rm -f "$staged" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT TERM
+
+info "Downloading $asset …"
+download "$base/$asset" "$tmp/$asset" ||
+	die "download failed: $base/$asset (does release $VERSION ship a $os/$arch binary?)"
+download "$base/checksums.txt" "$tmp/checksums.txt" ||
+	die "download failed: $base/checksums.txt"
+
+# Exact-match the checksum line ($2 is the filename column of `sha256sum`).
+want="$(awk -v a="$asset" '$2 == a {print $1}' "$tmp/checksums.txt")"
+[ -n "$want" ] || die "no checksum for $asset in checksums.txt"
+if command -v sha256sum >/dev/null 2>&1; then
+	got="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+	got="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+else
+	die "need sha256sum or shasum to verify the download"
+fi
+[ "$want" = "$got" ] || die "checksum mismatch for $asset (expected $want, got $got)"
+
+# Extract only the binary we expect, not whatever else an archive might carry.
+tar -C "$tmp" -xzf "$tmp/$asset" director || die "could not extract 'director' from $asset"
+[ -f "$tmp/director" ] || die "$asset did not contain a 'director' binary"
+chmod +x "$tmp/director"
+
+# --- install (validate before replacing any existing binary) ------------
+mkdir -p "$INSTALL_DIR" || die "cannot create $INSTALL_DIR"
+bin="$INSTALL_DIR/director"
+# Refuse a target that isn't a plain file/symlink (e.g. a directory): moving onto
+# it would nest the binary inside instead of replacing it.
+if [ -e "$bin" ] && [ ! -f "$bin" ] && [ ! -L "$bin" ]; then
+	die "$bin exists and is not a regular file — remove it and re-run"
+fi
+# Stage in the destination directory (same filesystem), smoke-test the staged
+# binary, THEN swap it in with an atomic rename — an interrupted or bad download
+# can never leave a truncated binary where a working one was.
+staged="$INSTALL_DIR/.director.install.$$"
+mv "$tmp/director" "$staged" || die "cannot write to $INSTALL_DIR"
+"$staged" version >/dev/null 2>&1 ||
+	die "the downloaded binary did not run (wrong platform build, or a noexec/unsigned install dir?)"
+mv "$staged" "$bin" || die "cannot install to $bin"
+staged="" # renamed into place; nothing left to clean up
+info "Installed director $VERSION → $bin"
+
+# --- wire the agent ------------------------------------------------------
+# Invoke via the absolute path: wiring must work before INSTALL_DIR is on PATH.
+# `director install` is idempotent and non-clobbering.
+wire_failed=0
+run_wire() { # DESCRIPTION ARGS...
+	desc="$1"
+	shift
+	info "$desc"
+	"$bin" "$@" || {
+		err "agent wiring failed — re-run \`$bin $*\` to see the error"
+		wire_failed=1
+	}
+}
+case "$WIRE" in
+claude) run_wire "Wiring Claude Code…" install ;;
+codex) run_wire "Wiring Codex…" install --codex ;;
+both)
+	run_wire "Wiring Claude Code…" install
+	run_wire "Wiring Codex…" install --codex
+	;;
+none) info "Skipping agent wiring (--no-wire)." ;;
+esac
+
+# --- PATH guidance + next steps -----------------------------------------
+on_path=0
+case ":${PATH:-}:" in
+*":$INSTALL_DIR:"*) on_path=1 ;;
+esac
+if [ "$on_path" -eq 0 ]; then
+	info ""
+	info "NOTE: $INSTALL_DIR is not on your PATH. To run 'director' directly, add:"
+	info "    export PATH=\"$INSTALL_DIR:\$PATH\""
+	info "  to your ~/.profile, ~/.bashrc, or ~/.zshrc."
+	info "  (Director's Claude Code hooks already work without this — 'install' dropped a PATH-independent fallback.)"
+fi
+
+# Point at the binary the way the user can actually invoke it right now.
+adopt="director"
+[ "$on_path" -eq 1 ] || adopt="$bin"
+info ""
+if [ "$wire_failed" -eq 0 ]; then
+	info "Done. Next: '$adopt adopt' in a project, then open your agent there."
+	info "See https://github.com/$REPO/blob/main/docs/getting-started.md"
+else
+	die "installed the binary, but agent wiring did not complete (see above)"
+fi

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,9 @@ INSTALL_DIR="${DIRECTOR_INSTALL_DIR:-}"
 # Progress goes to stderr; the wired `director install` writes its own
 # confirmations to stdout.
 info() { printf '%s\n' "$*" >&2; }
-err() { printf 'director install: %s\n' "$*" >&2; }
+# "director installer" (not "director install"): the script's own errors must be
+# distinguishable from the `director install` subcommand it invokes to wire.
+err() { printf 'director installer: %s\n' "$*" >&2; }
 die() {
 	err "$*"
 	exit 1
@@ -151,7 +153,11 @@ asset="director_${VERSION}_${os}_${arch}.tar.gz"
 base="https://github.com/$REPO/releases/download/$VERSION"
 
 # --- download + verify + extract ----------------------------------------
-tmp="$(mktemp -d)"
+# Explicit template: the universally-portable form across GNU, BSD/macOS, and
+# busybox mktemp (bare `mktemp -d` works on current macOS but the template removes
+# any BSD-variant doubt at zero cost). %/ strips a trailing slash from TMPDIR.
+tmpdir="${TMPDIR:-/tmp}"
+tmp="$(mktemp -d "${tmpdir%/}/director-install.XXXXXX")" || die "cannot create a temporary directory"
 staged="" # same-dir staging copy of the binary; removed if we die mid-install
 cleanup() {
 	rm -rf "$tmp"

--- a/site/index.html
+++ b/site/index.html
@@ -267,7 +267,7 @@
   <div class="install reveal d4">
     <div class="cmd">
       <span class="p">$</span>
-      <code id="install-cmd">go install github.com/colinsurprenant/director/cmd/director@latest</code>
+      <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh</code>
       <button class="copy" id="copy-btn" type="button" aria-live="polite">copy</button>
     </div>
     <nav class="btns" aria-label="Primary">
@@ -275,7 +275,7 @@
       <a class="btn" href="https://github.com/colinsurprenant/director/blob/main/docs/getting-started.md">Getting started</a>
     </nav>
   </div>
-  <p class="also reveal d4">prebuilt binaries for macOS &amp; Linux on the <a href="https://github.com/colinsurprenant/director/releases">releases page</a> · works with Claude Code + OpenAI Codex</p>
+  <p class="also reveal d4">downloads a verified binary and wires Claude Code (pass <code>--codex</code> for Codex) · macOS, Linux, WSL · <code>go install</code> and <a href="https://github.com/colinsurprenant/director/releases">prebuilt binaries</a> also available</p>
 </header>
 
 <main>


### PR DESCRIPTION
## What

A `curl | sh` one-line installer, so a discoverer goes from the landing page to **installed and wired** in a single command:

```bash
curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
```

`install.sh` detects the platform, resolves the latest release, downloads and sha256-verifies the tarball, stages the binary into `~/.local/bin` and swaps it in with a validated atomic rename, smoke-tests it, then runs `director install` to wire the agent. Options: `--codex` / `--both` / `--no-wire`, `--version`, `--dir` (space or `=` form). Windows users are routed to WSL.

Also switches the **README `## Install`** and the **landing-page CTA** off `go install` to the one-liner, and adds a **shellcheck + `dash -n` CI gate** for the script.

## Why

This closes the "did step 1, forgot step 2" onboarding gap: the previous front door was `go install …@latest` (Go 1.25 toolchain floor) followed by a *separate* `director install` that was easy to forget, with a silent-PATH failure mode if the binary wasn't reachable. The one-liner needs no Go toolchain and leaves the agent wired in one shot. Part of the Phase-0 "seal the funnel" work before any diffusion push (plan: `~/.claude/plans/i-want-to-discuss-synthetic-lightning.md`).

## Review

Ran **ce:code-reviewer** (verdict: approve — "genuinely well-engineered and security-conscious; no Critical or High") and a **codex adversarial pass**. Findings reconciled and addressed:

- Attributable API-failure diagnostics (a piped `fetch | sed` masked network/rate-limit errors; now a guarded fetch-into-var).
- `HOME`-less environments: the `~/.local/bin` default is applied after arg parsing, so `--dir` / `DIRECTOR_INSTALL_DIR` rescue a stripped env instead of aborting under `set -u`.
- Validate-before-replace: stage into the destination dir, smoke-test, then atomic same-fs rename, so an interrupted/bad download can't clobber a working `director`.
- Directory-target guard; extract only the `director` member; `head -1` → `sed 1q`; `${PATH:-}` guard; `--opt=value` form; trailing-slash `--dir`.
- Honest copy: README no longer claims it "puts it on your PATH" (it installs to `~/.local/bin` and warns if that's off PATH); the site caption makes Claude-Code-the-default explicit.

**Intentionally out of scope** (both reviewers agreed acceptable): the checksum verifies download *integrity*, not supply-chain provenance (asset + `checksums.txt` share the GitHub-release trust root the script already relies on via TLS) — a signed-release upgrade (minisign/cosign) is a separate follow-up; full tarball path-traversal hardening is over-engineering for a checksum-verified first-party artifact.

## Testing

Verified end-to-end against the live `v1.6.1` release:
- download + checksum-verify + extract + smoke-test, and a fully-sandboxed install **+ wire** writing the four `_managedBy:"director"` hooks into a temp `settings.json`;
- edge cases: `env -u HOME … --help`, `env -u HOME … --dir`, `--version=`/`--dir=` forms, directory-target guard, bad-option exit code;
- `sh -n`, `dash -n`, and `shellcheck -s sh install.sh` all clean.

No Go code changed, so the §13 gate is unaffected (CI still runs it). The new `installer` CI job uses no `github.event.*` input — no workflow-injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
