### PR TITLE
docs: general cleanup of reader-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![ci](https://github.com/colinsurprenant/director/actions/workflows/ci.yml/badge.svg)](https://github.com/colinsurprenant/director/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/colinsurprenant/director?display_name=tag)](https://github.com/colinsurprenant/director/releases/latest)
 
-**A coordination ledger for your coding-agent work: decisions, open loops, handoffs — durable across sessions, repos, and weeks.**
+**A coordination ledger for your coding-agent work: decisions, open loops, handoffs. Durable across sessions, repos, and weeks.**
 
 **[The two-minute tour: colinsurprenant.github.io/director](https://colinsurprenant.github.io/director/)**
 
-Memory tools answer *"what does the agent know?"* Director answers *"what is the state of the work?"*: what was decided and why, which loops were deliberately deferred, where the work stopped when the block ended, and what still needs *you*. Facts accumulate; loops open and close. Nothing in a memory store ever *closes* — that lifecycle is the difference. Run both: they don't overlap.
+Memory tools answer *"what does the agent know?"* Director answers *"what is the state of the work?"*: what was decided and why, which loops were deliberately deferred, where the work stopped when the block ended, and what still needs *you*. Facts accumulate; loops open and close. Nothing in a memory store ever *closes*. That lifecycle is the difference. Run both: they don't overlap.
 
 Three weeks after you park a project, a new session starts already knowing all of this: injected at session start as ground truth, not recalled by similarity.
 
@@ -18,7 +18,7 @@ Every session with a coding agent starts fresh on the state of the work: what wa
 - A SessionStart hook **injects** the CHARTER + digest into every new session as ground truth, so a cold re-entry starts from your parked handoff instead of from git archaeology.
 - The log is **model-agnostic**: the next session can be you tomorrow, you after a compaction, or a stronger model you escalate a stuck problem to, with the tried-and-failed hypotheses traveling along. Escalate with context, not with amnesia.
 
-The LOG (plus the deliberately-edited living docs) is the only system of record; sessions and every rendered view are disposable caches reconstructible from it. Director wires natively into **Claude Code and OpenAI Codex** — same hooks, same log, same boundary commands, either agent alone or both side by side. A single static binary, stdlib-first, one vetted build-time dependency (`github.com/oklog/ulid/v2`). No daemon, no database, no cloud: the log is plain NDJSON you could read with `cat`.
+The LOG (plus the deliberately-edited living docs) is the only system of record; sessions and every rendered view are disposable caches reconstructible from it. Director wires natively into **Claude Code and OpenAI Codex**: same hooks, same log, same boundary commands, either agent alone or both side by side. A single static binary, stdlib-first, one vetted build-time dependency (`github.com/oklog/ulid/v2`). No daemon, no database, no cloud: the log is plain NDJSON you could read with `cat`.
 
 ```text
 $ claude
@@ -63,7 +63,7 @@ docs-site-main-9d2e5b71 · dormant · 13d ago · ok
 
 ## Why Director
 
-The design in four ideas — the full argument, including honest comparisons, is [`docs/why-director.md`](docs/why-director.md):
+The design in four ideas (the full argument, including honest comparisons, is [`docs/why-director.md`](docs/why-director.md)):
 
 - **A portfolio, not a swarm.** Director's concurrency axis is *time and projects*, not just parallel terminals: one human, many workstreams, mostly one active at a time, dormant-between-blocks as a first-class state. Simultaneous sessions share the log and the cockpit too (supported, just not required).
 - **The git of coordination.** Fierce about invariants (no open loop silently vanishes, a decision another session needs is durable and visible, history is append-only) and completely agnostic about your process. Not a methodology; it constrains *state*, never the *path*. Nudges, never gates.
@@ -82,7 +82,7 @@ curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/insta
 
 Wire Codex instead with `sh -s -- --codex` (or `--both`); install the binary only with `sh -s -- --no-wire`.
 
-> **On Windows?** Run the one-liner inside [WSL](https://learn.microsoft.com/windows/wsl/) with the Linux binary: everything works there, hooks included. Native Windows is CLI-only for now: the binary is built and CI-tested, and every manual verb (`emit`, `render`, `status`, `brief`, `show`, `resolve`, …) works from PowerShell, but the hook shims are bash, so the ambient layer — session-start injection, heartbeats, boundary nudges — is not yet wired natively.
+> **On Windows?** Run the one-liner inside [WSL](https://learn.microsoft.com/windows/wsl/) with the Linux binary: everything works there, hooks included. Native Windows is CLI-only for now: the binary is built and CI-tested, and every manual verb (`emit`, `render`, `status`, `brief`, `show`, `resolve`, …) works from PowerShell, but the hook shims are bash, so the ambient layer (session-start injection, heartbeats, boundary nudges) is not yet wired natively.
 
 > **One machine for now.** Director's hub lives on the machine you install it on; there is no cross-machine sync yet. Work a repo from two machines (a laptop and a desktop, say) and each keeps its own separate hub: neither sees the other's decisions, open loops, or handoffs. Multi-machine sync is the one distribution mode on the roadmap (see [Status & scope](#status--scope)); until then, drive a given repo's Director state from a single machine.
 
@@ -103,13 +103,13 @@ director install
 
 `director install` does three things, all idempotent and self-contained:
 
-1. **Writes the hook shims.** The shims are embedded in the binary, so `install` materializes them (executable) into the hooks dir — there is **no manual copy step**.
+1. **Writes the hook shims.** The shims are embedded in the binary, so `install` materializes them (executable) into the hooks dir. There is **no manual copy step**.
 2. **Merges the hooks into `~/.claude/settings.json`.** Every entry it writes carries a `"_managedBy":"director"` tag, so Director's hooks run **alongside** GSD's and any hand-rolled hooks without clobbering them. Re-running adds nothing; `director uninstall` removes only Director's tagged entries **and** the shims and command files it wrote. Pass `--settings <path>` to target a project or test settings file.
 3. **Materializes the slash commands.** The `/director:adopt`, `/director:complete`, and `/director:handoff` commands (also embedded) are written under `~/.claude/commands/director/`, namespaced so they never clobber a user's own commands.
 
 The installed hook commands point at the **shims**, not the binary directly, so rebuilding or relocating `director` never requires rewriting `settings.json` (re-run `install` to refresh the shims to the current binary). If `~/.claude/settings.json` already has a malformed (non-object) `hooks` value, `install` refuses rather than overwrite it.
 
-Confirm the wiring will actually fire with `director doctor`. The shims fail safe (a missing binary exits 0 and coordination silently no-ops), so a broken install is otherwise invisible; `doctor` walks the same binary-resolution ladder the shims walk and reports each link (binary, Claude Code hooks, Codex hooks if present, hub). It exits non-zero when the install is broken, and warns (without failing) on a partial one — such as a terminal-only install the desktop app would miss:
+Confirm the wiring will actually fire with `director doctor`. The shims fail safe (a missing binary exits 0 and coordination silently no-ops), so a broken install is otherwise invisible; `doctor` walks the same binary-resolution ladder the shims walk and reports each link (binary, Claude Code hooks, Codex hooks if present, hub). It exits non-zero when the install is broken, and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss:
 
 ```bash
 director doctor
@@ -121,9 +121,9 @@ director doctor
 director install --codex
 ```
 
-Codex's hook contract mirrors Claude Code's, so the **same shims serve both agents** — and neither install needs the other: `--codex` works standalone on a machine that has never run Claude Code. It merges the three hooks into `~/.codex/hooks.json` (never your `config.toml`) and installs the boundary commands as agent skills under `~/.agents/skills`, invoked as `$director-adopt`, `$director-complete`, `$director-handoff`. Codex asks you to **trust** the three hooks at your next session start (if you dismiss that prompt, run `/hooks` in the session). Details, including what degrades on Codex, in [`docs/getting-started.md`](docs/getting-started.md).
+Codex's hook contract mirrors Claude Code's, so the **same shims serve both agents**, and neither install needs the other: `--codex` works standalone on a machine that has never run Claude Code. It merges the three hooks into `~/.codex/hooks.json` (never your `config.toml`) and installs the boundary commands as agent skills under `~/.agents/skills`, invoked as `$director-adopt`, `$director-complete`, `$director-handoff`. Codex asks you to **trust** the three hooks at your next session start (if you dismiss that prompt, run `/hooks` in the session). Details, including what degrades on Codex, in [`docs/getting-started.md`](docs/getting-started.md).
 
-Everything below uses the Claude Code command names (`/director:adopt` etc.); on Codex, read each as its `$director-*` skill twin — same command, same behavior.
+Everything below uses the Claude Code command names (`/director:adopt` etc.); on Codex, read each as its `$director-*` skill twin: same command, same behavior.
 
 ### Environment variables
 
@@ -137,14 +137,14 @@ Install paths and runtime knobs, common to both agents unless a default says oth
 | `DIRECTOR_CODEX_HOOKS_PATH` | `~/.codex/hooks.json` | the Codex hooks file `install --codex` merges into |
 | `DIRECTOR_CODEX_SKILLS_DIR` | `~/.agents/skills` | where `install --codex` writes the `$director-*` agent skills |
 | `DIRECTOR_HUB` | `~/.director` | the central hub that holds all cross-repo coordination state |
-| `DIRECTOR_BIN` | (PATH) | which `director` binary the shims invoke (defaults to `director` on `PATH`, then the symlink `install` drops next to the shims at `<hooks dir>/../bin/director` — `~/.claude/director/bin/director` by default) |
+| `DIRECTOR_BIN` | (PATH) | which `director` binary the shims invoke (defaults to `director` on `PATH`, then the symlink `install` drops next to the shims at `<hooks dir>/../bin/director`, `~/.claude/director/bin/director` by default) |
 | `DIRECTOR_HANDOFF_NUDGE_TOKENS` | (unset) | the context-fill handoff nudge (Claude Code-only for now): an absolute token threshold at which sessions are nudged toward `/director:handoff`; unset or `0` disables it. Fires once per crossing and re-arms only after context falls below half the threshold (a compaction or a context clear) |
 
-> **The binary must be findable.** With `DIRECTOR_BIN` set, the shims use it and nothing else — a stale value exits 0 without ever trying the other tiers. Unset, they fall back to `director` on `PATH`, then to the symlink `install` drops next to them at `<hooks dir>/../bin/director` (`~/.claude/director/bin/director` by default; a `DIRECTOR_HOOKS_DIR` override moves it too). A miss exits 0 (fail-safe) and coordination silently no-ops. The symlink tier covers the Claude Code **desktop app**, whose Dock/Launchpad launches get the bare launchd `PATH` ([anthropics/claude-code#44649](https://github.com/anthropics/claude-code/issues/44649)). To pin a specific binary explicitly, set `DIRECTOR_BIN` via `"env"` in `~/.claude/settings.json`. `director doctor` flags a stale `DIRECTOR_BIN` that resolves to nothing, the failure mode that silently disables the fallback tiers.
+> **The binary must be findable.** With `DIRECTOR_BIN` set, the shims use it and nothing else; a stale value exits 0 without ever trying the other tiers. Unset, they fall back to `director` on `PATH`, then to the symlink `install` drops next to them at `<hooks dir>/../bin/director` (`~/.claude/director/bin/director` by default; a `DIRECTOR_HOOKS_DIR` override moves it too). A miss exits 0 (fail-safe) and coordination silently no-ops. The symlink tier covers the Claude Code **desktop app**, whose Dock/Launchpad launches get the bare launchd `PATH` ([anthropics/claude-code#44649](https://github.com/anthropics/claude-code/issues/44649)). To pin a specific binary explicitly, set `DIRECTOR_BIN` via `"env"` in `~/.claude/settings.json`. `director doctor` flags a stale `DIRECTOR_BIN` that resolves to nothing, the failure mode that silently disables the fallback tiers.
 
 ## Adopt an existing repo
 
-A director's projects already exist, so adoption of existing repos is on the critical path. It has two layers: **`director adopt` registers; `/director:adopt` understands** (on Codex: `$director-adopt` — same command, delivered as a skill). From inside (or pointing at) a repo:
+A director's projects already exist, so adoption of existing repos is on the critical path. It has two layers: **`director adopt` registers; `/director:adopt` understands** (on Codex: `$director-adopt`, same command, delivered as a skill). From inside (or pointing at) a repo:
 
 ```bash
 director adopt [<dir>]        # defaults to the current directory
@@ -152,14 +152,14 @@ director adopt [<dir>]        # defaults to the current directory
 
 Working in an agent session, you can skip straight to `/director:adopt` (Claude Code) or `$director-adopt` (Codex): the command runs this registration itself as its first step. The bare CLI verb is what you use outside a session (scripts, a quick shell registration).
 
-Adoption **requires a git repository** — workstream identity and liveness are derived from git. On a non-git directory `adopt` fails fast and tells you to `git init` first (an empty init is enough).
+Adoption **requires a git repository**: workstream identity and liveness are derived from git. On a non-git directory `adopt` fails fast and tells you to `git init` first (an empty init is enough).
 
-`adopt` (the register layer) derives the repo's **stable workstream identity** (handling worktrees, remotes, and forks — see [Identity](#identity)), creates `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub** there, and registers the workstream in the fleet. Re-adopting never clobbers an edited CHARTER. That is all the CLI does — deterministic, done in seconds.
+`adopt` (the register layer) derives the repo's **stable workstream identity** (handling worktrees, remotes, and forks; see [Identity](#identity)), creates `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub** there, and registers the workstream in the fleet. Re-adopting never clobbers an edited CHARTER. That is all the CLI does: deterministic, done in seconds.
 
-The understand layer is **`/director:adopt`** (Claude Code; `$director-adopt` on Codex), installed by the matching `director install` form and run inside an agent session. It starts with the same `director adopt`, then fans out read-only agents over the repo — docs and planning files, code TODOs read *in context*, git state, the repo's self-descriptions — and brings back two things for your confirmation:
+The understand layer is **`/director:adopt`** (Claude Code; `$director-adopt` on Codex), installed by the matching `director install` form and run inside an agent session. It starts with the same `director adopt`, then fans out read-only agents over the repo (docs and planning files, code TODOs read *in context*, git state, the repo's self-descriptions) and brings back two things for your confirmation:
 
 - a **CHARTER proposal** (goal, non-goals, risk line): every claim cited, inferences marked `(inferred)`, plus the short list of questions only you can answer. Approved, it replaces the stub; adoption starts from an informed draft instead of a blank template.
-- the repo's open loops, **triaged** into four buckets: genuinely **in-flight** work (imported as `open-item` events after your confirm — git state must corroborate the prose, which keeps this bucket naturally small), **backlog** (stays in the repo's own tracker and planning docs; Director is not the tracker), **doc-stamps** (facts wearing a TODO costume — they feed the CHARTER), and **fossils**. Every bucket's count is reported; nothing is imported silently.
+- the repo's open loops, **triaged** into four buckets: genuinely **in-flight** work (imported as `open-item` events after your confirm; git state must corroborate the prose, which keeps this bucket naturally small), **backlog** (stays in the repo's own tracker and planning docs; Director is not the tracker), **doc-stamps** (facts wearing a TODO costume; they feed the CHARTER), and **fossils**. Every bucket's count is reported; nothing is imported silently.
 
 Re-running `/director:adopt` on an adopted repo is the refresh path: the proposal diffs against your current CHARTER, and triage dedupes against the log's existing open-set.
 
@@ -197,7 +197,7 @@ misc:
   version     print the director version
 ```
 
-### emit — the model write path
+### emit: the model write path
 
 `emit` is the **only** sanctioned way a semantic event reaches the LOG (never `Edit`/`Write` a log file):
 
@@ -206,17 +206,17 @@ director emit --type decision|open-item|handoff|note --area <subsystem> \
   [--risk low|escalate] [--to <handle>] [--refs <ulid,ulid>] <body>
 ```
 
-`emit` prints the **new event's ULID to stdout** — note it; that is the id used to `--refs` or `resolve` the event later.
+`emit` prints the **new event's ULID to stdout**: note it; that is the id used to `--refs` or `resolve` the event later.
 
-### resolve — close an open-item
+### resolve: close an open-item
 
 ```bash
 director resolve <ulid>
 ```
 
-`resolve` appends a close-marker for an open-item. The `<ulid>` **must** be one the CLI surfaced (from `emit`, `render`, or `open-items`) — `resolve` validates the target and rejects invented ids, non-open-items, and already-closed items.
+`resolve` appends a close-marker for an open-item. The `<ulid>` **must** be one the CLI surfaced (from `emit`, `render`, or `open-items`); `resolve` validates the target and rejects invented ids, non-open-items, and already-closed items.
 
-### promote — fold aged rationale into the docs
+### promote: fold aged rationale into the docs
 
 ```bash
 director promote <ulid> [<ulid>...] --to <doc>
@@ -224,9 +224,9 @@ director promote <ulid> [<ulid>...] --to <doc>
 
 `promote` is the grooming ceremony that keeps the digest tracking **current work, not project age**. Once a batch of aged-but-durable decisions' rationale has been written into a living doc (an ADR, an architecture overview), `promote` appends one **promote-marker**: a `decision` with `status: promoted`, `refs` naming the promoted decisions, and `promoted_to` carrying the doc path. The fold drops the promoted decisions from the active projection; the marker stays as a one-line doc pointer, and `director show <ulid>` still serves every original in full. Nothing is lost, the rationale just changed address (and since Director is single-human by design, promotion into the slow layer is also the cross-human interface).
 
-Validation is `resolve`-parity: every target must be a decision the CLI surfaced, not superseded by an ordinary decision, and not already claimed by a *live* promote-marker. Invented ids, non-decisions, already-promoted and superseded targets are refused, and one bad target rejects the whole batch (nothing is written). A mispointed promotion is recoverable: supersede the bad marker with an ordinary decision (`emit --refs <marker-ulid>`), then re-promote to the correct address — only *live* markers hold the already-promoted claim.
+Validation is `resolve`-parity: every target must be a decision the CLI surfaced, not superseded by an ordinary decision, and not already claimed by a *live* promote-marker. Invented ids, non-decisions, already-promoted and superseded targets are refused, and one bad target rejects the whole batch (nothing is written). A mispointed promotion is recoverable: supersede the bad marker with an ordinary decision (`emit --refs <marker-ulid>`), then re-promote to the correct address. Only *live* markers hold the already-promoted claim.
 
-`--to` takes a **durable address**, not necessarily a file: a repo-relative path (`docs/adr/0007-cursor-pagination.md`) or a stable URL (a GitHub issue where the rationale now lives). Machine-specific paths (absolute, `~/…`) are refused — the log is a portable file and its pointers must travel. Two conventions, nudged not gated: prefer the repo doc (it's version-controlled and travels with the repo; a URL can die, though the original rationale stays one `show` away), and have the receiving doc cite the promoted ULIDs, so a reader can drill back from the ADR into the full decision chain, superseded alternatives included. Director records the address; it never dials it — no issue is created, no doc is checked, the write-the-doc-then-promote ordering is yours.
+`--to` takes a **durable address**, not necessarily a file: a repo-relative path (`docs/adr/0007-cursor-pagination.md`) or a stable URL (a GitHub issue where the rationale now lives). Machine-specific paths (absolute, `~/…`) are refused: the log is a portable file and its pointers must travel. Two conventions, nudged not gated: prefer the repo doc (it's version-controlled and travels with the repo; a URL can die, though the original rationale stays one `show` away), and have the receiving doc cite the promoted ULIDs, so a reader can drill back from the ADR into the full decision chain, superseded alternatives included. Director records the address; it never dials it: no issue is created, no doc is checked, the write-the-doc-then-promote ordering is yours.
 
 ### The three projections
 
@@ -236,13 +236,13 @@ Validation is `resolve`-parity: every target must be a decision the CLI surfaced
 | `brief [--project <key>]` | human | the on-demand bigger-picture re-orientation view (outlook from CHARTER, latest handoff per workstream, open/escalate items, recent decisions), at project or whole-fleet altitude. |
 | `status` | human | the one-line-per-workstream fleet cockpit: handle · liveness · heartbeat recency · the **Needs-you** band (open `escalate` items). |
 
-`brief` and `render` share the same byte-identical fold — the human reads the same picture a fresh session reads. A fourth, narrower projection, `open-items`, lists a workstream's unresolved open-items (ULID + body); it exists to feed `resolve` and `/director:complete`. It defaults to the current workstream; `--workstream <id>` retargets it at a sibling — the close-out path for a workstream whose session is already gone.
+`brief` and `render` share the same byte-identical fold: the human reads the same picture a fresh session reads. A fourth, narrower projection, `open-items`, lists a workstream's unresolved open-items (ULID + body); it exists to feed `resolve` and `/director:complete`. It defaults to the current workstream; `--workstream <id>` retargets it at a sibling: the close-out path for a workstream whose session is already gone.
 
-The digest is deliberately an *index*: every line is capped to a headline so the injection stays small as a project's log grows, and nothing is lost — `show <ulid>` prints any single event in full (body verbatim, as recorded), one deterministic hop from any headline. When even the capped digest would overrun the injection budget, the decisions section collapses to a count-plus-pointer line and the overflow lands in `health/` as a grooming signal; the open-set and the latest handoff are never cut. The grooming verbs that keep that headroom are `resolve` (compacts the open-set), supersession via `--refs`, and `promote` (compacts the decision set into the docs).
+The digest is deliberately an *index*: every line is capped to a headline so the injection stays small as a project's log grows, and nothing is lost: `show <ulid>` prints any single event in full (body verbatim, as recorded), one deterministic hop from any headline. When even the capped digest would overrun the injection budget, the decisions section collapses to a count-plus-pointer line and the overflow lands in `health/` as a grooming signal; the open-set and the latest handoff are never cut. The grooming verbs that keep that headroom are `resolve` (compacts the open-set), supersession via `--refs`, and `promote` (compacts the decision set into the docs).
 
 ### Fleet lifecycle
 
-`register` / `heartbeat` / `done` maintain a workstream's liveness row and are normally fired by the hooks, not run by hand. Liveness is **derived from heartbeat age** (TTL/lease) — never self-declared: a workstream that stops heartbeating ages to `idle` (after 4h) then `dormant` (after 2d), and dormant is a first-class state (a project parked between blocks), not a fault. A workstream whose branch no longer exists reads `gone` regardless of heartbeat: it looks complete and is the `/director:complete` candidate. Because git refuses to delete a checked-out branch, a gone workstream is always a *sibling* (a worktree that merged and was removed), never the session's own — so the surfacing happens one session later: `status` shows the gone row's open-item count with the remedy, and — if the gone workstream still owns open items — the next agent session on that repo gets a session-start nudge naming it (a zero-loop corpse has nothing at risk, so it gets the `status` remedy only). `/director:complete <workstream-id>` then closes out the dead sibling from wherever you are in the repo (`done --workstream <id>` archives every row it left behind). `done` archives rows to `fleet/archive/<date>/` rather than deleting them.
+`register` / `heartbeat` / `done` maintain a workstream's liveness row and are normally fired by the hooks, not run by hand. Liveness is **derived from heartbeat age** (TTL/lease), never self-declared: a workstream that stops heartbeating ages to `idle` (after 4h) then `dormant` (after 2d), and dormant is a first-class state (a project parked between blocks), not a fault. A workstream whose branch no longer exists reads `gone` regardless of heartbeat: it looks complete and is the `/director:complete` candidate. Because git refuses to delete a checked-out branch, a gone workstream is always a *sibling* (a worktree that merged and was removed), never the session's own, so the surfacing happens one session later: `status` shows the gone row's open-item count with the remedy, and, if the gone workstream still owns open items, the next agent session on that repo gets a session-start nudge naming it (a zero-loop corpse has nothing at risk, so it gets the `status` remedy only). `/director:complete <workstream-id>` then closes out the dead sibling from wherever you are in the repo (`done --workstream <id>` archives every row it left behind). `done` archives rows to `fleet/archive/<date>/` rather than deleting them.
 
 ## The four event kinds
 
@@ -251,19 +251,19 @@ There are exactly four model-emitted semantic kinds. Pick by what the fact *is*:
 | Kind | Use it for | Lifecycle |
 |---|---|---|
 | `decision` | a choice + what it affects | active → superseded (a later decision's `--refs`) or promoted (via `promote`); carries `--risk low\|escalate` |
-| `open-item` | an open loop / follow-up / deferred item — the canonical home for "documented, not dropped" | open → closed (via `resolve`) |
-| `handoff` | a positional snapshot: current task · next action · hypotheses | — |
-| `note` | FYI / context for a parallel or future session | — |
+| `open-item` | an open loop / follow-up / deferred item, the canonical home for "documented, not dropped" | open → closed (via `resolve`) |
+| `handoff` | a positional snapshot: current task · next action · hypotheses | none |
+| `note` | FYI / context for a parallel or future session | none |
 
-- **There is no `blocker` kind.** "Stuck, needs a human" is an `open-item` with `--risk escalate` — exactly the open-set that surfaces in `status`'s Needs-you band.
-- **`done` is not a semantic kind** — it is fleet-liveness only (a hook marks the session terminal). "What's done" belongs in a `handoff` body.
+- **There is no `blocker` kind.** "Stuck, needs a human" is an `open-item` with `--risk escalate`, exactly the open-set that surfaces in `status`'s Needs-you band.
+- **`done` is not a semantic kind**: it is fleet-liveness only (a hook marks the session terminal). "What's done" belongs in a `handoff` body.
 
 ## The coordination protocol
 
 The SessionStart hook injects this protocol into every managed-repo session, so the emit habit is in context from turn one: pushed as injected state, not shipped as a lazy model-invoked skill, because an always-on habit only fires if it is already in the window. (`skills/director/SKILL.md` is the readable source of the same text.) It teaches a session two load-bearing habits that no hook can perform for it:
 
-- **Continuous boundary-flush** — emit durable state to the LOG *as you work* (the moment a decision is made or a loop is deferred, and a `handoff` at each natural boundary), never batched for the end of a session. Transient working state survives a compaction only if the model wrote it to the LOG during a turn.
-- **Ground Truth** — treat the CHARTER + digest injected at session start as the *authoritative current picture*: build on it, do not re-derive it by re-scanning the repo or re-reading the log.
+- **Continuous boundary-flush**: emit durable state to the LOG *as you work* (the moment a decision is made or a loop is deferred, and a `handoff` at each natural boundary), never batched for the end of a session. Transient working state survives a compaction only if the model wrote it to the LOG during a turn.
+- **Ground Truth**: treat the CHARTER + digest injected at session start as the *authoritative current picture*: build on it, do not re-derive it by re-scanning the repo or re-reading the log.
 
 ## Identity
 
@@ -271,9 +271,9 @@ A workstream's id is `<repo>-<branch>-<shortid>`, derived deterministically from
 
 ## Status & scope
 
-**In v1:** the hook-first coordination core (CLI write path, identity, event store, fleet/liveness, `render`/`brief`/`status`, hooks + the `_managedBy` installer, the injected coordination protocol), **informed adoption** (`adopt` registers; `/director:adopt` drafts the CHARTER proposal and runs the triaged open-loop import — see [Adopt an existing repo](#adopt-an-existing-repo)), and a **Codex adapter**: `director install --codex` wires the same hooks into Codex's `hooks.json` (Codex asks you to trust them at the next session start; if you dismiss that prompt, run `/hooks` in the session) and installs the boundary commands as agent skills — `$director-adopt`, `$director-complete`, `$director-handoff`. Ground truth injection, liveness, and close-out work identically on both agents; the emit-guard and the context-fill handoff nudge are Claude Code-only for now (they read CC's transcript format and stay safely inert on Codex). Single-machine.
+**In v1:** the hook-first coordination core (CLI write path, identity, event store, fleet/liveness, `render`/`brief`/`status`, hooks + the `_managedBy` installer, the injected coordination protocol), **informed adoption** (`adopt` registers; `/director:adopt` drafts the CHARTER proposal and runs the triaged open-loop import; see [Adopt an existing repo](#adopt-an-existing-repo)), and a **Codex adapter**: `director install --codex` wires the same hooks into Codex's `hooks.json` (Codex asks you to trust them at the next session start; if you dismiss that prompt, run `/hooks` in the session) and installs the boundary commands as agent skills: `$director-adopt`, `$director-complete`, `$director-handoff`. Ground truth injection, liveness, and close-out work identically on both agents; the emit-guard and the context-fill handoff nudge are Claude Code-only for now (they read CC's transcript format and stay safely inert on Codex). Single-machine.
 
-**Deferred:** deeper brownfield analysis beyond the informed-adopt pass (doc living/record/rot reconciliation, an arc42 overview draft, back-dated decision records). `brief --synthesize` (model-narrated prose) is deferred — v1 ships the deterministic brief. A background monitor/reaper, notifications, and a freshness sweep come later.
+**Deferred:** deeper brownfield analysis beyond the informed-adopt pass (doc living/record/rot reconciliation, an arc42 overview draft, back-dated decision records). `brief --synthesize` (model-narrated prose) is deferred: v1 ships the deterministic brief. A background monitor/reaper, notifications, and a freshness sweep come later.
 
 **Multi-machine** is the one distribution mode on the roadmap, and its shape is settled: the hub becomes git-synced, and the merge is just the fold (the fold is a pure, order-independent function of the event set, so per-machine logs merge as set union). No server, no protocol, no conflict resolution, ever.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,17 +2,17 @@
 
 Two kinds of documents live here, and the distinction is deliberate (it mirrors Director's own records-vs-living-docs model):
 
-**Living documents** — kept current; when anything disagrees with these or the code, these win:
+**Living documents**: kept current; when anything disagrees with these or the code, these win:
 
-- [`why-director.md`](why-director.md) — the positioning: what Director is, where it sits, what it refuses to be, honest comparisons.
-- [`getting-started.md`](getting-started.md) — task-oriented first run: install → adopt → first session → cockpit, plus troubleshooting.
-- [`../README.md`](../README.md) — the reference.
+- [`why-director.md`](why-director.md), the positioning: what Director is, where it sits, what it refuses to be, honest comparisons.
+- [`getting-started.md`](getting-started.md), task-oriented first run: install → adopt → first session → cockpit, plus troubleshooting.
+- [`../README.md`](../README.md), the reference.
 
-**Frozen records** — dated artifacts kept as-written for provenance, never rewritten, superseded by later decisions in the Director LOG and the living docs. Read them for the design rationale and its adversarial review, not for current behavior:
+**Frozen records**: dated artifacts kept as-written for provenance, never rewritten, superseded by later decisions in the Director LOG and the living docs. Read them for the design rationale and its adversarial review, not for current behavior:
 
-- [`specs/2026-06-03-director-coordination-design.md`](specs/2026-06-03-director-coordination-design.md) — the v1 design, including the corrections from adversarial review that shaped it.
-- [`specs/2026-07-01-close-out-commands-design.md`](specs/2026-07-01-close-out-commands-design.md) — the close-out commands design (`/director:complete`, `/director:handoff`, the `open-items` verb).
-- [`specs/2026-07-03-informed-adoption-design.md`](specs/2026-07-03-informed-adoption-design.md) — the informed-adoption design (`/director:adopt`: CHARTER proposal + triaged open-loop import; keyword-scan removal).
-- [`plans/2026-06-08-director-v1.md`](plans/2026-06-08-director-v1.md) — the v1 build plan as executed.
-- [`review-2026-06-08-director-v1.md`](review-2026-06-08-director-v1.md) — the v1 pre-merge review, findings and resolutions.
-- [`dogfood.md`](dogfood.md) — the pre-code validation exercise (superseded before v1 shipped).
+- [`specs/2026-06-03-director-coordination-design.md`](specs/2026-06-03-director-coordination-design.md), the v1 design, including the corrections from adversarial review that shaped it.
+- [`specs/2026-07-01-close-out-commands-design.md`](specs/2026-07-01-close-out-commands-design.md), the close-out commands design (`/director:complete`, `/director:handoff`, the `open-items` verb).
+- [`specs/2026-07-03-informed-adoption-design.md`](specs/2026-07-03-informed-adoption-design.md), the informed-adoption design (`/director:adopt`: CHARTER proposal + triaged open-loop import; keyword-scan removal).
+- [`plans/2026-06-08-director-v1.md`](plans/2026-06-08-director-v1.md), the v1 build plan as executed.
+- [`review-2026-06-08-director-v1.md`](review-2026-06-08-director-v1.md), the v1 pre-merge review, findings and resolutions.
+- [`dogfood.md`](dogfood.md), the pre-code validation exercise (superseded before v1 shipped).

--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -1,9 +1,9 @@
-# Director dogfood — validate before building
+# Director dogfood: validate before building
 
-> **SUPERSEDED (2026-06-08) — do not run.** The *value* question ("does this surface what I'd otherwise lose?") was settled by lived experience; the *schema* question this exercise would have hardened is now locked by decision in `docs/specs/2026-06-03-director-coordination-design.md` §17. Kept for provenance only. The 5 kinds below are superseded by the canonical 4 — **decision · open-item · handoff · note** — where `done` is fleet-liveness (not a semantic kind) and `blocker` folds into `open-item` + `risk: escalate`.
+> **SUPERSEDED (2026-06-08): do not run.** The *value* question ("does this surface what I'd otherwise lose?") was settled by lived experience; the *schema* question this exercise would have hardened is now locked by decision in `docs/specs/2026-06-03-director-coordination-design.md` §17. Kept for provenance only. The 5 kinds below are superseded by the canonical 4 (**decision · open-item · handoff · note**), where `done` is fleet-liveness (not a semantic kind) and `blocker` folds into `open-item` + `risk: escalate`.
 
 Goal: confirm the 5 event kinds capture the info that actually matters, before writing any Go.
-(The Assignment from the product doc — do this first.)
+(The Assignment from the product doc: do this first.)
 
 For ~3 days, while working in any session, append one line per moment to `~/director-dogfood/<repo>.log`:
 
@@ -19,4 +19,4 @@ End of day: `cat ~/director-dogfood/*.log` and ask:
 - **Yes** → the soul is validated. Build the CLI (see `docs/specs/2026-06-03-…md` §15 + the product doc's "Next Steps").
 - **No** → the event kinds/schema are wrong. Fix that before any code.
 
-By hand, skip JSON/fields — format is the CLI's job. You're testing information value only.
+By hand, skip JSON/fields: format is the CLI's job. You're testing information value only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,7 +57,7 @@ VCS metadata is available.
 
 **Windows note.** This guide, including the `director install` step above, assumes a unix-like
 environment: macOS, Linux, or Windows via [WSL](https://learn.microsoft.com/windows/wsl/), which is
-the recommended Windows setup — with the Linux binary, install and hooks work there exactly as on
+the recommended Windows setup: with the Linux binary, install and hooks work there exactly as on
 Linux. On native Windows the CLI itself works (build and tests run in CI on `windows-latest`), but
 `director install` refuses to run there: the hook shims are bash scripts, which Claude Code on
 native Windows cannot execute, so the ambient layer (session-start injection, heartbeats, boundary
@@ -89,14 +89,14 @@ installed Director hooks into /Users/you/.claude/settings.json (set DIRECTOR_SET
   There is no manual copy step.
 - It merges three hooks into `~/.claude/settings.json` (`SessionStart`, `PostToolUse`, `Stop`), each tagged
   `"_managedBy":"director"` so they coexist with GSD and any hand-rolled hooks. Re-running changes nothing.
-- It materializes the three slash commands: `/director:adopt` (informed adoption — see section 3),
+- It materializes the three slash commands: `/director:adopt` (informed adoption, see section 3),
   `/director:handoff` (pause a workstream, record the resume point) and `/director:complete` (close out a finished,
   merged workstream). More on the boundary pair in section 5.
 
 Verify it took. `director doctor` is the thorough check: it walks the same binary-resolution ladder
 the hooks walk and reports each link (binary, Claude Code hooks, Codex hooks if present, hub), so a
 broken install becomes loud instead of a silent no-op. It exits non-zero when the install is broken,
-and warns (without failing) on a partial one — such as a terminal-only install the desktop app would miss.
+and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss.
 
 ```bash
 director doctor
@@ -118,17 +118,17 @@ director status
 # (no live workstreams)        ← expected before you adopt anything / open a session
 ```
 
-> **Keep `director` on `PATH`.** With `DIRECTOR_BIN` set, the shims use it and nothing else — a
+> **Keep `director` on `PATH`.** With `DIRECTOR_BIN` set, the shims use it and nothing else: a
 > stale value exits 0 without ever trying `PATH` or the symlink. Unset, they fall back to `director`
 > on `PATH`, then to the symlink `install` drops next to them at `<hooks dir>/../bin/director`
 > (`~/.claude/director/bin/director` by default; a `DIRECTOR_HOOKS_DIR` override moves it too).
 > If the binary isn't found, the shims exit 0 (fail-safe) and
-> coordination silently no-ops — nothing breaks, but nothing coordinates. After rebuilding the binary,
+> coordination silently no-ops: nothing breaks, but nothing coordinates. After rebuilding the binary,
 > re-run `director install` to refresh the shims.
 >
 > The last tier is what the install's **bin symlink** provisions, and it matters more than it looks:
 > the Claude Code **desktop app** launched from the Dock/Launchpad inherits the bare launchd `PATH`
-> (no `/opt/homebrew/bin`, `/usr/local/bin`, or `~/go/bin` —
+> (no `/opt/homebrew/bin`, `/usr/local/bin`, or `~/go/bin`,
 > [anthropics/claude-code#44649](https://github.com/anthropics/claude-code/issues/44649)), so the
 > `PATH` tier misses there even when your terminal finds `director` fine. The explicit alternative is
 > pinning the binary via `DIRECTOR_BIN` in `~/.claude/settings.json`:
@@ -138,7 +138,7 @@ director status
 > ```
 >
 > Install never overwrites a **regular file** already sitting at the fallback path
-> (`<hooks dir>/../bin/director`) — a binary you placed there yourself stays, and the shims run it
+> (`<hooks dir>/../bin/director`). A binary you placed there yourself stays, and the shims run it
 > as long as it is executable.
 
 ### Using OpenAI Codex?
@@ -151,7 +151,7 @@ Codex's hook contract mirrors Claude Code's, so the same shims serve both agents
 merges the three hooks into `~/.codex/hooks.json` (never your `config.toml`) and installs the boundary
 commands as **agent skills** under `~/.agents/skills`: invoke them as `$director-adopt`,
 `$director-complete`, `$director-handoff` (or find them in the `/skills` browser). Skills are the
-surface Codex recommends — its older `~/.codex/prompts` custom prompts are deprecated upstream. Two
+surface Codex recommends; its older `~/.codex/prompts` custom prompts are deprecated upstream. Two
 Codex-specific notes:
 
 - **Trust the hooks once.** Codex asks you to review and trust the three hook definitions at your next
@@ -161,16 +161,16 @@ Codex-specific notes:
   and the context-fill handoff nudge are Claude Code-only for now (they read CC's transcript format and
   stay safely inert on Codex).
 - Codex exposes no session id to shell commands, so a hand-run `director done` (including
-  `$director-complete`'s final step) may report "row not found" there — not a failure: the Stop hook
+  `$director-complete`'s final step) may report "row not found" there, not a failure: the Stop hook
   archives the session's row at turn end, and everything durable was already written. Targeted
   `done --workstream <id>` is unaffected.
 
 The rest of this guide uses the Claude Code command names (`/director:adopt` etc.); on Codex, read each
-as its `$director-*` skill twin — same command, same behavior.
+as its `$director-*` skill twin: same command, same behavior.
 
 `director uninstall --codex` removes only the tagged entries and the three skill directories. The hook
 shims are shared between the two agents: either uninstall form leaves them in place while the other
-agent's install still references them, and reclaims them once neither does — so uninstalling one agent
+agent's install still references them, and reclaims them once neither does, so uninstalling one agent
 never silently breaks the other, and uninstalling the last one leaves no shim files behind.
 
 ---
@@ -189,7 +189,7 @@ adopted some-project-main-1a2b3c4d
   CHARTER scaffolded at ~/.director/projects/<repo-key>/CHARTER.md — fill in goal / non-goals / risk-line, or run /director:adopt in a session to draft it from the repo's docs
 ```
 
-A bare `adopt` **registers** — the fast, deterministic floor: it derives a **stable workstream identity**
+A bare `adopt` **registers** (the fast, deterministic floor): it derives a **stable workstream identity**
 (handles worktrees, remotes, forks), creates `projects/<repo-key>/` in the hub, scaffolds a ~3-line
 **CHARTER stub**, and registers the workstream. Re-adopting never clobbers an edited CHARTER.
 
@@ -198,20 +198,20 @@ session. It starts with the same `director adopt`, then fans out read-only agent
 (docs and planning files, code TODOs read *in context*, git state, the repo's self-descriptions) and brings
 back two things for your confirmation:
 
-- a **CHARTER proposal** — every claim cited, inferences marked, plus the questions only you can answer —
+- a **CHARTER proposal** (every claim cited, inferences marked, plus the questions only you can answer),
   so adoption starts from an informed draft instead of a blank template;
 - the repo's open loops **triaged**: genuinely **in-flight** work (imported as `open-item` events after your
   confirm; git state must corroborate the prose, which keeps this bucket small), **backlog** (stays in your
   tracker and TODO docs), **doc-stamps** (feed the CHARTER), and **fossils**. Every bucket's count is
   reported; nothing is imported silently.
 
-Re-run `/director:adopt` anytime — on an adopted repo it refreshes a stale CHARTER (shown as a diff) and
+Re-run `/director:adopt` anytime: on an adopted repo it refreshes a stale CHARTER (shown as a diff) and
 triages only loops the log doesn't already carry.
 
-### The CHARTER — where you steer
+### The CHARTER: where you steer
 
 `adopt` scaffolds `~/.director/projects/<repo-key>/CHARTER.md` with placeholders. Intent isn't in the code,
-so the content comes from you — but you don't have to write it from scratch: run **`/director:adopt`** and
+so the content comes from you, but you don't have to write it from scratch: run **`/director:adopt`** and
 confirm the proposal it drafts from the repo's own docs (the recommended path), or hand-edit the stub (the
 fallback, and still the way to steer it afterwards):
 
@@ -234,7 +234,7 @@ Just start Claude Code (or Codex) in the adopted repo as usual. Director's `Sess
 
 - registers/refreshes the workstream's liveness row, and
 - injects the **CHARTER + a deterministic digest** of the LOG as the session's *authoritative current
-  state* ("Ground Truth"). The digest is an index of capped headlines — `director show <ulid>` prints
+  state* ("Ground Truth"). The digest is an index of capped headlines; `director show <ulid>` prints
   any entry in full.
 
 You don't run anything. The session is now coordinating. As it works, its `PostToolUse` hook keeps the
@@ -257,7 +257,7 @@ docs-site-main-9d2e5b71 · dormant · 13d ago · ok
 ```
 
 One line per live workstream: handle · liveness (`active`/`idle`/`dormant`/`gone`, derived from heartbeat age and branch existence)
-· heartbeat recency · the **Needs-you band** (its open `escalate` items — what's waiting on *you*).
+· heartbeat recency · the **Needs-you band** (its open `escalate` items, what's waiting on *you*).
 
 ```bash
 director brief                       # whole-fleet bigger picture
@@ -265,7 +265,7 @@ director brief --project <repo-key>  # one project
 ```
 
 `brief` composes the outlook (from each CHARTER), the latest handoff per workstream, the carried-forward
-open items, and recent decisions — the moving narrative between the stable CHARTER and the per-session
+open items, and recent decisions: the moving narrative between the stable CHARTER and the per-session
 handoff. It's fully deterministic: you read the same picture a fresh session reads.
 
 ```text
@@ -300,21 +300,21 @@ director show <ulid>      # read any event in full first — digest lines are ca
 
 ## 5. How the model uses Director
 
-You rarely run `emit`/`resolve` by hand — **the session does**, guided by the coordination protocol the
+You rarely run `emit`/`resolve` by hand; **the session does**, guided by the coordination protocol the
 SessionStart hook injects into every managed-repo session (its readable source is
 [`../skills/director/SKILL.md`](../skills/director/SKILL.md)). The protocol teaches two habits no hook can
 perform for the model:
 
-- **Continuous boundary-flush** — emit durable state *as work happens* (a `decision` the moment it's made,
+- **Continuous boundary-flush**: emit durable state *as work happens* (a `decision` the moment it's made,
   an `open-item` the moment a loop is deferred, a `handoff` at each natural boundary), never batched for the
   end. Transient working state survives a compaction only if it was written to the LOG during a turn.
-- **Ground Truth** — treat the injected CHARTER + digest as authoritative: build on it, don't re-derive it
+- **Ground Truth**: treat the injected CHARTER + digest as authoritative: build on it, don't re-derive it
   by re-scanning the repo or re-reading the log.
 
 There are exactly four event kinds: `decision`, `open-item` (the home for "documented, not dropped";
 `--risk escalate` is the "needs a human" subset that surfaces in `status`), `handoff`, and `note`. There is
-no `blocker` kind and `done` is fleet-liveness only. Your job is to **review** — read `status`/`brief`,
-answer the escalations, edit CHARTERs to steer — not to relay.
+no `blocker` kind and `done` is fleet-liveness only. Your job is to **review**: read `status`/`brief`,
+answer the escalations, edit CHARTERs to steer, not to relay.
 
 At block boundaries, two slash commands (installed by `director install`) mark workstream lifecycle:
 
@@ -323,7 +323,7 @@ At block boundaries, two slash commands (installed by `director install`) mark w
   weeks later) rehydrates from the parked handoff instead of re-deriving state.
 - **`/director:complete`** when a workstream is done and merged. It closes out the workstream's open loops
   with your confirmation and archives its fleet row. Nothing auto-resolves; close-out is human-confirmed.
-  It also takes a workstream id — `/director:complete <id>` — to close out a *dead sibling*: a worktree
+  It also takes a workstream id (`/director:complete <id>`) to close out a *dead sibling*: a worktree
   that merged and was deleted before anyone ran the close-out. Its branch reads `gone` in `status`, and
   if it still owns open items, the next session you start on that repo will surface a "close-out pending"
   nudge naming it; you don't have to hunt for corpses yourself.
@@ -344,14 +344,14 @@ would not fire. The table covers the specifics.
 | **Hooks don't seem to fire** | Confirm `director install` ran and `director` is on `PATH` (`command -v director`). Check the shims exist: `ls $DIRECTOR_HOOKS_DIR` (default `~/.claude/director/hooks`). Re-run `director install` after moving/rebuilding the binary. |
 | **Coordination silently does nothing** | The shims fail-safe to exit 0 when the binary is missing. Ensure `DIRECTOR_BIN` (or `PATH`, or the `~/.claude/director/bin/director` symlink a re-run of `director install` refreshes) resolves `director`. |
 | **Works in the terminal, dead in the desktop app** | Dock/Launchpad launches get the bare launchd `PATH` ([anthropics/claude-code#44649](https://github.com/anthropics/claude-code/issues/44649)), so the shims' `PATH` tier misses. Re-run `director install` (it drops the `~/.claude/director/bin/director` symlink the shims fall back to), or pin the binary explicitly with `DIRECTOR_BIN` via `"env"` in `settings.json`. |
-| **State is in the wrong place** | All cross-repo state lives under `DIRECTOR_HUB` (default `~/.director`). If you set it for one command, set it for all — sessions and your CLI must agree. |
-| **A hook seems broken** | Hooks are fail-safe by design — a failure never blocks a session, it logs. Read `$DIRECTOR_HUB/health/hook.log` (one line per outcome, `ok=false` marks failures). |
-| **`director _hook ...`** | Internal — invoked by the shims, never run by hand. |
+| **State is in the wrong place** | All cross-repo state lives under `DIRECTOR_HUB` (default `~/.director`). If you set it for one command, set it for all: sessions and your CLI must agree. |
+| **A hook seems broken** | Hooks are fail-safe by design: a failure never blocks a session, it logs. Read `$DIRECTOR_HUB/health/hook.log` (one line per outcome, `ok=false` marks failures). |
+| **`director _hook ...`** | Internal: invoked by the shims, never run by hand. |
 | **A row reads `idle` or `dormant` though the session is active** | Liveness is derived from heartbeat age. `PostToolUse` refreshes it on every tool call, so a session making no tool calls can age to `idle` (after 4h) then `dormant` (after 2d). Dormant is the normal between-blocks state, not an error. |
 | **A row reads `gone` despite a fresh heartbeat** | Liveness also checks that the workstream's branch still exists. A branch that no longer exists reads `gone` by design (merged away and deleted, or the whole worktree directory is gone: any failed branch check counts), meaning the workstream looks complete: close it out with `/director:complete <workstream-id>` from any session on the repo. `status` shows its open-item count, and new sessions on the repo are nudged about it at start while it still owns open items. Rows without branch/dir info fail open and age out by TTL only. |
 | **`status` shows "N unreadable fleet row(s) skipped"** | One or more row files under `$DIRECTOR_HUB/fleet/` are corrupt; the cockpit skips them rather than failing. Inspect/remove the bad files there. |
-| **`adopt` imported nothing** | By design — the CLI registers only (identity + CHARTER stub + fleet row). The import path is `/director:adopt` in an agent session: it triages the repo's real open loops and imports only what you confirm. |
-| **`install` refused** | Your `~/.claude/settings.json` has a malformed (non-object) `hooks` value. Director won't overwrite data it doesn't understand — fix the file, then re-run. |
+| **`adopt` imported nothing** | By design: the CLI registers only (identity + CHARTER stub + fleet row). The import path is `/director:adopt` in an agent session: it triages the repo's real open loops and imports only what you confirm. |
+| **`install` refused** | Your `~/.claude/settings.json` has a malformed (non-object) `hooks` value. Director won't overwrite data it doesn't understand: fix the file, then re-run. |
 
 ---
 


### PR DESCRIPTION
## What

Removes em dashes from the four reader-facing docs (`README.md`, `docs/getting-started.md`, `docs/README.md`, `docs/dogfood.md`), per the prose-style preference. ~86 replacements, each chosen by context (colon / comma / parentheses / semicolon / sentence split), not a blind swap.

## Scope
- **In:** the reader-facing docs above.
- **Left as literal content:** em dashes inside fenced code blocks / inline code (terminal output, command examples, one example CHARTER) and numeric en-dashes (`1–16`). Table N/A cells (`handoff`/`note` lifecycle) went from `—` to `none`.
- **Already clean:** `site/index.html`, `docs/why-director.md`.
- **Out of scope (separate call):** Go source comments (~500), design specs/plans/review docs, model-facing `SKILL.md` + slash-command prompts. Director's own example/emitted content (the `adopt` CHARTER stub in `adopt.go`, `doctor` output in `doctorcmd.go`) still has em dashes; say the word for a follow-up.

## Method
Four parallel agents (one per file, shared rubric), then a full manual review pass. The review caught and fixed two things before this PR: a tagline that read as a 4-item list, and a space-before-punctuation defect in docs/README.md's link list.

## Gate
`go build ./...` clean. Docs-only, no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
