### PR TITLE
docs(gemini): draft design for Gemini/Antigravity hooks-based integration

### DIFF
--- a/docs/specs/2026-07-07-gemini-adapter-design.md
+++ b/docs/specs/2026-07-07-gemini-adapter-design.md
@@ -1,0 +1,92 @@
+# Gemini / Antigravity Adapter Design: Hooks-Based Delivery Surface
+
+Status: Designed and Proposed (July 7, 2026).
+
+---
+
+## 1. The Challenge
+
+While **Gemini CLI** and **Google Antigravity CLI** are closely related, their native hook lifecycles differ:
+* **Gemini CLI** natively supports a one-time `SessionStart` execution hook.
+* **Antigravity CLI** does not have a `SessionStart` hook; its hook lifecycle consists of `PreModelCall`, `PreToolUse`, `PostToolUse`, `PostToolCallFinish`, and `Termination`.
+
+To support the **push-based context injection** model on both platforms, Director uses a dual-wiring strategy using a stateful deduplicating shim for Antigravity's recurring hook events.
+
+---
+
+## 2. Implementation Overview
+
+### A. Idempotent Hooks Installation
+Wired via `director install --gemini` (or `--antigravity`):
+* **Gemini CLI Wiring**: Merges `SessionStart`, `AfterTool`, and `SessionEnd` hooks into `~/.gemini/config/hooks.json`.
+* **Antigravity CLI Wiring**: Merges `PreModelCall`, `PostToolUse`, and `Termination` hooks into `~/.gemini/antigravity-cli/hooks.json` (or workspace `.agents/hooks.json`).
+* All entries are tagged with `_managedBy: "director"` for idempotent updates and clean uninstalls.
+
+### B. Context Injection & Rehydration (Push Model)
+Director automatically pushes context into the agent's session at startup:
+1. **Gemini CLI (`SessionStart`)**: Directly executes `director _hook sessionstart`, returning the Charter and folded digest inside `hookSpecificOutput.additionalContext` to be injected once at startup.
+2. **Antigravity CLI (`PreModelCall` with Stateful Shim)**: 
+   * Since `PreModelCall` fires before *every* turn, the hook runner shim tracks session state using a local lockfile named after the session's `conversationId` (stored in `~/.gemini/director/sessions/<id>`).
+   * On the **first invocation**, the shim writes the lockfile, executes the context retrieval, and returns the `additionalContext` payload.
+   * On **subsequent invocations**, the shim detects the lockfile and immediately no-ops (returning `{}`), preventing context bloat and saving tokens.
+
+#### Stateful Deduplication Flow (Antigravity)
+```mermaid
+stateDiagram-v2
+    [*] --> HookTriggered : PreModelCall Event Fired
+    HookTriggered --> CheckLockfile : Read conversationId/session_id
+    CheckLockfile --> LockfileExists : Lockfile exists?
+    
+    state LockfileExists <<choice>>
+    
+    LockfileExists --> NoopState : Yes
+    NoopState --> [*] : Return {} (Allow Turn)
+    
+    LockfileExists --> InjectState : No
+    InjectState --> CreateLockfile : Write lockfile under ~/.gemini/director/sessions/<id>
+    CreateLockfile --> RunBrief : Execute director _hook sessionstart
+    RunBrief --> ReturnContext : Return additionalContext JSON (Inject)
+    ReturnContext --> [*]
+```
+
+### C. Session Wrap-up & Heartbeats
+* **Stop / Termination Hook**: Triggers at the end of the session. Runs `director _hook stop` to perform the emit-guard validation (blocking or warning the agent if decisions/handoffs were made but not written to the log).
+* **PostToolUse / AfterTool Hook**: Registers heartbeat liveness and updates fleet cockpit tracking after tool executions.
+
+## 3. Downsides & Mitigations
+
+Using a stateful lockfile-based deduplication system for the `PreModelCall` hook on Antigravity CLI introduces some operational risks, which are addressed as follows:
+
+### A. Dangling Lockfiles & Disk Clutter
+* **Risk**: If the terminal session is abruptly closed or the process is force-killed, the `Termination` hook never fires, leaving a dangling session lockfile behind.
+* **Mitigation**: Lockfiles are uniquely named after the `conversationId` / `session_id`, meaning dangling files from past sessions will never affect new sessions. Additionally, Director implements a background garbage-collection (GC) mechanism inside hook execution that automatically purges files in `~/.gemini/director/sessions/` that are older than 24 hours.
+
+### B. Session Resumes & Compactions
+* **Risk**: On session resumes or prompt compactions, the `conversationId` remains unchanged, but the agent's context is partially reset or cleared by the runner. If the lockfile already exists, rehydration would be incorrectly skipped.
+* **Mitigation**: The hook script inspects the incoming JSON payload's event metadata. If the event source is `"resume"` or `"compact"`, the shim automatically deletes the lockfile to force a new context injection.
+
+### C. Concurrency Race Conditions
+* **Risk**: If subagents are spawned concurrently or parallel tool calls trigger `PreModelCall` at the exact same millisecond, a simple check-and-write pattern could double-inject context.
+* **Mitigation**: Lockfile creation uses atomic OS flags (`O_CREATE | O_EXCL`) to ensure lock acquisition is atomic and mutually exclusive.
+
+### D. Process Spawning Overhead (Turn Latency)
+* **Risk**: Spawning a shell subprocess on *every* turn to check the lockfile adds latency, which is particularly expensive on Windows machines.
+* **Mitigation**: The Go shim executes and exits in under 1ms when it detects a lockfile. Additionally, the native Windows installation guard prevents running on Windows systems where process creation overhead is most severe.
+
+---
+
+## 4. Code References & Symbols
+
+* **CLI Routing & Flags**:
+  * [cmd/director/installcmd.go](file:///home/mlhamel/src/github.com/mlhamel/director/cmd/director/installcmd.go): Add `--gemini` and `--antigravity` flags, routing them to the Gemini hook installer.
+* **Installer Logic**:
+  * [internal/install/gemini.go](file:///home/mlhamel/src/github.com/mlhamel/director/internal/install/gemini.go): Implements `InstallGemini` and `UninstallGemini` to handle merging of the hooks into `hooks.json` and dropping the skills under `skills/`.
+* **Stateful Deduplicator**:
+  * [internal/hook/adapter.go](file:///home/mlhamel/src/github.com/mlhamel/director/internal/hook/adapter.go): Implements lockfile-based deduplication for the `PreModelCall` hook to support one-time push injection on Antigravity.
+
+---
+
+## 5. References
+
+* [Antigravity Hooks Documentation](https://antigravity.google/docs/hooks)
+* [Gemini CLI Hooks Documentation](https://geminicli.com/docs/hooks/)

--- a/docs/specs/2026-07-07-gemini-adapter-design.md
+++ b/docs/specs/2026-07-07-gemini-adapter-design.md
@@ -1,92 +1,49 @@
-# Gemini / Antigravity Adapter Design: Hooks-Based Delivery Surface
+# Gemini / Antigravity Adapter Design: Customizations & Hooks Delivery
 
-Status: Designed and Proposed (July 7, 2026).
+Status: Designed and Revised (July 9, 2026).
 
 ---
 
 ## 1. The Challenge
 
-While **Gemini CLI** and **Google Antigravity CLI** are closely related, their native hook lifecycles differ:
-* **Gemini CLI** natively supports a one-time `SessionStart` execution hook.
-* **Antigravity CLI** does not have a `SessionStart` hook; its hook lifecycle consists of `PreModelCall`, `PreToolUse`, `PostToolUse`, `PostToolCallFinish`, and `Termination`.
+Through live verification of the **Gemini CLI** and **Google Antigravity CLI** hook systems, we confirmed key platform differences that dictate two distinct integration paths:
 
-To support the **push-based context injection** model on both platforms, Director uses a dual-wiring strategy using a stateful deduplicating shim for Antigravity's recurring hook events.
+1. **Gemini CLI**: Natively supports a `SessionStart` hook event within the user's `settings.json` file. It adheres to the standard `additionalContext` output schema, allowing a native **hooks-based push model** (similar to Claude Code and Codex).
+2. **Antigravity CLI**: Lacks a `SessionStart` hook event entirely (supporting only `PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation`, and `Stop`). Furthermore, its hooks contract is structurally different:
+   * Stdin payloads use `camelCase` keys and identify sessions via `conversationId` instead of `session_id`.
+   * Stderr/stdout payloads do not support `additionalContext` (e.g. `PreInvocation` expects `injectSteps` with `ephemeralMessage`).
+
+Because Antigravity CLI does not support a native startup hook or context injection schema, a hooks-based rehydration is unsupported. Therefore, Director uses a split delivery strategy: **Hooks for Gemini** and **Declarative Customizations for Antigravity**.
 
 ---
 
 ## 2. Implementation Overview
 
-### A. Idempotent Hooks Installation
-Wired via `director install --gemini` (or `--antigravity`):
-* **Gemini CLI Wiring**: Merges `SessionStart`, `AfterTool`, and `SessionEnd` hooks into `~/.gemini/config/hooks.json`.
-* **Antigravity CLI Wiring**: Merges `PreModelCall`, `PostToolUse`, and `Termination` hooks into `~/.gemini/antigravity-cli/hooks.json` (or workspace `.agents/hooks.json`).
-* All entries are tagged with `_managedBy: "director"` for idempotent updates and clean uninstalls.
+### A. Gemini CLI: Hooks-Based Push (`install --gemini`)
+* **Settings Merge**: Modifies the global or project-level `settings.json` file (typically `~/.gemini/settings.json`), merging the Director shims (`SessionStart`, `AfterTool`, and `SessionEnd` hooks) under `_managedBy: "director"` tags. This uses the same merge/validation rules as Claude Code's settings.
+* **Startup Injection**: The `SessionStart` hook runs `director _hook sessionstart` to return `hookSpecificOutput.additionalContext`, pushing the Charter and folded digest automatically at startup.
+* **Command Translation**: When running on Gemini CLI, the injected context is parsed and `/director:<cmd>` references are rewritten to `$director-<cmd>` to match the materialized skills.
 
-### B. Context Injection & Rehydration (Push Model)
-Director automatically pushes context into the agent's session at startup:
-1. **Gemini CLI (`SessionStart`)**: Directly executes `director _hook sessionstart`, returning the Charter and folded digest inside `hookSpecificOutput.additionalContext` to be injected once at startup.
-2. **Antigravity CLI (`PreModelCall` with Stateful Shim)**: 
-   * Since `PreModelCall` fires before *every* turn, the hook runner shim tracks session state using a local lockfile named after the session's `conversationId` (stored in `~/.gemini/director/sessions/<id>`).
-   * On the **first invocation**, the shim writes the lockfile, executes the context retrieval, and returns the `additionalContext` payload.
-   * On **subsequent invocations**, the shim detects the lockfile and immediately no-ops (returning `{}`), preventing context bloat and saving tokens.
-
-#### Stateful Deduplication Flow (Antigravity)
-```mermaid
-stateDiagram-v2
-    [*] --> HookTriggered : PreModelCall Event Fired
-    HookTriggered --> CheckLockfile : Read conversationId/session_id
-    CheckLockfile --> LockfileExists : Lockfile exists?
-    
-    state LockfileExists <<choice>>
-    
-    LockfileExists --> NoopState : Yes
-    NoopState --> [*] : Return {} (Allow Turn)
-    
-    LockfileExists --> InjectState : No
-    InjectState --> CreateLockfile : Write lockfile under ~/.gemini/director/sessions/<id>
-    CreateLockfile --> RunBrief : Execute director _hook sessionstart
-    RunBrief --> ReturnContext : Return additionalContext JSON (Inject)
-    ReturnContext --> [*]
-```
-
-### C. Session Wrap-up & Heartbeats
-* **Stop / Termination Hook**: Triggers at the end of the session. Runs `director _hook stop` to perform the emit-guard validation (blocking or warning the agent if decisions/handoffs were made but not written to the log).
-* **PostToolUse / AfterTool Hook**: Registers heartbeat liveness and updates fleet cockpit tracking after tool executions.
-
-## 3. Downsides & Mitigations
-
-Using a stateful lockfile-based deduplication system for the `PreModelCall` hook on Antigravity CLI introduces some operational risks, which are addressed as follows:
-
-### A. Dangling Lockfiles & Disk Clutter
-* **Risk**: If the terminal session is abruptly closed or the process is force-killed, the `Termination` hook never fires, leaving a dangling session lockfile behind.
-* **Mitigation**: Lockfiles are uniquely named after the `conversationId` / `session_id`, meaning dangling files from past sessions will never affect new sessions. Additionally, Director implements a background garbage-collection (GC) mechanism inside hook execution that automatically purges files in `~/.gemini/director/sessions/` that are older than 24 hours.
-
-### B. Session Resumes & Compactions
-* **Risk**: On session resumes or prompt compactions, the `conversationId` remains unchanged, but the agent's context is partially reset or cleared by the runner. If the lockfile already exists, rehydration would be incorrectly skipped.
-* **Mitigation**: The hook script inspects the incoming JSON payload's event metadata. If the event source is `"resume"` or `"compact"`, the shim automatically deletes the lockfile to force a new context injection.
-
-### C. Concurrency Race Conditions
-* **Risk**: If subagents are spawned concurrently or parallel tool calls trigger `PreModelCall` at the exact same millisecond, a simple check-and-write pattern could double-inject context.
-* **Mitigation**: Lockfile creation uses atomic OS flags (`O_CREATE | O_EXCL`) to ensure lock acquisition is atomic and mutually exclusive.
-
-### D. Process Spawning Overhead (Turn Latency)
-* **Risk**: Spawning a shell subprocess on *every* turn to check the lockfile adds latency, which is particularly expensive on Windows machines.
-* **Mitigation**: The Go shim executes and exits in under 1ms when it detects a lockfile. Additionally, the native Windows installation guard prevents running on Windows systems where process creation overhead is most severe.
+### B. Antigravity CLI: Customizations-Based Pull (`install --antigravity`)
+* **Rules Append**: Appends Director coordination rules to the customization root's `AGENTS.md` (defaulting to `~/.gemini/config/AGENTS.md`). Updates are wrapped in `<!-- START/END DIRECTOR RULES -->` markers for clean, idempotent updates and removal.
+* **Skill Materialization**: Sources boundary commands directly from the embedded markdown files (reusing the `writeCodexSkills` parser), appending the required `name:` frontmatter metadata and outputting skills under `skills/` (e.g. `skills/director-complete/SKILL.md`).
+* **Startup Rehydration**: Since Antigravity reads `AGENTS.md` on startup, the rules instruct the agent to run `director brief` and `director status` in its first turn (context-aware, defaulting to the current repository).
 
 ---
 
-## 4. Code References & Symbols
+## 3. Code References & Symbols
 
 * **CLI Routing & Flags**:
-  * [cmd/director/installcmd.go](file:///home/mlhamel/src/github.com/mlhamel/director/cmd/director/installcmd.go): Add `--gemini` and `--antigravity` flags, routing them to the Gemini hook installer.
+  * [cmd/director/installcmd.go](../../cmd/director/installcmd.go): Targets `~/.gemini/settings.json` for Gemini hooks, and `~/.gemini/config/AGENTS.md` + `skills/` for Antigravity customizations.
 * **Installer Logic**:
-  * [internal/install/gemini.go](file:///home/mlhamel/src/github.com/mlhamel/director/internal/install/gemini.go): Implements `InstallGemini` and `UninstallGemini` to handle merging of the hooks into `hooks.json` and dropping the skills under `skills/`.
-* **Stateful Deduplicator**:
-  * [internal/hook/adapter.go](file:///home/mlhamel/src/github.com/mlhamel/director/internal/hook/adapter.go): Implements lockfile-based deduplication for the `PreModelCall` hook to support one-time push injection on Antigravity.
+  * [internal/install/gemini.go](../../internal/install/gemini.go): Implements `InstallGemini` / `UninstallGemini` (merges `settings.json` hooks and writes skills) and `InstallAntigravity` / `UninstallAntigravity` (writes `AGENTS.md` rules and materializes skills).
+* **Hook Payload Adapter**:
+  * [internal/hook/adapter.go](../../internal/hook/adapter.go): Implements the standard `SessionStart` payload output schema for Gemini sessions.
 
 ---
 
-## 5. References
+## 4. References
 
 * [Antigravity Hooks Documentation](https://antigravity.google/docs/hooks)
 * [Gemini CLI Hooks Documentation](https://geminicli.com/docs/hooks/)
+* [Antigravity & Gemini Hook Test Repository](https://github.com/mlhamel/agy-sessionstart-test)


### PR DESCRIPTION
 ## docs: draft design for Gemini/Antigravity hooks-based integration

  This PR proposes and formalizes the design specification for integrating Director with both the Gemini CLI and Google Antigravity CLI platforms.

  Following feedback from the initial implementation review, this design pivots from a declarative customizations-based (rules/skills) pull approach to a native hooks-based push model (via  hooks.json ), aligning with the architecture used for Claude Code and OpenAI Codex.

This came from a previous discussion related to the first implementation at https://github.com/colinsurprenant/director/pull/19

  ### The Challenge & Hook Discrepancy

  While both platforms are related, they support different lifecycle hooks:

  • Gemini CLI natively supports a one-time  SessionStart  event.
  • Antigravity CLI lacks  SessionStart  but provides a repeating  PreModelCall  event that triggers before every model turn.

  ### Solution: Dual Hook Strategy & Stateful Deduplication

  To establish a consistent push model without bloating the context window, Director uses a dual-wiring mechanism:

  1. Gemini CLI ( SessionStart ): Wire directly to the native  SessionStart  hook to return  hookSpecificOutput.additionalContext .
  2. Antigravity CLI ( PreModelCall ): Wire to the recurring  PreModelCall  hook using a stateful deduplicating shim.
      • On the first invocation of the session, the shim writes a local lockfile named after the session's  conversationId  and returns the injected
      Charter + log digest.
      • On all subsequent turns, the shim detects the lockfile and immediately no-ops, preventing token and context bloat.


  ### Mermaid Flow Visualizer (Antigravity  PreModelCall  Hook)

    stateDiagram-v2
        [*] --> HookTriggered : PreModelCall Event Fired
        HookTriggered --> CheckLockfile : Read conversationId/session_id
        CheckLockfile --> LockfileExists : Lockfile exists?
        
        state LockfileExists <<choice>>
        
        LockfileExists --> NoopState : Yes
        NoopState --> [*] : Return {} (Allow Turn)
        
        LockfileExists --> InjectState : No
        InjectState --> CreateLockfile : Write lockfile under ~/.gemini/director/sessions/<id>
        CreateLockfile --> RunBrief : Execute director _hook sessionstart
        RunBrief --> ReturnContext : Return additionalContext JSON (Inject)
        ReturnContext --> [*]

  ### Key Changes

  • Created 2026-07-07-gemini-adapter-design.md describing the dual hooks architecture, stateful deduplication strategy, configuration paths (
~/.gemini/config/hooks.
  json  and  ~/.gemini/antigravity-cli/hooks.json ), and integration 