### PR TITLE
docs: reframe hero copy around the session boundary, not project count

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Memory tools answer *"what does the agent know?"* Director answers *"what is the
 
 Three weeks after you park a project, a new session starts already knowing all of this: injected at session start as ground truth, not recalled by similarity.
 
-You work with a coding agent (Claude Code, OpenAI Codex, or both) across several projects, in blocks: days or weeks deep in one, an afternoon in another, back to the first, sometimes a few parallel worktree sessions in a burst. The state of the work is exactly what nothing else carries across those boundaries, so the human becomes the message bus, re-explaining last month's decision to this morning's session. Director moves you from **message bus** to **reviewer**. It is a standalone Go CLI built around a shared, durable, **append-only event log** per repo:
+Every session with a coding agent starts fresh on the state of the work: what was decided and why, which loops you left open on purpose, where the last block stopped. Most people carry that across by hand (a CLAUDE.md, a notes file, a "write a handoff for the next one" before they stop), and that instinct is right; a hand-kept record just rides on you remembering, has no open-vs-closed lifecycle, and doesn't survive two sessions at once. **The session boundary is where the state leaks**: one repo or many, whether it's a compaction, a session ending, a week away, or a parallel worktree. Director closes that leak and moves you from **message bus** to **reviewer**. You don't operate it: it wires into Claude Code and Codex through hooks, the session emits as it works, and that state is injected into the next one as ground truth. It is built around a shared, durable, **append-only event log** per repo:
 
 - Sessions **`emit`** typed events as they work (`decision` · `open-item` · `handoff` · `note`) and **`resolve`** open loops when they truly close.
 - A deterministic fold collapses the log into **`render`** (the machine digest), **`brief`** (the human re-orientation view), and **`status`** (the one-line-per-workstream cockpit).
@@ -47,7 +47,7 @@ $ claude
 
 *The same three facts on both sides of the gap: recorded as the session works, injected when the next one starts.*
 
-That is one workstream. `director status` is the whole portfolio at a glance:
+That is one workstream. When several are in flight, `director status` is the whole board at a glance:
 
 ```text
 acme-api-main-7c21e9d4 · active · just now · blocked(1): timezone edge case before the backfill merges

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,12 @@
 # Getting started with Director
 
-You work with a coding agent (Claude Code, OpenAI Codex, or both) across several projects in blocks: days or weeks deep in one repo, an afternoon
-in another, back to the first, sometimes a burst of parallel worktree sessions. Director keeps that
-portfolio coordinated without you being the message bus. Sessions write durable coordination state
-(decisions, open loops, handoffs) to a shared append-only LOG; every new session starts from that record
-instead of from git archaeology, so re-entering a project you haven't touched in weeks picks up exactly
-where the last block left off. You read deterministic projections (`status`, `brief`) and step in
-only where a human is actually needed.
+Every session with a coding agent starts fresh on the state of the work: what was decided, which loops
+are open, where the last one stopped. **The session boundary is where the state leaks**, whether you
+have one repo or many. Director closes the leak: sessions write durable coordination state (decisions,
+open loops, handoffs) to a shared append-only LOG as they work, and every new session starts from that
+record instead of from git archaeology, so re-entering a project you haven't touched in weeks picks up
+exactly where the last block left off. You don't operate it: you read the projections (`status`,
+`brief`) and step in only where a human is actually needed.
 
 This guide walks the first run end to end, written in Claude Code terms with the Codex differences
 called out where they exist (see "Using OpenAI Codex?" in section 1). Go is only needed for the

--- a/docs/why-director.md
+++ b/docs/why-director.md
@@ -6,15 +6,17 @@
 
 ## The problem
 
-You work with coding agents across several projects. Not all at once, but in **blocks**: a few days or weeks deep in one project, an afternoon in another, back to the first. Some blocks overlap; occasionally you run two or three sessions in parallel worktrees. Over weeks, that adds up to a real fleet of workstreams, most of them dormant at any given moment, all of them still *yours*.
+Every session with a coding agent starts fresh on the state of the work. Most people carry it across by hand: a CLAUDE.md, a notes file, a "write a handoff for the next one" before they stop. That instinct is right, but a hand-kept record rides on you remembering, has no open-vs-closed lifecycle, and doesn't survive two sessions at once. **The session boundary is where the state leaks**: one repo or many, whether a compaction, a session ending, a week away, or a parallel worktree.
 
-Every session starts amnesiac about exactly the layer that matters across those boundaries. Native agent memory has gotten good at *facts*: what the project is, how the build works, your preferences. What nothing carries is the **coordination narrative**: what was decided and why, which loops were deliberately deferred, where the work stopped when the block ended, and what still needs *you*. So the human becomes the message bus, re-explaining last month's decision to this morning's session, re-discovering their own open loops by grepping git history, relaying context by hand between a worktree session and the main one.
+And it compounds. Work in **blocks** over weeks (a few days deep in one project, an afternoon in another, back to the first, occasionally two or three sessions in parallel worktrees) and that adds up to a real fleet of workstreams, most dormant at any given moment, all of them still *yours*.
+
+The leak is specific. Native agent memory has gotten good at *facts*: what the project is, how the build works, your preferences. What nothing carries is the **coordination narrative**: what was decided and why, which loops were deliberately deferred, where the work stopped when the block ended, and what still needs *you*. So you become the message bus, re-explaining last month's decision to this morning's session, re-discovering your own open loops by grepping git history, relaying context by hand between a worktree session and the main one.
 
 Director exists to move you from **message bus** to **reviewer**.
 
 ## What Director is
 
-A standalone Go CLI (single static binary, no daemon, no database, no cloud) that gives your sessions a shared, durable, **append-only event log** per repo, plus **deterministic projections** over it:
+You don't operate Director; your agents do. It installs into Claude Code and Codex as hooks, so the writing happens as sessions work and the state is there waiting when the next one starts. What it maintains is a shared, durable, **append-only event log** per repo (one static Go binary: no daemon, no database, no cloud), plus **deterministic projections** over it:
 
 - Sessions **emit** typed events as they work, using exactly four kinds (`decision`, `open-item`, `handoff`, `note`), and **resolve** open-items when they are truly closed.
 - A deterministic, non-LLM fold collapses the log into three views: `render` (the machine digest), `brief` (the human re-orientation view), and `status` (the one-line-per-workstream cockpit with a *Needs-you* band).

--- a/site/index.html
+++ b/site/index.html
@@ -261,8 +261,9 @@
   </div>
   <p class="facts reveal d3"><span class="f">what was decided, and why</span> <span class="sep">·</span> <span class="f">which loops are still open</span> <span class="sep">·</span> <span class="f">where the work stopped</span> <span class="sep">·</span> <span class="f">what still needs you</span></p>
   <p class="lede reveal d3">
-    Nothing in a memory store ever <strong>closes</strong>. Your agents keep the ledger as they
-    work; you never write a status update. <strong>You review.</strong>
+    <strong>The session boundary is where the state leaks.</strong> Nothing in a memory store ever
+    <strong>closes</strong>. Your agents keep the ledger as they work; you never write a status
+    update. <strong>You review.</strong>
   </p>
   <div class="install reveal d4">
     <div class="cmd">


### PR DESCRIPTION
## What

Reframes the hero/opening copy of the README, why-director, and getting-started (plus the site lede) around the **session boundary**, not project count.

## Why (three positioning problems, recorded as LOG decisions)

1. **Multi-project lead** (`01KWZR3SEP`): the openings led with "you work across several projects in blocks", so single-project users self-selected out. The pain is the session boundary, which fires identically on one repo (a compaction, a session ending, a week away, a parallel worktree) as on many.
2. **Selling against competence** (`01KWZSFZ4D`): the copy framed the reader as failing to track state. Advanced users with good doc hygiene felt accused and bounced. It now validates the hand-rolled fix (CLAUDE.md / "write a handoff for the next one") and pitches Director as that instinct made structural.
3. **CLI-recoil** (note `01KWZTT0R4`): "a standalone Go CLI" headlined as if you operate it. Reframed to "you don't operate it: it wires in through hooks, the model emits, you read"; the binary facts stay as a trust aside.

Canonical tagline **"the session boundary is where the state leaks"** promoted into all four surfaces.

## Changes
- **README.md**: flagship intro rewrite (`:14`); soften "whole portfolio" to "when several are in flight, the whole board" (`:50`).
- **docs/why-director.md**: reframe The Problem (session-boundary + validation + tagline; portfolio becomes the compounding second beat); lead "What Director is" with "you don't operate it".
- **docs/getting-started.md**: same session-boundary-first opening, lighter.
- **site/index.html**: prepend the tagline to the hero lede.

## Kept deliberately
The "portfolio, not a swarm" pillar and "message bus to reviewer" (both intentional brand; the portfolio is real, it is just no longer the lead).

## Gate
`go test ./... -race` green; `go build` clean. Docs-only, no code changed.

## Needs an eyeball
The **site/index.html** lede change is the one I could not self-verify rendered. Please glance at the landing hero before merge (worst case it is one sentence to tweak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
