### PR TITLE
feat(doctor): `director doctor` install self-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ director install
 
 The installed hook commands point at the **shims**, not the binary directly, so rebuilding or relocating `director` never requires rewriting `settings.json` (re-run `install` to refresh the shims to the current binary). If `~/.claude/settings.json` already has a malformed (non-object) `hooks` value, `install` refuses rather than overwrite it.
 
+Confirm the wiring will actually fire with `director doctor`. The shims fail safe (a missing binary exits 0 and coordination silently no-ops), so a broken install is otherwise invisible; `doctor` walks the same binary-resolution ladder the shims walk and reports each link (binary, Claude Code hooks, Codex hooks if present, hub). It exits non-zero when the install is broken, and warns (without failing) on a partial one — such as a terminal-only install the desktop app would miss:
+
+```bash
+director doctor
+```
+
 ### Wire into OpenAI Codex
 
 ```bash
@@ -122,7 +128,7 @@ Install paths and runtime knobs, common to both agents unless a default says oth
 | `DIRECTOR_BIN` | (PATH) | which `director` binary the shims invoke (defaults to `director` on `PATH`, then the symlink `install` drops next to the shims at `<hooks dir>/../bin/director` — `~/.claude/director/bin/director` by default) |
 | `DIRECTOR_HANDOFF_NUDGE_TOKENS` | (unset) | the context-fill handoff nudge (Claude Code-only for now): an absolute token threshold at which sessions are nudged toward `/director:handoff`; unset or `0` disables it. Fires once per crossing and re-arms only after context falls below half the threshold (a compaction or a context clear) |
 
-> **The binary must be findable.** With `DIRECTOR_BIN` set, the shims use it and nothing else — a stale value exits 0 without ever trying the other tiers. Unset, they fall back to `director` on `PATH`, then to the symlink `install` drops next to them at `<hooks dir>/../bin/director` (`~/.claude/director/bin/director` by default; a `DIRECTOR_HOOKS_DIR` override moves it too). A miss exits 0 (fail-safe) and coordination silently no-ops. The symlink tier covers the Claude Code **desktop app**, whose Dock/Launchpad launches get the bare launchd `PATH` ([anthropics/claude-code#44649](https://github.com/anthropics/claude-code/issues/44649)). To pin a specific binary explicitly, set `DIRECTOR_BIN` via `"env"` in `~/.claude/settings.json`.
+> **The binary must be findable.** With `DIRECTOR_BIN` set, the shims use it and nothing else — a stale value exits 0 without ever trying the other tiers. Unset, they fall back to `director` on `PATH`, then to the symlink `install` drops next to them at `<hooks dir>/../bin/director` (`~/.claude/director/bin/director` by default; a `DIRECTOR_HOOKS_DIR` override moves it too). A miss exits 0 (fail-safe) and coordination silently no-ops. The symlink tier covers the Claude Code **desktop app**, whose Dock/Launchpad launches get the bare launchd `PATH` ([anthropics/claude-code#44649](https://github.com/anthropics/claude-code/issues/44649)). To pin a specific binary explicitly, set `DIRECTOR_BIN` via `"env"` in `~/.claude/settings.json`. `director doctor` flags a stale `DIRECTOR_BIN` that resolves to nothing, the failure mode that silently disables the fallback tiers.
 
 ## Adopt an existing repo
 
@@ -173,6 +179,7 @@ adoption & install:
   install     idempotent merge of Director hooks into settings.json
               (--codex: Codex's hooks.json + $director-* agent skills instead)
   uninstall   remove only Director-managed hook entries (--codex: Codex's)
+  doctor      check the install is wired and the hooks will actually fire
 
 misc:
   version     print the director version
@@ -294,6 +301,7 @@ go build -o bin/director ./cmd/director
 sudo install bin/director /usr/local/bin/director
 director install              # Claude Code
 director install --codex      # OpenAI Codex — either, or both
+director doctor               # confirm the wiring will actually fire
 
 # 2. Register an existing repo in the fleet
 cd ~/dev/src/some-project

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/colinsurprenant/director/internal/install"
+)
+
+// doctor answers the one question the silent-by-design hooks can't: will Director
+// actually fire? The shims fail safe — if they can't resolve the binary they
+// exit 0 and coordination just... doesn't happen, with no error anywhere. doctor
+// walks the same resolution ladder the shims walk (DIRECTOR_BIN → director on
+// PATH → the install symlink) plus the rest of the wiring, and turns that
+// invisible dead state into a loud, checkable one.
+
+type checkLevel int
+
+const (
+	levelOK checkLevel = iota
+	levelWarn
+	levelFail
+)
+
+func (l checkLevel) glyph() string {
+	switch l {
+	case levelOK:
+		return "✓"
+	case levelWarn:
+		return "⚠"
+	default:
+		return "✗"
+	}
+}
+
+type check struct {
+	title  string
+	level  checkLevel
+	detail string
+}
+
+type doctorReport struct {
+	checks  []check
+	healthy bool // no fail-level checks
+}
+
+func (r doctorReport) hasWarn() bool {
+	for _, c := range r.checks {
+		if c.level == levelWarn {
+			return true
+		}
+	}
+	return false
+}
+
+// doctorInputs is the resolved environment diagnose inspects. The paths and the
+// PATH lookup are passed in (not read inside diagnose) so the whole assessment is
+// unit-testable against temp dirs, with no dependency on the real ~/.claude
+// layout or the ambient PATH.
+type doctorInputs struct {
+	directorBin  string                // DIRECTOR_BIN ("" if unset)
+	lookDirector func() (string, bool) // resolves `director` on PATH → (path, found)
+	settingsPath string                // ~/.claude/settings.json
+	hooksDir     string                // where the shims live
+	binPath      string                // the install symlink tier (<hooks root>/bin/director)
+	codexHooks   string                // ~/.codex/hooks.json
+	hub          string                // the coordination hub root
+}
+
+// runDoctor is the CLI wrapper: resolve the environment, diagnose, print, and
+// return non-zero when the install is not healthy so it is usable in a script.
+func runDoctor(args []string) int {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: director doctor")
+		return 2
+	}
+
+	in, err := doctorInputsFromEnv()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "doctor: %v\n", err)
+		return 1
+	}
+	rep := diagnose(in)
+	writeReport(os.Stdout, rep)
+	if !rep.healthy {
+		return 1
+	}
+	return 0
+}
+
+// doctorInputsFromEnv resolves the real install paths (honoring the DIRECTOR_*
+// overrides) and the ambient PATH lookup.
+func doctorInputsFromEnv() (doctorInputs, error) {
+	settingsPath, err := install.DefaultSettingsPath()
+	if err != nil {
+		return doctorInputs{}, err
+	}
+	hooksDir, err := install.DefaultHooksDir()
+	if err != nil {
+		return doctorInputs{}, err
+	}
+	binPath, err := install.DefaultBinPath()
+	if err != nil {
+		return doctorInputs{}, err
+	}
+	codexHooks, err := install.DefaultCodexHooksPath()
+	if err != nil {
+		return doctorInputs{}, err
+	}
+	hub, err := hubRoot()
+	if err != nil {
+		return doctorInputs{}, err
+	}
+	return doctorInputs{
+		directorBin:  os.Getenv("DIRECTOR_BIN"),
+		lookDirector: func() (string, bool) { p, e := exec.LookPath("director"); return p, e == nil },
+		settingsPath: settingsPath,
+		hooksDir:     hooksDir,
+		binPath:      binPath,
+		codexHooks:   codexHooks,
+		hub:          hub,
+	}, nil
+}
+
+// diagnose assembles the health checks and the overall verdict. healthy is true
+// when no check failed (warnings don't sink it — coordination still fires).
+func diagnose(in doctorInputs) doctorReport {
+	var r doctorReport
+	r.checks = append(r.checks, binaryResolutionCheck(in))
+	r.checks = append(r.checks, claudeHooksCheck(in))
+	if c, ok := codexHooksCheck(in); ok {
+		r.checks = append(r.checks, c)
+	}
+	r.checks = append(r.checks, hubCheck(in.hub))
+
+	r.healthy = true
+	for _, c := range r.checks {
+		if c.level == levelFail {
+			r.healthy = false
+		}
+	}
+	return r
+}
+
+// binaryResolutionCheck walks the exact ladder the shims walk. This is the
+// headline check: a miss here is precisely the silent-no-op doctor exists to
+// surface.
+func binaryResolutionCheck(in doctorInputs) check {
+	// DIRECTOR_BIN, when set, is authoritative — the shims use it and nothing
+	// else, so a stale value is worse than an unset one: it disables the fallback
+	// tiers and coordination silently dies.
+	if in.directorBin != "" {
+		if binResolves(in.directorBin) {
+			return check{"binary", levelOK, fmt.Sprintf("hooks use DIRECTOR_BIN=%s (it overrides the PATH and symlink tiers)", in.directorBin)}
+		}
+		return check{"binary", levelFail, fmt.Sprintf(
+			"DIRECTOR_BIN=%s is set but not executable — the shims use it and nothing else, so coordination silently no-ops. Unset it, or point it at a real director binary.", in.directorBin)}
+	}
+
+	pathBin, onPath := in.lookDirector()
+	symOK := isExecutable(in.binPath)
+	switch {
+	case symOK:
+		return check{"binary", levelOK, fmt.Sprintf(
+			"hooks resolve director via the install symlink %s — works from a terminal and from desktop-app (Dock/Launchpad) launches", in.binPath)}
+	case onPath:
+		return check{"binary", levelWarn, fmt.Sprintf(
+			"director is on your PATH (%s) but the install symlink %s is missing — desktop-app launches get a bare PATH and may not find it. Re-run `director install` to drop the symlink.", pathBin, in.binPath)}
+	default:
+		return check{"binary", levelFail, fmt.Sprintf(
+			"director is not on your PATH and the install symlink %s is missing — the hooks will silently no-op. Re-run `director install` (or put director on your PATH).", in.binPath)}
+	}
+}
+
+// claudeHooksCheck verifies the Claude Code side is wired: the tagged entries are
+// in settings.json AND the shims those entries point at actually exist.
+func claudeHooksCheck(in doctorInputs) check {
+	if !install.ManagedEntriesPresent(in.settingsPath) {
+		return check{"claude code hooks", levelFail, fmt.Sprintf("no Director hooks in %s — run `director install`.", in.settingsPath)}
+	}
+	if missing := missingShims(in.hooksDir); len(missing) > 0 {
+		return check{"claude code hooks", levelFail, fmt.Sprintf(
+			"settings.json references Director hooks, but shims are missing from %s (%s) — re-run `director install`.", in.hooksDir, strings.Join(missing, ", "))}
+	}
+	return check{"claude code hooks", levelOK, fmt.Sprintf("wired in %s; shims present in %s", in.settingsPath, in.hooksDir)}
+}
+
+// codexHooksCheck reports the Codex side only when a Codex install is present, so
+// it never nags a Claude-Code-only user. The bool is false when there is nothing
+// to report.
+func codexHooksCheck(in doctorInputs) (check, bool) {
+	if !install.ManagedEntriesPresent(in.codexHooks) {
+		return check{}, false
+	}
+	if missing := missingShims(in.hooksDir); len(missing) > 0 {
+		return check{"codex hooks", levelFail, fmt.Sprintf(
+			"%s references Director hooks, but shims are missing from %s (%s) — re-run `director install --codex`.", in.codexHooks, in.hooksDir, strings.Join(missing, ", "))}, true
+	}
+	return check{"codex hooks", levelOK, fmt.Sprintf("wired in %s", in.codexHooks)}, true
+}
+
+// hubCheck confirms coordination state can actually be written. A not-yet-created
+// hub is fine (it is made on first write); an unwritable one is fatal.
+func hubCheck(hub string) check {
+	fi, err := os.Stat(hub)
+	if os.IsNotExist(err) {
+		return check{"hub", levelOK, fmt.Sprintf("%s does not exist yet — it is created on first write", hub)}
+	}
+	if err != nil {
+		return check{"hub", levelFail, fmt.Sprintf("cannot access hub %s: %v", hub, err)}
+	}
+	if !fi.IsDir() {
+		return check{"hub", levelFail, fmt.Sprintf("hub %s exists but is not a directory", hub)}
+	}
+	if !dirWritable(hub) {
+		return check{"hub", levelFail, fmt.Sprintf("hub %s is not writable — coordination state cannot be recorded", hub)}
+	}
+	return check{"hub", levelOK, fmt.Sprintf("%s is present and writable", hub)}
+}
+
+// writeReport prints one line per check and a closing verdict.
+func writeReport(w io.Writer, rep doctorReport) {
+	for _, c := range rep.checks {
+		fmt.Fprintf(w, "%s %s: %s\n", c.level.glyph(), c.title, c.detail)
+	}
+	fmt.Fprintln(w)
+	switch {
+	case !rep.healthy:
+		fmt.Fprintln(w, "✗ Director is NOT healthy: coordination will not fire. Fix the ✗ items above.")
+	case rep.hasWarn():
+		fmt.Fprintln(w, "⚠ Director works, with caveats — see the ⚠ items above.")
+	default:
+		fmt.Fprintln(w, "✓ Director is healthy: the hooks will fire and coordination is live.")
+	}
+	fmt.Fprintln(w, "  (For a repo's coordination state, run `director status`.)")
+}
+
+// binResolves mirrors the shims' `[ -x "$bin" ] || command -v "$bin"`: a value
+// with a path separator must be an executable file; a bare name must be on PATH.
+func binResolves(v string) bool {
+	if strings.ContainsRune(v, filepath.Separator) || strings.Contains(v, "/") {
+		return isExecutable(v)
+	}
+	_, err := exec.LookPath(v)
+	return err == nil
+}
+
+// isExecutable reports whether path is a regular (or symlinked-to) executable
+// file. os.Stat follows symlinks, matching the shims' `-x` test against the
+// install symlink.
+func isExecutable(path string) bool {
+	if path == "" {
+		return false
+	}
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return false
+	}
+	return fi.Mode()&0o111 != 0
+}
+
+// missingShims returns the expected shim basenames absent (or non-executable) in
+// hooksDir, checked against install's own embedded set so the two never drift.
+func missingShims(hooksDir string) []string {
+	var missing []string
+	for _, name := range install.ExpectedShims() {
+		if !isExecutable(filepath.Join(hooksDir, name)) {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+// dirWritable probes write access by creating and removing a temp file — the
+// only reliable check across platforms and permission models.
+func dirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".director-doctor-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	f.Close()
+	os.Remove(name)
+	return true
+}

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -63,13 +63,14 @@ func (r doctorReport) hasWarn() bool {
 // unit-testable against temp dirs, with no dependency on the real ~/.claude
 // layout or the ambient PATH.
 type doctorInputs struct {
-	directorBin  string                // DIRECTOR_BIN ("" if unset)
-	lookDirector func() (string, bool) // resolves `director` on PATH → (path, found)
-	settingsPath string                // ~/.claude/settings.json
-	hooksDir     string                // where the shims live
-	binPath      string                // the install symlink tier (<hooks root>/bin/director)
-	codexHooks   string                // ~/.codex/hooks.json
-	hub          string                // the coordination hub root
+	directorBin             string                // effective DIRECTOR_BIN the shim will see ("" if unset)
+	directorBinFromSettings bool                  // the value came from settings.json's env block, not the shell
+	lookDirector            func() (string, bool) // resolves `director` on PATH → (path, found)
+	settingsPath            string                // ~/.claude/settings.json
+	hooksDir                string                // where the shims live
+	binPath                 string                // the install symlink tier (<hooks root>/bin/director)
+	codexHooks              string                // ~/.codex/hooks.json
+	hub                     string                // the coordination hub root
 }
 
 // runDoctor is the CLI wrapper: resolve the environment, diagnose, print, and
@@ -82,6 +83,18 @@ func runDoctor(args []string) int {
 	if fs.NArg() != 0 {
 		fmt.Fprintln(os.Stderr, "usage: director doctor")
 		return 2
+	}
+
+	// On native Windows the hooks are intentionally not wired (install refuses —
+	// the shims are bash), so running the checks would report failures whose only
+	// remedy, `director install`, also refuses: a dead-end loop. Report the real
+	// state instead — CLI works, ambient layer needs WSL — and exit 0, since
+	// nothing is broken; it's the platform limitation.
+	if installGOOS == "windows" {
+		fmt.Println("director doctor: native Windows is CLI-only — the hook shims are bash scripts, so the ambient layer (session-start injection, heartbeats, boundary nudges) is not wired here.")
+		fmt.Println("  The manual verbs (emit, render, status, brief, show, resolve) work natively; run under WSL with the Linux binary for the full hook-driven layer.")
+		fmt.Println("  Details: https://github.com/colinsurprenant/director/blob/main/docs/getting-started.md")
+		return 0
 	}
 
 	in, err := doctorInputsFromEnv()
@@ -120,14 +133,30 @@ func doctorInputsFromEnv() (doctorInputs, error) {
 	if err != nil {
 		return doctorInputs{}, err
 	}
+	// Resolve the DIRECTOR_BIN the shim will actually see. A value exported in the
+	// current shell wins (a terminal-launched session inherits it), but the
+	// DOCUMENTED way to pin it — for desktop-app launches that get a bare PATH — is
+	// the "env" block in settings.json, which Claude Code injects into the hook and
+	// the shim uses exclusively. Reading only the shell env would blind doctor to a
+	// stale settings.json pin: it would fall through to PATH/symlink and report
+	// healthy while the real hook no-ops on the dead pin.
+	directorBin := os.Getenv("DIRECTOR_BIN")
+	fromSettings := false
+	if directorBin == "" {
+		if pinned, ok := install.SettingsDirectorBin(settingsPath); ok {
+			directorBin = pinned
+			fromSettings = true
+		}
+	}
 	return doctorInputs{
-		directorBin:  os.Getenv("DIRECTOR_BIN"),
-		lookDirector: func() (string, bool) { p, e := exec.LookPath("director"); return p, e == nil },
-		settingsPath: settingsPath,
-		hooksDir:     hooksDir,
-		binPath:      binPath,
-		codexHooks:   codexHooks,
-		hub:          hub,
+		directorBin:             directorBin,
+		directorBinFromSettings: fromSettings,
+		lookDirector:            func() (string, bool) { p, e := exec.LookPath("director"); return p, e == nil },
+		settingsPath:            settingsPath,
+		hooksDir:                hooksDir,
+		binPath:                 binPath,
+		codexHooks:              codexHooks,
+		hub:                     hub,
 	}, nil
 }
 
@@ -159,25 +188,38 @@ func binaryResolutionCheck(in doctorInputs) check {
 	// else, so a stale value is worse than an unset one: it disables the fallback
 	// tiers and coordination silently dies.
 	if in.directorBin != "" {
+		source := "the shell environment"
+		if in.directorBinFromSettings {
+			source = "settings.json env"
+		}
 		if binResolves(in.directorBin) {
-			return check{"binary", levelOK, fmt.Sprintf("hooks use DIRECTOR_BIN=%s (it overrides the PATH and symlink tiers)", in.directorBin)}
+			return check{"binary", levelOK, fmt.Sprintf("hooks use DIRECTOR_BIN=%s (from %s; it overrides the PATH and symlink tiers)", in.directorBin, source)}
 		}
 		return check{"binary", levelFail, fmt.Sprintf(
-			"DIRECTOR_BIN=%s is set but not executable — the shims use it and nothing else, so coordination silently no-ops. Unset it, or point it at a real director binary.", in.directorBin)}
+			"DIRECTOR_BIN=%s (from %s) is set but not executable — the shims use it and nothing else, so coordination silently no-ops. Unset it, or point it at a real director binary.", in.directorBin, source)}
 	}
 
+	// No DIRECTOR_BIN: the shim tries `director` on PATH FIRST, then falls back to
+	// the install symlink. Mirror that order in what we report. The verdict:
+	// resolvable everywhere (PATH covers a terminal, the symlink covers desktop-app
+	// launches with their bare PATH) → OK; PATH-only, no symlink → WARN (a terminal
+	// works but Dock/Launchpad launches miss it); symlink-only → OK (the shim falls
+	// through to it in every launch context); neither → FAIL.
 	pathBin, onPath := in.lookDirector()
 	symOK := isExecutable(in.binPath)
 	switch {
-	case symOK:
+	case onPath && symOK:
 		return check{"binary", levelOK, fmt.Sprintf(
-			"hooks resolve director via the install symlink %s — works from a terminal and from desktop-app (Dock/Launchpad) launches", in.binPath)}
+			"director resolves on your PATH (%s), and the install symlink %s backs desktop-app (Dock/Launchpad) launches — both launch contexts covered", pathBin, in.binPath)}
 	case onPath:
 		return check{"binary", levelWarn, fmt.Sprintf(
-			"director is on your PATH (%s) but the install symlink %s is missing — desktop-app launches get a bare PATH and may not find it. Re-run `director install` to drop the symlink.", pathBin, in.binPath)}
+			"director is on your PATH (%s) but the install symlink %s is missing or broken — desktop-app launches get a bare PATH and may not find it. Re-run `director install` to drop the symlink.", pathBin, in.binPath)}
+	case symOK:
+		return check{"binary", levelOK, fmt.Sprintf(
+			"director is not on your PATH; the hooks resolve it via the install symlink %s — works from a terminal and from desktop-app (Dock/Launchpad) launches", in.binPath)}
 	default:
 		return check{"binary", levelFail, fmt.Sprintf(
-			"director is not on your PATH and the install symlink %s is missing — the hooks will silently no-op. Re-run `director install` (or put director on your PATH).", in.binPath)}
+			"director is not on your PATH and the install symlink %s is missing or broken — the hooks will silently no-op. Re-run `director install` (or put director on your PATH).", in.binPath)}
 	}
 }
 
@@ -209,10 +251,18 @@ func codexHooksCheck(in doctorInputs) (check, bool) {
 }
 
 // hubCheck confirms coordination state can actually be written. A not-yet-created
-// hub is fine (it is made on first write); an unwritable one is fatal.
+// hub is fine (it is made on first write) — but only if the nearest existing
+// ancestor is writable, else the first write's MkdirAll fails and coordination is
+// dead while doctor would otherwise call it healthy. An existing-but-unwritable
+// hub is fatal.
 func hubCheck(hub string) check {
 	fi, err := os.Stat(hub)
 	if os.IsNotExist(err) {
+		anc := nearestExistingDir(filepath.Dir(hub))
+		if !dirWritable(anc) {
+			return check{"hub", levelFail, fmt.Sprintf(
+				"%s does not exist and its nearest existing parent %s is not writable — the first coordination write (MkdirAll) will fail.", hub, anc)}
+		}
 		return check{"hub", levelOK, fmt.Sprintf("%s does not exist yet — it is created on first write", hub)}
 	}
 	if err != nil {
@@ -278,6 +328,23 @@ func missingShims(hooksDir string) []string {
 		}
 	}
 	return missing
+}
+
+// nearestExistingDir walks up from p to the first ancestor that exists on disk.
+// It always terminates: the filesystem root always exists, and filepath.Dir is a
+// fixed point there. Used to find the directory MkdirAll would actually create
+// the hub under, so its writability can be probed before the first hub write.
+func nearestExistingDir(p string) string {
+	for {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return p // reached the root; nothing more to climb
+		}
+		p = parent
+	}
 }
 
 // dirWritable probes write access by creating and removing a temp file — the

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -227,6 +227,14 @@ func binaryResolutionCheck(in doctorInputs) check {
 // in settings.json AND the shims those entries point at actually exist.
 func claudeHooksCheck(in doctorInputs) check {
 	if !install.ManagedEntriesPresent(in.settingsPath) {
+		// ManagedEntriesPresent collapses a read/parse failure to the same false as
+		// "no managed entries", but the remedies differ: a malformed settings.json
+		// needs fixing (install would refuse to overwrite it), not a re-run. Split
+		// the two so the message points at the real fix.
+		if err := install.SettingsParseError(in.settingsPath); err != nil {
+			return check{"claude code hooks", levelFail, fmt.Sprintf(
+				"%s is unreadable or not valid JSON (%v) — fix the file, then re-run `director install`.", in.settingsPath, err)}
+		}
 		return check{"claude code hooks", levelFail, fmt.Sprintf("no Director hooks in %s — run `director install`.", in.settingsPath)}
 	}
 	if missing := missingShims(in.hooksDir); len(missing) > 0 {
@@ -294,8 +302,16 @@ func writeReport(w io.Writer, rep doctorReport) {
 	fmt.Fprintln(w, "  (For a repo's coordination state, run `director status`.)")
 }
 
-// binResolves mirrors the shims' `[ -x "$bin" ] || command -v "$bin"`: a value
-// with a path separator must be an executable file; a bare name must be on PATH.
+// binResolves models how the shims resolve DIRECTOR_BIN (`[ -x "$bin" ] ||
+// command -v "$bin"`): a value with a path separator must be an executable file;
+// a bare name must be on PATH. It deliberately does NOT replicate the shims'
+// cwd-relative `-x` for a bare name — that resolves against the HOOK's working
+// directory (Claude Code's, the project dir), which doctor, run from a different
+// cwd, cannot know; matching it here would probe the wrong directory and could
+// report healthy when the hook is dead. Depending on a cwd-relative binary for a
+// hook is unsupportable anyway (it breaks under every other cwd), and Go's
+// exec.LookPath excludes cwd for exactly that footgun. PATH is the portable,
+// cwd-independent contract.
 func binResolves(v string) bool {
 	if strings.ContainsRune(v, filepath.Separator) || strings.Contains(v, "/") {
 		return isExecutable(v)

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -266,10 +266,14 @@ func codexHooksCheck(in doctorInputs) (check, bool) {
 func hubCheck(hub string) check {
 	fi, err := os.Stat(hub)
 	if os.IsNotExist(err) {
-		anc := nearestExistingDir(filepath.Dir(hub))
+		anc, ancErr := nearestExistingAncestor(filepath.Dir(hub))
+		if ancErr != nil {
+			return check{"hub", levelFail, fmt.Sprintf(
+				"%s cannot be created — %v; the first coordination write (MkdirAll) will fail.", hub, ancErr)}
+		}
 		if !dirWritable(anc) {
 			return check{"hub", levelFail, fmt.Sprintf(
-				"%s does not exist and its nearest existing parent %s is not writable — the first coordination write (MkdirAll) will fail.", hub, anc)}
+				"%s does not exist and its nearest existing ancestor %s is not writable — the first coordination write (MkdirAll) will fail.", hub, anc)}
 		}
 		return check{"hub", levelOK, fmt.Sprintf("%s does not exist yet — it is created on first write", hub)}
 	}
@@ -346,18 +350,34 @@ func missingShims(hooksDir string) []string {
 	return missing
 }
 
-// nearestExistingDir walks up from p to the first ancestor that exists on disk.
-// It always terminates: the filesystem root always exists, and filepath.Dir is a
-// fixed point there. Used to find the directory MkdirAll would actually create
-// the hub under, so its writability can be probed before the first hub write.
-func nearestExistingDir(p string) string {
+// nearestExistingAncestor returns the nearest ancestor of p (inclusive) that
+// exists as a real directory MkdirAll could create p under. It applies the same
+// not-exist-vs-broken discipline as event.logTrulyAbsent: a plain not-exist is
+// safe to climb past, but a stat error that is NOT not-exist (EACCES, ENOTDIR,
+// ELOOP), a dangling symlink (Stat follows it to not-exist while Lstat still finds
+// the link), or an existing non-directory is a broken surface MkdirAll cannot
+// cross — returned as an error rather than silently skipped, which would let
+// doctor report an uncreatable hub as healthy.
+func nearestExistingAncestor(p string) (string, error) {
 	for {
-		if _, err := os.Stat(p); err == nil {
-			return p
+		info, statErr := os.Stat(p)
+		if statErr == nil {
+			if info.IsDir() {
+				return p, nil
+			}
+			return p, fmt.Errorf("%s exists but is not a directory", p)
+		}
+		if !os.IsNotExist(statErr) {
+			return p, statErr // inaccessible/broken (EACCES, ENOTDIR, ELOOP, …)
+		}
+		if _, lerr := os.Lstat(p); lerr == nil {
+			return p, fmt.Errorf("%s is a dangling symlink", p)
+		} else if !os.IsNotExist(lerr) {
+			return p, lerr
 		}
 		parent := filepath.Dir(p)
 		if parent == p {
-			return p // reached the root; nothing more to climb
+			return p, fmt.Errorf("no existing ancestor of %s", p) // unreachable: the root exists
 		}
 		p = parent
 	}

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -256,6 +256,27 @@ func TestDoctorSettingsPinSourceLabeled(t *testing.T) {
 	}
 }
 
+// TestDoctorMalformedSettingsReported: a settings.json that can't be parsed must
+// report as unreadable/malformed with the right remedy, not as "no hooks — run
+// director install" (which would refuse on a malformed file).
+func TestDoctorMalformedSettingsReported(t *testing.T) {
+	in := installedFixture(t)
+	bad := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(bad, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	in.settingsPath = bad
+	rep := diagnose(in)
+	if levelOf(t, rep, "claude code hooks") != levelFail {
+		t.Fatal("a malformed settings.json must FAIL the hooks check")
+	}
+	for _, c := range rep.checks {
+		if c.title == "claude code hooks" && !strings.Contains(c.detail, "not valid JSON") {
+			t.Errorf("malformed settings should be reported as such, got: %s", c.detail)
+		}
+	}
+}
+
 // TestDoctorNativeWindowsIsCLIOnly: on native Windows the hooks are intentionally
 // unwired (install refuses), so doctor reports the CLI-only state and exits 0
 // rather than emitting failures whose only remedy also refuses. Usage errors

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/colinsurprenant/director/internal/install"
@@ -207,5 +210,128 @@ func TestRunDoctorSandboxed(t *testing.T) {
 	}
 	if code := runDoctor([]string{"extra"}); code != 2 {
 		t.Fatalf("extra arg: runDoctor exit = %d, want 2", code)
+	}
+}
+
+// TestDoctorSettingsPinnedBinBroken is the P1 regression: a DIRECTOR_BIN pinned
+// ONLY in settings.json's env block (the documented desktop-app path, invisible
+// to the shell) must still be caught. Without the pin the install is healthy
+// (see TestRunDoctorSandboxed), so a flip to exit 1 can only come from doctor
+// reading the settings-level pin.
+func TestDoctorSettingsPinnedBinBroken(t *testing.T) {
+	root := t.TempDir()
+	settings := filepath.Join(root, "settings.json")
+	t.Setenv("DIRECTOR_HOOKS_DIR", filepath.Join(root, "hooks"))
+	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
+	t.Setenv("DIRECTOR_SETTINGS_PATH", settings)
+	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", filepath.Join(root, "no-codex.json"))
+	t.Setenv("DIRECTOR_HUB", root)
+	t.Setenv("DIRECTOR_BIN", "") // NOT pinned in the shell
+	if err := install.Install(settings); err != nil {
+		t.Fatal(err)
+	}
+	pinSettingsEnv(t, settings, "DIRECTOR_BIN", filepath.Join(root, "not-a-binary"))
+	if code := runDoctor(nil); code != 1 {
+		t.Fatalf("a dead settings.json-pinned DIRECTOR_BIN must fail doctor: exit = %d, want 1", code)
+	}
+}
+
+// TestDoctorSettingsPinSourceLabeled locks the report wording: when the pin comes
+// from settings.json the failure names that source, so a user knows where to fix
+// it (the shell env vs the settings file are different edits).
+func TestDoctorSettingsPinSourceLabeled(t *testing.T) {
+	in := installedFixture(t)
+	in.directorBin = filepath.Join(t.TempDir(), "not-a-binary")
+	in.directorBinFromSettings = true
+	rep := diagnose(in)
+	if levelOf(t, rep, "binary") != levelFail {
+		t.Fatal("a broken settings-pinned DIRECTOR_BIN must FAIL")
+	}
+	for _, c := range rep.checks {
+		if c.title == "binary" {
+			if !strings.Contains(c.detail, "settings.json env") {
+				t.Errorf("binary detail should name the settings.json source, got: %s", c.detail)
+			}
+		}
+	}
+}
+
+// TestDoctorNativeWindowsIsCLIOnly: on native Windows the hooks are intentionally
+// unwired (install refuses), so doctor reports the CLI-only state and exits 0
+// rather than emitting failures whose only remedy also refuses. Usage errors
+// still win over the platform note.
+func TestDoctorNativeWindowsIsCLIOnly(t *testing.T) {
+	saved := installGOOS
+	installGOOS = "windows"
+	defer func() { installGOOS = saved }()
+	if code := runDoctor(nil); code != 0 {
+		t.Fatalf("native Windows doctor must exit 0 (CLI-only, not broken): got %d", code)
+	}
+	if code := runDoctor([]string{"extra"}); code != 2 {
+		t.Fatalf("usage error must return 2 even on Windows: got %d", code)
+	}
+}
+
+// TestNearestExistingDir exercises the ancestor walk behind the missing-hub
+// writability check deterministically, with no permission mutation.
+func TestNearestExistingDir(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c", "d")
+	if got := nearestExistingDir(deep); got != root {
+		t.Fatalf("nearestExistingDir(%q) = %q, want %q", deep, got, root)
+	}
+	if got := nearestExistingDir(root); got != root {
+		t.Fatalf("nearestExistingDir(existing) = %q, want %q", got, root)
+	}
+}
+
+// TestDoctorHubUnwritableAncestorFails covers the P2 branch: a not-yet-created
+// hub whose nearest existing parent is unwritable must FAIL (the first write's
+// MkdirAll would fail). Guarded off Windows (which ignores unix perms) and root
+// (which bypasses them).
+func TestDoctorHubUnwritableAncestorFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix directory permissions; Windows ignores 0o555")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked")
+	if err := os.Mkdir(locked, 0o555); err != nil { // read+execute, no write
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0o755) }) // let TempDir cleanup remove it
+	in := installedFixture(t)
+	in.hub = filepath.Join(locked, "hub") // missing; nearest ancestor is unwritable
+	if levelOf(t, diagnose(in), "hub") != levelFail {
+		t.Fatal("a missing hub under an unwritable parent must FAIL")
+	}
+}
+
+// pinSettingsEnv merges an env-var pin into a settings.json file's top-level
+// "env" block, mirroring the documented DIRECTOR_BIN pinning edit.
+func pinSettingsEnv(t *testing.T, path, key, val string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatal(err)
+	}
+	env, _ := root["env"].(map[string]any)
+	if env == nil {
+		env = map[string]any{}
+	}
+	env[key] = val
+	root["env"] = env
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/colinsurprenant/director/internal/install"
 )
 
+// skipUnixOnlyDoctor marks a test that exercises doctor's diagnose engine, which
+// models Unix hook resolution: executable shim bits and the install bin symlink
+// (writeBinSymlink no-ops on native Windows, and Go reports files without 0o111
+// there). Production `director doctor` short-circuits on native Windows before
+// diagnose, so these paths only ever run on Unix/WSL — matching install_test's
+// own bin-symlink skip.
+func skipUnixOnlyDoctor(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("doctor's diagnose engine is Unix/WSL-only; native Windows short-circuits before it")
+	}
+}
+
 // installedFixture performs a real `install.Install` into temp dirs (honoring the
 // DIRECTOR_* overrides) and returns doctorInputs describing that healthy state.
 // diagnose is then tested against genuine install output, not a hand-built mock —
@@ -19,6 +32,7 @@ import (
 // passes via the symlink without touching the ambient PATH.
 func installedFixture(t *testing.T) doctorInputs {
 	t.Helper()
+	skipUnixOnlyDoctor(t)
 	root := t.TempDir()
 	hooksDir := filepath.Join(root, "hooks")
 	t.Setenv("DIRECTOR_HOOKS_DIR", hooksDir)
@@ -190,6 +204,7 @@ func TestDoctorHubMissingIsOK(t *testing.T) {
 // TestRunDoctorSandboxed drives the full CLI wrapper through env overrides so no
 // real ~/.claude or ~/.director is touched, covering the exit codes.
 func TestRunDoctorSandboxed(t *testing.T) {
+	skipUnixOnlyDoctor(t)
 	root := t.TempDir()
 	settings := filepath.Join(root, "settings.json")
 	t.Setenv("DIRECTOR_HOOKS_DIR", filepath.Join(root, "hooks"))
@@ -219,6 +234,7 @@ func TestRunDoctorSandboxed(t *testing.T) {
 // (see TestRunDoctorSandboxed), so a flip to exit 1 can only come from doctor
 // reading the settings-level pin.
 func TestDoctorSettingsPinnedBinBroken(t *testing.T) {
+	skipUnixOnlyDoctor(t)
 	root := t.TempDir()
 	settings := filepath.Join(root, "settings.json")
 	t.Setenv("DIRECTOR_HOOKS_DIR", filepath.Join(root, "hooks"))

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -309,16 +309,45 @@ func TestDoctorNativeWindowsIsCLIOnly(t *testing.T) {
 	}
 }
 
-// TestNearestExistingDir exercises the ancestor walk behind the missing-hub
-// writability check deterministically, with no permission mutation.
-func TestNearestExistingDir(t *testing.T) {
+// TestNearestExistingAncestor exercises the ancestor walk behind the missing-hub
+// creatability check deterministically, with no permission mutation: a deep
+// missing path resolves to its nearest real-dir ancestor; an existing dir returns
+// itself; a regular-file ancestor is a broken surface (error), not a dir to climb.
+func TestNearestExistingAncestor(t *testing.T) {
 	root := t.TempDir()
 	deep := filepath.Join(root, "a", "b", "c", "d")
-	if got := nearestExistingDir(deep); got != root {
-		t.Fatalf("nearestExistingDir(%q) = %q, want %q", deep, got, root)
+	if got, err := nearestExistingAncestor(deep); err != nil || got != root {
+		t.Fatalf("deep-missing: got (%q, %v), want (%q, nil)", got, err, root)
 	}
-	if got := nearestExistingDir(root); got != root {
-		t.Fatalf("nearestExistingDir(existing) = %q, want %q", got, root)
+	if got, err := nearestExistingAncestor(root); err != nil || got != root {
+		t.Fatalf("existing dir: got (%q, %v), want (%q, nil)", got, err, root)
+	}
+	f := filepath.Join(root, "afile")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := nearestExistingAncestor(f); err == nil {
+		t.Fatal("a regular-file ancestor must return an error, not be treated as creatable")
+	}
+}
+
+// TestHubDanglingSymlinkAncestorFails is the reachable false-healthy the naive
+// walk missed: a hub under a dangling-symlink ancestor. Stat follows the link to
+// not-exist and would climb past it, but MkdirAll cannot create through a dangling
+// link, so the hub is uncreatable and must FAIL. Mirrors event.logTrulyAbsent's
+// Lstat tiebreak.
+func TestHubDanglingSymlinkAncestorFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on native Windows")
+	}
+	root := t.TempDir()
+	dangling := filepath.Join(root, "link")
+	if err := os.Symlink(filepath.Join(root, "no-such-target"), dangling); err != nil {
+		t.Fatal(err)
+	}
+	c := hubCheck(filepath.Join(dangling, "hub"))
+	if c.level != levelFail {
+		t.Fatalf("a hub under a dangling-symlink ancestor must FAIL, got level %v: %s", c.level, c.detail)
 	}
 }
 

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/colinsurprenant/director/internal/install"
+)
+
+// installedFixture performs a real `install.Install` into temp dirs (honoring the
+// DIRECTOR_* overrides) and returns doctorInputs describing that healthy state.
+// diagnose is then tested against genuine install output, not a hand-built mock —
+// so a change to what install writes surfaces here. The symlink tier points at
+// the test binary (os.Executable), which is executable, so the binary check
+// passes via the symlink without touching the ambient PATH.
+func installedFixture(t *testing.T) doctorInputs {
+	t.Helper()
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, "hooks")
+	t.Setenv("DIRECTOR_HOOKS_DIR", hooksDir)
+	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
+	settings := filepath.Join(root, "settings.json")
+	if err := install.Install(settings); err != nil {
+		t.Fatalf("install fixture: %v", err)
+	}
+	binPath, err := install.DefaultBinPath()
+	if err != nil {
+		t.Fatalf("resolve bin path: %v", err)
+	}
+	return doctorInputs{
+		directorBin:  "",
+		lookDirector: func() (string, bool) { return "", false }, // rely on the symlink tier
+		settingsPath: settings,
+		hooksDir:     hooksDir,
+		binPath:      binPath,
+		codexHooks:   filepath.Join(root, "no-codex.json"),
+		hub:          root, // a writable directory
+	}
+}
+
+func levelOf(t *testing.T, rep doctorReport, title string) checkLevel {
+	t.Helper()
+	for _, c := range rep.checks {
+		if c.title == title {
+			return c.level
+		}
+	}
+	t.Fatalf("no check titled %q in %+v", title, rep.checks)
+	return levelFail
+}
+
+func hasCheck(rep doctorReport, title string) bool {
+	for _, c := range rep.checks {
+		if c.title == title {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDoctorHealthy(t *testing.T) {
+	rep := diagnose(installedFixture(t))
+	if !rep.healthy {
+		t.Fatalf("want healthy, got %+v", rep.checks)
+	}
+	if lv := levelOf(t, rep, "binary"); lv != levelOK {
+		t.Errorf("binary check: got %v, want OK", lv)
+	}
+	if lv := levelOf(t, rep, "claude code hooks"); lv != levelOK {
+		t.Errorf("hooks check: got %v, want OK", lv)
+	}
+	if hasCheck(rep, "codex hooks") {
+		t.Errorf("codex check must be absent without a Codex install")
+	}
+}
+
+func TestDoctorDirectorBinBrokenFails(t *testing.T) {
+	in := installedFixture(t)
+	in.directorBin = filepath.Join(t.TempDir(), "not-a-binary") // set but non-existent
+	rep := diagnose(in)
+	if levelOf(t, rep, "binary") != levelFail {
+		t.Fatal("a set-but-unresolvable DIRECTOR_BIN must FAIL the binary check (it disables the fallback tiers)")
+	}
+	if rep.healthy {
+		t.Fatal("report must be unhealthy when the binary can't resolve")
+	}
+}
+
+func TestDoctorDirectorBinValidIsOK(t *testing.T) {
+	in := installedFixture(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in.directorBin = exe // the test binary is a real executable
+	if levelOf(t, diagnose(in), "binary") != levelOK {
+		t.Fatal("a valid DIRECTOR_BIN must be OK")
+	}
+}
+
+func TestDoctorPathOnlyWarns(t *testing.T) {
+	in := installedFixture(t)
+	if err := os.Remove(in.binPath); err != nil { // drop the symlink tier
+		t.Fatal(err)
+	}
+	in.lookDirector = func() (string, bool) { return "/usr/local/bin/director", true }
+	rep := diagnose(in)
+	if levelOf(t, rep, "binary") != levelWarn {
+		t.Fatal("director on PATH but no symlink must WARN (desktop-app launches may miss it)")
+	}
+	if !rep.healthy {
+		t.Fatal("a warning must not sink the report — coordination still fires from a terminal")
+	}
+}
+
+func TestDoctorNoResolvableBinaryFails(t *testing.T) {
+	in := installedFixture(t)
+	if err := os.Remove(in.binPath); err != nil {
+		t.Fatal(err)
+	}
+	in.lookDirector = func() (string, bool) { return "", false }
+	rep := diagnose(in)
+	if levelOf(t, rep, "binary") != levelFail {
+		t.Fatal("no tier resolving must FAIL")
+	}
+	if rep.healthy {
+		t.Fatal("report must be unhealthy")
+	}
+}
+
+func TestDoctorNoHooksFails(t *testing.T) {
+	in := installedFixture(t)
+	in.settingsPath = filepath.Join(t.TempDir(), "empty.json") // no managed entries
+	if levelOf(t, diagnose(in), "claude code hooks") != levelFail {
+		t.Fatal("missing hooks in settings.json must FAIL")
+	}
+}
+
+func TestDoctorMissingShimFails(t *testing.T) {
+	in := installedFixture(t)
+	if err := os.Remove(filepath.Join(in.hooksDir, "sessionstart.sh")); err != nil {
+		t.Fatal(err)
+	}
+	if levelOf(t, diagnose(in), "claude code hooks") != levelFail {
+		t.Fatal("a referenced-but-missing shim must FAIL")
+	}
+}
+
+func TestDoctorCodexReportedWhenInstalled(t *testing.T) {
+	in := installedFixture(t)
+	t.Setenv("DIRECTOR_CODEX_SKILLS_DIR", filepath.Join(t.TempDir(), "skills"))
+	codexHooks := filepath.Join(t.TempDir(), "codex-hooks.json")
+	if err := install.InstallCodex(codexHooks); err != nil {
+		t.Fatal(err)
+	}
+	in.codexHooks = codexHooks
+	rep := diagnose(in)
+	if !hasCheck(rep, "codex hooks") {
+		t.Fatal("codex check must appear when a Codex install is present")
+	}
+	if levelOf(t, rep, "codex hooks") != levelOK {
+		t.Fatal("codex hooks must be OK for a fresh Codex install")
+	}
+}
+
+func TestDoctorHubNotADirFails(t *testing.T) {
+	in := installedFixture(t)
+	f := filepath.Join(t.TempDir(), "hub-is-a-file")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	in.hub = f
+	if levelOf(t, diagnose(in), "hub") != levelFail {
+		t.Fatal("a non-directory hub must FAIL")
+	}
+}
+
+func TestDoctorHubMissingIsOK(t *testing.T) {
+	in := installedFixture(t)
+	in.hub = filepath.Join(t.TempDir(), "not-created-yet")
+	if levelOf(t, diagnose(in), "hub") != levelOK {
+		t.Fatal("a not-yet-created hub is OK (created on first write)")
+	}
+}
+
+// TestRunDoctorSandboxed drives the full CLI wrapper through env overrides so no
+// real ~/.claude or ~/.director is touched, covering the exit codes.
+func TestRunDoctorSandboxed(t *testing.T) {
+	root := t.TempDir()
+	settings := filepath.Join(root, "settings.json")
+	t.Setenv("DIRECTOR_HOOKS_DIR", filepath.Join(root, "hooks"))
+	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
+	t.Setenv("DIRECTOR_SETTINGS_PATH", settings)
+	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", filepath.Join(root, "no-codex.json"))
+	t.Setenv("DIRECTOR_HUB", root)
+	t.Setenv("DIRECTOR_BIN", "") // unset override → rely on the symlink tier
+	if err := install.Install(settings); err != nil {
+		t.Fatal(err)
+	}
+	if code := runDoctor(nil); code != 0 {
+		t.Fatalf("healthy install: runDoctor exit = %d, want 0", code)
+	}
+	t.Setenv("DIRECTOR_BIN", filepath.Join(root, "not-a-binary")) // set but broken
+	if code := runDoctor(nil); code != 1 {
+		t.Fatalf("broken DIRECTOR_BIN: runDoctor exit = %d, want 1", code)
+	}
+	if code := runDoctor([]string{"extra"}); code != 2 {
+		t.Fatalf("extra arg: runDoctor exit = %d, want 2", code)
+	}
+}

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -90,6 +90,8 @@ func run(args []string) int {
 		return runInstall(rest)
 	case "uninstall":
 		return runUninstall(rest)
+	case "doctor":
+		return runDoctor(rest)
 	case "_hook":
 		return runHook(rest)
 	case "version", "--version":
@@ -134,6 +136,8 @@ adoption & install:
   install     idempotent merge of Director hooks into settings.json
               (--codex: Codex's hooks.json + $director-* agent skills instead)
   uninstall   remove only Director-managed hook entries (--codex: Codex's)
+  doctor      check the install is healthy: hooks wired and the binary reachable
+              the way the shims resolve it (exits non-zero if not)
 
 misc:
   version     print the director version

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,25 @@ installed Director hooks into /Users/you/.claude/settings.json (set DIRECTOR_SET
   `/director:handoff` (pause a workstream, record the resume point) and `/director:complete` (close out a finished,
   merged workstream). More on the boundary pair in section 5.
 
-Verify it took:
+Verify it took. `director doctor` is the thorough check: it walks the same binary-resolution ladder
+the hooks walk and reports each link (binary, Claude Code hooks, Codex hooks if present, hub), so a
+broken install becomes loud instead of a silent no-op. It exits non-zero when the install is broken,
+and warns (without failing) on a partial one — such as a terminal-only install the desktop app would miss.
+
+```bash
+director doctor
+```
+
+```text
+✓ binary: director resolves on your PATH (/usr/local/bin/director), and the install symlink ~/.claude/director/bin/director backs desktop-app (Dock/Launchpad) launches — both launch contexts covered
+✓ claude code hooks: wired in ~/.claude/settings.json; shims present in ~/.claude/director/hooks
+✓ hub: ~/.director does not exist yet — it is created on first write
+
+✓ Director is healthy: the hooks will fire and coordination is live.
+  (For a repo's coordination state, run `director status`.)
+```
+
+`director status` confirms the read side:
 
 ```bash
 director status
@@ -292,6 +310,10 @@ what `brief` shows and what the next session starts from.
 ---
 
 ## 6. Troubleshooting
+
+Start with **`director doctor`**: it checks the whole install chain (binary resolution, Claude Code and
+Codex hooks, shims present, hub writable) and names the broken link, exiting non-zero when coordination
+would not fire. The table covers the specifics.
 
 | Symptom | Cause & fix |
 |---|---|

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -153,7 +153,7 @@ func codexInstallPresent() bool {
 	if err != nil {
 		return false
 	}
-	return managedEntriesPresent(hooksPath)
+	return ManagedEntriesPresent(hooksPath)
 }
 
 // codexSkillName maps an embedded command filename to its skill name:

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -361,15 +361,16 @@ func claudeInstallPresent() bool {
 	if err != nil {
 		return false
 	}
-	return managedEntriesPresent(settingsPath)
+	return ManagedEntriesPresent(settingsPath)
 }
 
-// managedEntriesPresent reports whether the hooks file at path carries any
-// Director-managed command object — the shared scan behind codexInstallPresent
-// and claudeInstallPresent. Read errors and foreign shapes read as "not
-// present": both callers want the fail-open direction (see codexInstallPresent
-// for why fail-safe would make shim removal permanently leaky).
-func managedEntriesPresent(path string) bool {
+// ManagedEntriesPresent reports whether the hooks file at path carries any
+// Director-managed command object — the shared scan behind codexInstallPresent,
+// claudeInstallPresent, and `director doctor`. Read errors and foreign shapes
+// read as "not present": the uninstall callers want the fail-open direction (see
+// codexInstallPresent for why fail-safe would make shim removal permanently leaky),
+// and doctor treats an unreadable/absent hooks file the same as "not wired".
+func ManagedEntriesPresent(path string) bool {
 	root, err := loadSettings(path)
 	if err != nil {
 		return false
@@ -400,6 +401,24 @@ func managedEntriesPresent(path string) bool {
 		}
 	}
 	return false
+}
+
+// ExpectedShims returns the basenames of the hook shim scripts install writes
+// into the hooks dir. The embedded shims/ dir is the single source of truth, so a
+// consumer that verifies an install (`director doctor`) checks exactly the set
+// install materializes — no drift between what is written and what is checked.
+func ExpectedShims() []string {
+	entries, err := fs.ReadDir(shimFS, "shims")
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names
 }
 
 // writeShims materializes the embedded hook shims into hooksDir, creating the dir

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -442,6 +442,17 @@ func SettingsDirectorBin(path string) (string, bool) {
 	return "", false
 }
 
+// SettingsParseError returns the error from reading and parsing the settings file
+// at path, or nil when the file is absent, empty, or valid JSON. It lets a caller
+// (`director doctor`) tell "the file is fine but carries no Director hooks" apart
+// from "the file is unreadable or malformed" — two states ManagedEntriesPresent
+// collapses to the same false, but whose remedies differ (run install vs. fix the
+// file, which install itself would refuse to overwrite).
+func SettingsParseError(path string) error {
+	_, err := loadSettings(path)
+	return err
+}
+
 // writeShims materializes the embedded hook shims into hooksDir, creating the dir
 // and overwriting any existing shims so they always match THIS binary. Writing is
 // idempotent (re-install reproduces the same files) and atomic per file (temp +

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -421,6 +421,27 @@ func ExpectedShims() []string {
 	return names
 }
 
+// SettingsDirectorBin returns the DIRECTOR_BIN value pinned in the settings
+// file's top-level "env" block, if any. Claude Code injects that env into the
+// hook process, and the shims use DIRECTOR_BIN exclusively when set — so a
+// self-check (`director doctor`) must consult the pinned value, not just the
+// ambient shell env, to predict what the shim will actually resolve. A missing
+// file, absent env block, or non-string/empty value all read as "not pinned".
+func SettingsDirectorBin(path string) (string, bool) {
+	root, err := loadSettings(path)
+	if err != nil {
+		return "", false
+	}
+	env, ok := typedMap(root, "env")
+	if !ok {
+		return "", false
+	}
+	if v := stringAt(env, "DIRECTOR_BIN"); v != "" {
+		return v, true
+	}
+	return "", false
+}
+
 // writeShims materializes the embedded hook shims into hooksDir, creating the dir
 // and overwriting any existing shims so they always match THIS binary. Writing is
 // idempotent (re-install reproduces the same files) and atomic per file (temp +

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -772,3 +772,34 @@ func TestUninstallSparesShimsWhenCodexPresent(t *testing.T) {
 		t.Errorf("with no Codex install left, CC uninstall should remove the shims (err=%v)", err)
 	}
 }
+
+// TestSettingsDirectorBin pins the contract doctor relies on: read a DIRECTOR_BIN
+// pinned in settings.json's env block, and read "not pinned" for every shape that
+// isn't a non-empty string — a missing file, no env block, an empty value, or a
+// non-string value.
+func TestSettingsDirectorBin(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	if v, ok := SettingsDirectorBin(filepath.Join(dir, "does-not-exist.json")); ok {
+		t.Errorf("missing file: got (%q, true), want not pinned", v)
+	}
+	if v, ok := SettingsDirectorBin(write("no-env.json", `{"hooks":{}}`)); ok {
+		t.Errorf("no env block: got (%q, true), want not pinned", v)
+	}
+	if v, ok := SettingsDirectorBin(write("empty.json", `{"env":{"DIRECTOR_BIN":""}}`)); ok {
+		t.Errorf("empty value: got (%q, true), want not pinned", v)
+	}
+	if v, ok := SettingsDirectorBin(write("wrong-type.json", `{"env":{"DIRECTOR_BIN":123}}`)); ok {
+		t.Errorf("non-string value: got (%q, true), want not pinned", v)
+	}
+	if v, ok := SettingsDirectorBin(write("pinned.json", `{"env":{"DIRECTOR_BIN":"/opt/director"}}`)); !ok || v != "/opt/director" {
+		t.Errorf("pinned value: got (%q, %v), want (/opt/director, true)", v, ok)
+	}
+}

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -803,3 +803,22 @@ func TestSettingsDirectorBin(t *testing.T) {
 		t.Errorf("pinned value: got (%q, %v), want (/opt/director, true)", v, ok)
 	}
 }
+
+// TestExpectedShims locks the invariant doctor's missingShims relies on: the set
+// is sourced from the embedded shims/ dir, which `//go:embed shims/*.sh` requires
+// be non-empty at BUILD time (the build fails otherwise), so fs.ReadDir cannot
+// fail and the nil-on-error path is unreachable in a real binary. Asserting the
+// exact set here turns any future break of that embed into a loud test failure
+// rather than a silently-empty expected set (which would weaken the shim check).
+func TestExpectedShims(t *testing.T) {
+	got := ExpectedShims()
+	want := map[string]bool{"sessionstart.sh": true, "posttooluse.sh": true, "stop.sh": true}
+	if len(got) != len(want) {
+		t.Fatalf("ExpectedShims() = %v, want the %d embedded shims %v", got, len(want), want)
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("ExpectedShims() returned unexpected %q; want exactly %v", name, want)
+		}
+	}
+}


### PR DESCRIPTION
Adds `director doctor`, a read-only install self-check that answers the one question the fail-safe hooks can't: **will Director actually fire?** The shims exit 0 when they can't resolve the binary, so a broken install is invisible — `doctor` walks the same resolution ladder the shims walk and turns that silent dead state into a loud, checkable one.

## What it checks

- **binary** — the `DIRECTOR_BIN` → `director` on PATH → install-symlink ladder the shims walk, including a `DIRECTOR_BIN` pinned in settings.json's `env` block (what Claude Code injects into the hook)
- **claude code hooks** — Director's tagged entries present in settings.json and the shims materialized
- **codex hooks** — reported only when a Codex install is present
- **hub** — present and writable, or creatable (its nearest existing ancestor is writable)

Exits non-zero when the install is broken; warns without failing on a partial one (e.g. a terminal-only install the desktop app would miss). On native Windows it reports the CLI-only state and points at WSL, rather than emitting failures whose only remedy (`director install`) also refuses.

## Review

Ran the standing convention — codex adversarial pass + `ce:code-reviewer`:

- **codex** flagged the settings.json-`env` `DIRECTOR_BIN` blind spot (P1, a real false-healthy — fixed via `install.SettingsDirectorBin`), hub ancestor writability (P2 — fixed, matches the ancestor-walk in `736cda4`), plus resolution-message faithfulness (PATH-before-symlink order).
- **ce:code-reviewer** approved, and caught the native-Windows remediation loop (fixed) and an exit-code doc overstatement (fixed).
- Deferred as an open-item (codex P1-3): verifying all four managed hook entries are wired, not just that one tagged entry exists — the write side is atomic, so the real risk is low.

## Gate

`go test ./... -race` green; `gofmt`/`vet` clean. New tests cover the settings-pin false-healthy end to end, the native-Windows path, the hub ancestor walk, and `SettingsDirectorBin` edge cases.

Part of the Phase-0 seal-the-funnel diffusion arc (step 0.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
