### PR TITLE
docs: single-machine caveat + bump install example to v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Wire Codex instead with `sh -s -- --codex` (or `--both`); install the binary onl
 
 > **On Windows?** Run the one-liner inside [WSL](https://learn.microsoft.com/windows/wsl/) with the Linux binary: everything works there, hooks included. Native Windows is CLI-only for now: the binary is built and CI-tested, and every manual verb (`emit`, `render`, `status`, `brief`, `show`, `resolve`, …) works from PowerShell, but the hook shims are bash, so the ambient layer — session-start injection, heartbeats, boundary nudges — is not yet wired natively.
 
+> **One machine for now.** Director's hub lives on the machine you install it on; there is no cross-machine sync yet. Work a repo from two machines (a laptop and a desktop, say) and each keeps its own separate hub: neither sees the other's decisions, open loops, or handoffs. Multi-machine sync is the one distribution mode on the roadmap (see [Status & scope](#status--scope)); until then, drive a given repo's Director state from a single machine.
+
 **Other ways in:** prebuilt binaries for macOS, Linux, and Windows (amd64/arm64) are on the [releases page](https://github.com/colinsurprenant/director/releases) ([`docs/getting-started.md`](docs/getting-started.md) covers install-from-release), `go install github.com/colinsurprenant/director/cmd/director@latest` builds from source (Go 1.25+), or build it yourself:
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ sudo install bin/director /usr/local/bin/director   # or copy anywhere on PATH
 ```
 
 Confirm the binary resolves with `director version`. A release or `go install` binary prints its
-version (e.g. `director v1.4.0`); a `go build` from a git clone prints the version Go derives from
+version (e.g. `director v1.7.0`); a `go build` from a git clone prints the version Go derives from
 the checkout (a tag or pseudo-version, `+dirty` if modified); `director dev` appears only when no
 VCS metadata is available.
 
@@ -63,6 +63,12 @@ Linux. On native Windows the CLI itself works (build and tests run in CI on `win
 native Windows cannot execute, so the ambient layer (session-start injection, heartbeats, boundary
 nudges) is not wired there yet. You can still use the manual verbs (`emit`, `render`, `status`, `brief`, `show`,
 `resolve`) from PowerShell.
+
+**Single-machine note.** Director's hub lives on the machine you install it on; there is no
+cross-machine sync yet. If you work a repo from two machines (a laptop and a desktop, say), each keeps
+its own separate hub, and neither sees the other's decisions, open loops, or handoffs. Multi-machine
+sync is on the roadmap (see [`../README.md`](../README.md) "Status & scope"); until then, drive a
+given repo's Director state from a single machine.
 
 ### Wire the hooks
 


### PR DESCRIPTION
0.5 seal-the-funnel: loud single-machine caveat in install/onboarding copy (README + getting-started), so a laptop+desktop user isn't surprised by two divergent hubs. Pre-tag: bump the install-from-release version example to v1.7.0 — the tag that first ships `director doctor` and the curl|sh installer.

Docs-only. Precedes the v1.7.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)