### PR TITLE
docs: port the Reddit-post messaging lessons into the user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@
 
 **[The two-minute tour: colinsurprenant.github.io/director](https://colinsurprenant.github.io/director/)**
 
-Memory tools answer *"what does the agent know?"* Director answers *"what is the state of the work?"*: what was decided and why, which loops were deliberately deferred, where the work stopped when the block ended, and what still needs *you*. Facts accumulate; loops open and close. Nothing in a memory store ever *closes*. That lifecycle is the difference. Run both: they don't overlap.
+Every session with a coding agent starts fresh on the state of the work: what was decided and why, which loops you left open on purpose, where the last block stopped. Most people carry that across by hand (a CLAUDE.md, a notes file, a "write a handoff for the next one" before they stop), and that instinct is right. But a hand-kept record rides on you remembering, has no open-vs-closed lifecycle, and doesn't survive two sessions at once. **The session boundary is where the state leaks**: one repo or many, whether it's a compaction, a session ending, a week away, or a parallel worktree.
 
-Three weeks after you park a project, a new session starts already knowing all of this: injected at session start as ground truth, not recalled by similarity.
-
-Every session with a coding agent starts fresh on the state of the work: what was decided and why, which loops you left open on purpose, where the last block stopped. Most people carry that across by hand (a CLAUDE.md, a notes file, a "write a handoff for the next one" before they stop), and that instinct is right; a hand-kept record just rides on you remembering, has no open-vs-closed lifecycle, and doesn't survive two sessions at once. **The session boundary is where the state leaks**: one repo or many, whether it's a compaction, a session ending, a week away, or a parallel worktree. Director closes that leak and moves you from **message bus** to **reviewer**. You don't operate it: it wires into Claude Code and Codex through hooks, the session emits as it works, and that state is injected into the next one as ground truth. It is built around a shared, durable, **append-only event log** per repo:
+Director closes that leak, and you don't operate it: it wires into Claude Code and Codex through hooks, the session emits as it works, and that state is injected into the next one as ground truth. It moves you from **message bus** to **reviewer**, built around a shared, durable, **append-only event log** per repo:
 
 - Sessions **`emit`** typed events as they work (`decision` · `open-item` · `handoff` · `note`) and **`resolve`** open loops when they truly close.
-- A deterministic fold collapses the log into **`render`** (the machine digest), **`brief`** (the human re-orientation view), and **`status`** (the one-line-per-workstream cockpit).
-- A SessionStart hook **injects** the CHARTER + digest into every new session as ground truth, so a cold re-entry starts from your parked handoff instead of from git archaeology.
+- The log collapses deterministically into **`render`** (the machine digest), **`brief`** (the human re-orientation view), and **`status`** (the one-line-per-workstream cockpit).
+- A SessionStart hook **injects** the CHARTER + digest into every new session as ground truth, so a cold re-entry (three weeks after the last block) starts from your parked handoff instead of from git archaeology.
 - The log is **model-agnostic**: the next session can be you tomorrow, you after a compaction, or a stronger model you escalate a stuck problem to, with the tried-and-failed hypotheses traveling along. Escalate with context, not with amnesia.
 
-The LOG (plus the deliberately-edited living docs) is the only system of record; sessions and every rendered view are disposable caches reconstructible from it. Director wires natively into **Claude Code and OpenAI Codex**: same hooks, same log, same boundary commands, either agent alone or both side by side. A single static binary, stdlib-first, one vetted build-time dependency (`github.com/oklog/ulid/v2`). No daemon, no database, no cloud: the log is plain NDJSON you could read with `cat`.
+Memory tools answer *"what does the agent know?"* Director answers *"what is the state of the work?"*: what was decided and why, which loops were deliberately deferred, and what still needs *you*. Facts accumulate; loops open and close, and nothing in a memory store ever *closes*. That lifecycle is the difference, and so is the delivery: pushed at session start, not recalled by similarity. Run both: they don't overlap.
+
+The LOG (plus the deliberately-edited living docs) is the only system of record; sessions and every rendered view are disposable caches reconstructible from it. Director wires natively into **Claude Code and OpenAI Codex**: same hooks, same log, same boundary commands, either agent alone or both side by side. A single static binary, stdlib-first, one vetted build-time dependency (`github.com/oklog/ulid/v2`). No daemon, no database, no cloud, no telemetry: the binary never opens a network connection, and the log is plain NDJSON.
 
 ```text
 $ claude
@@ -45,7 +45,7 @@ $ claude
 01KWJ4W8…  decision   cursor pagination, not offset; offsets break under deletes
 ```
 
-*The same three facts on both sides of the gap: recorded as the session works, injected when the next one starts.*
+*The same three facts on both sides of the gap: recorded as the session works, injected when the next one starts ("need-you" counts the open items waiting on a human call).*
 
 That is one workstream. When several are in flight, `director status` is the whole board at a glance:
 
@@ -70,7 +70,7 @@ The design in four ideas (the full argument, including honest comparisons, is [`
 - **The durability gradient.** Director owns only the fast layer (coordination in flight); plans and architecture docs own the slower ones. One home per fact; truth flows up, never sideways.
 - **Steering is a hat, not a daemon.** No master session: the big picture is a durable projection owned by nobody, and any session wears the steering hat by reading `brief` + `status`. If a session dying loses real information, that's a liability, not an architecture.
 
-**How it compares, in one line each** ([full versions](docs/why-director.md#how-it-compares)): memory tools answer *"what does the agent know?"* while Director answers *"what is in flight?"*; issue trackers (beads et al.) hold the work items while Director holds **the narrative between tasks**; native multi-session features (Agent Teams) are session-scoped by design while Director is the durable, git-adjacent layer *underneath* them; and versus a markdown file plus discipline, Director adds append-only integrity under concurrent writers, a byte-identical verifiable fold, `resolve` lifecycle semantics, and push-injection that doesn't depend on the model remembering to read a file.
+**How it compares, in one line each** ([full versions](docs/why-director.md#how-it-compares)): memory tools answer *"what does the agent know?"* while Director answers *"what is in flight?"*; issue trackers (beads et al.) hold the work items while Director holds **the narrative between tasks**; native multi-session features (Agent Teams) are session-scoped by design while Director is the durable, git-adjacent layer *underneath* them; and versus a markdown file plus discipline, Director adds append-only integrity under concurrent writers, byte-identical verifiable views, `resolve` lifecycle semantics, and push-injection that doesn't depend on the model remembering to read a file.
 
 ## Install
 
@@ -222,7 +222,7 @@ director resolve <ulid>
 director promote <ulid> [<ulid>...] --to <doc>
 ```
 
-`promote` is the grooming ceremony that keeps the digest tracking **current work, not project age**. Once a batch of aged-but-durable decisions' rationale has been written into a living doc (an ADR, an architecture overview), `promote` appends one **promote-marker**: a `decision` with `status: promoted`, `refs` naming the promoted decisions, and `promoted_to` carrying the doc path. The fold drops the promoted decisions from the active projection; the marker stays as a one-line doc pointer, and `director show <ulid>` still serves every original in full. Nothing is lost, the rationale just changed address (and since Director is single-human by design, promotion into the slow layer is also the cross-human interface).
+`promote` is the grooming ceremony that keeps the digest tracking **current work, not project age**. Once a batch of aged-but-durable decisions' rationale has been written into a living doc (an ADR, an architecture overview), `promote` appends one **promote-marker**: a `decision` with `status: promoted`, `refs` naming the promoted decisions, and `promoted_to` carrying the doc path. The fold that builds the projections drops the promoted decisions from the active view; the marker stays as a one-line doc pointer, and `director show <ulid>` still serves every original in full. Nothing is lost, the rationale just changed address (and since Director is single-human by design, promotion into the slow layer is also the cross-human interface).
 
 Validation is `resolve`-parity: every target must be a decision the CLI surfaced, not superseded by an ordinary decision, and not already claimed by a *live* promote-marker. Invented ids, non-decisions, already-promoted and superseded targets are refused, and one bad target rejects the whole batch (nothing is written). A mispointed promotion is recoverable: supersede the bad marker with an ordinary decision (`emit --refs <marker-ulid>`), then re-promote to the correct address. Only *live* markers hold the already-promoted claim.
 
@@ -236,7 +236,7 @@ Validation is `resolve`-parity: every target must be a decision the CLI surfaced
 | `brief [--project <key>]` | human | the on-demand bigger-picture re-orientation view (outlook from CHARTER, latest handoff per workstream, open/escalate items, recent decisions), at project or whole-fleet altitude. |
 | `status` | human | the one-line-per-workstream fleet cockpit: handle · liveness · heartbeat recency · the **Needs-you** band (open `escalate` items). |
 
-`brief` and `render` share the same byte-identical fold: the human reads the same picture a fresh session reads. A fourth, narrower projection, `open-items`, lists a workstream's unresolved open-items (ULID + body); it exists to feed `resolve` and `/director:complete`. It defaults to the current workstream; `--workstream <id>` retargets it at a sibling: the close-out path for a workstream whose session is already gone.
+`brief` and `render` share the same byte-identical fold of the log: the human reads the same picture a fresh session reads. A fourth, narrower projection, `open-items`, lists a workstream's unresolved open-items (ULID + body); it exists to feed `resolve` and `/director:complete`. It defaults to the current workstream; `--workstream <id>` retargets it at a sibling: the close-out path for a workstream whose session is already gone.
 
 The digest is deliberately an *index*: every line is capped to a headline so the injection stays small as a project's log grows, and nothing is lost: `show <ulid>` prints any single event in full (body verbatim, as recorded), one deterministic hop from any headline. When even the capped digest would overrun the injection budget, the decisions section collapses to a count-plus-pointer line and the overflow lands in `health/` as a grooming signal; the open-set and the latest handoff are never cut. The grooming verbs that keep that headroom are `resolve` (compacts the open-set), supersession via `--refs`, and `promote` (compacts the decision set into the docs).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,9 +17,21 @@ called out where they exist (see "Using OpenAI Codex?" in section 1). Go is only
 
 ## 1. Install (one time)
 
-Get the `director` binary onto your `PATH` by any of the three paths below, then run `director install`.
+### The one-liner (recommended)
 
-### From a release (recommended)
+```bash
+curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
+```
+
+One command downloads the right prebuilt binary for your platform (checksum-verified), installs it to
+`~/.local/bin`, and runs `director install` to wire Claude Code (wire Codex instead with `sh -s -- --codex`,
+or `--both`; install the binary only with `sh -s -- --no-wire`). **Already ran it?** The binary is in
+place: run `director doctor` to confirm the wiring, then skip to section 2.
+
+Prefer to place the binary yourself? Any of the three paths below gets `director` onto your `PATH`;
+then run `director install` (the "Wire the hooks" step below).
+
+### From a release
 
 Each tagged release publishes prebuilt binaries for macOS, Linux, and Windows (amd64 and arm64) as
 `director_<tag>_<os>_<arch>.tar.gz` (`.zip` for Windows), plus a `checksums.txt`, on the

--- a/docs/why-director.md
+++ b/docs/why-director.md
@@ -16,14 +16,14 @@ Director exists to move you from **message bus** to **reviewer**.
 
 ## What Director is
 
-You don't operate Director; your agents do. It installs into Claude Code and Codex as hooks, so the writing happens as sessions work and the state is there waiting when the next one starts. What it maintains is a shared, durable, **append-only event log** per repo (one static Go binary: no daemon, no database, no cloud), plus **deterministic projections** over it:
+You don't operate Director; your agents do. It installs into Claude Code and Codex as hooks, so the writing happens as sessions work and the state is there waiting when the next one starts. What it maintains is a shared, durable, **append-only event log** per repo (one static Go binary: no daemon, no database, no cloud, no telemetry), plus **deterministic projections** over it:
 
 - Sessions **emit** typed events as they work, using exactly four kinds (`decision`, `open-item`, `handoff`, `note`), and **resolve** open-items when they are truly closed.
-- A deterministic, non-LLM fold collapses the log into three views: `render` (the machine digest), `brief` (the human re-orientation view), and `status` (the one-line-per-workstream cockpit with a *Needs-you* band).
-- A SessionStart hook **injects** the project CHARTER plus the folded digest into every new session as authoritative ground truth. Push, not pull: a protocol the model must remember to invoke is a protocol that never fires.
+- The log collapses deterministically (no LLM in the loop) into three views: `render` (the machine digest), `brief` (the human re-orientation view), and `status` (the one-line-per-workstream cockpit with a *Needs-you* band).
+- A SessionStart hook **injects** the project CHARTER plus the digest into every new session as authoritative ground truth. Push, not pull: a protocol the model must remember to invoke is a protocol that never fires.
 - Boundary commands mark workstream lifecycle: `/director:handoff` when pausing (records the resume point), `/director:complete` when a workstream is done and merged (human-confirmed close-out of its open loops).
 
-The log is NDJSON: plain, greppable, git-trackable text. If Director disappeared tomorrow, your coordination history would still be readable with `cat`.
+The log is NDJSON: plain, greppable, git-trackable text. If Director disappeared tomorrow, your coordination history would still be readable, no tooling required.
 
 The shortest honest description: **a coordination ledger your agents actually keep.** Engineers have known for decades that an append-only, timestamped, never-rewritten journal (the engineering daybook) beats a curated wiki for recovering context. Director mechanizes that practice for a portfolio of agent sessions, and adds the two things a daybook can't do: lifecycle (a loop stays open until consciously resolved; a decision is superseded, never lost) and deterministic projections that answer "what's open, everywhere, right now."
 
@@ -74,7 +74,7 @@ The slow layer independently validates the design. Nygard's original ADR discipl
 
 ## Steering is a hat, not a daemon
 
-Director has **no master session.** The big picture, the thing every "orchestrator" architecture centralizes in a coordinator that must stay alive, is here a *durable projection owned by nobody*. Any session (or the human, directly) can wear the steering hat for a moment by reading `brief` and `status`. The integrator is the fold, not a process.
+Director has **no master session.** The big picture, the thing every "orchestrator" architecture centralizes in a coordinator that must stay alive, is here a *durable projection owned by nobody*. Any session (or the human, directly) can wear the steering hat for a moment by reading `brief` and `status`. The integrator is the fold of the log into its projections, not a process.
 
 The design test: **if a session dying loses real information, that's a liability, not an architecture.** A long-lived "cockpit" session is fine as a convenience, but it must hold no privileged knowledge; everything it knows is in the stream, so losing it costs only scrollback. Corollary: if you feel you need a master session, the stream isn't rich enough. Fix the stream, don't anoint an owner.
 
@@ -111,7 +111,7 @@ Non-goals, stated as firmly as the goals:
 - **Not a methodology.** Invariants, not process (see above).
 - **Not semantic memory.** No embeddings, no vector DB, no retrieval ranking. The record is small enough to read because emission is deliberate, and legible because it's typed prose.
 - **Not multi-user.** Single-human by design: Director externalizes *one* developer's in-flight working memory. Sessions are plural, machines are plural, humans are not. In-flight fast-band context is inherently singular in every org shape; teams sync through the slow layers (PRs, tickets, ADRs), so the cross-human interface is `promote`, never a shared log. Succession still works for free: the log is a portable file plus a deterministic fold, and an inheritor rehydrates exactly like your own next session would.
-- **No database, no daemon, no cloud.** Durable state is NDJSON files in a directory you own. The binary runs and exits.
+- **No database, no daemon, no cloud, no telemetry.** Durable state is NDJSON files in a directory you own. The binary runs, never opens a network connection, and exits.
 - **No autonomy.** Close-out is human-confirmed; nothing auto-resolves your open loops; nudges never write on your behalf.
 
 ## The honest caveats

--- a/site/index.html
+++ b/site/index.html
@@ -311,13 +311,13 @@
 <span class="hd">## decisions</span>
 <span class="id">01KWJ4W8…</span>  <span class="cyan">decision</span>   cursor pagination, not offset; offsets break under deletes</code></pre>
     </div>
-    <figcaption class="term-cap">the same three facts on both sides of the gap: recorded as the session works, injected when the next one starts</figcaption>
+    <figcaption class="term-cap">the same three facts on both sides of the gap: recorded as the session works, injected when the next one starts · need-you counts what waits on a human call</figcaption>
   </figure>
 </div>
 
 <section class="wrap">
   <p class="kicker">how it works</p>
-  <h2>An append-only log per repo. A deterministic fold. A push at session start.</h2>
+  <h2>An append-only log per repo. Deterministic projections. A push at session start.</h2>
   <div class="grid">
     <div class="cell">
       <h3><span class="p">$</span> director emit</h3>
@@ -329,7 +329,7 @@
     </div>
     <div class="cell">
       <h3><span class="p">$</span> director brief</h3>
-      <p>A deterministic fold collapses the log into the machine digest, the human brief, and the fleet cockpit. Every session and the human read the <em>same</em> picture, byte-identical, verifiable.</p>
+      <p>The log collapses deterministically into the machine digest, the human brief, and the fleet cockpit. Every session and the human read the <em>same</em> picture, byte-identical, verifiable.</p>
     </div>
     <div class="cell">
       <h3>SessionStart hook</h3>
@@ -352,14 +352,14 @@
     </div>
     <div>
       <dt>vs a markdown file</dt>
-      <dd>Append-only integrity under concurrent writers, a byte-identical verifiable fold, lifecycle semantics, push-injection. Willpower is not a file format.</dd>
+      <dd>Append-only integrity under concurrent writers, byte-identical verifiable views, lifecycle semantics, push-injection. Willpower is not a file format.</dd>
     </div>
   </dl>
 </section>
 </main>
 
 <footer class="wrap">
-  <p class="foot-line">A single static Go binary. No daemon, no database, no cloud. The log is plain NDJSON you could read with <code>cat</code>.</p>
+  <p class="foot-line">A single static Go binary. No daemon, no database, no cloud, no telemetry: it never opens a network connection. The log is plain NDJSON.</p>
   <nav class="foot-links" aria-label="Footer">
     <a href="https://github.com/colinsurprenant/director">GitHub</a>
     <a href="https://github.com/colinsurprenant/director/blob/main/docs/getting-started.md">Getting started</a>


### PR DESCRIPTION
Backports the messaging lessons from the finalized r/ClaudeAI post review into every reader-facing surface (README, getting-started, why-director, the site), so the docs and the post tell the same story the same way.

## What changed

**Funnel fix (getting-started §1).** The curl one-liner was absent from getting-started entirely, and the manual release-tarball path was marked "recommended" -- while the installer's own final output points users at this doc. The one-liner is now the recommended path, with an "already ran it? `director doctor`, then section 2" fast path; manual release install is demoted to an alternative.

**README hero restructure.** Problem-first order: fresh-start problem, the validated hand-rolled habit, then Director. The memory-tools distinction moves after the mechanism instead of leading the README (a cold reader was handed a rebuttal before the problem). The former 150-word wall paragraph is split into short ones. No content lost.

**Jargon at hero altitude.** "A deterministic fold collapses..." becomes "The log collapses deterministically into..." in the README bullet, the why-director bullet, and the site (h2 -> "Deterministic projections.", card, vs-row). "fold" survives in the reference sections, grounded as "fold of the log" at each first use so the term never dangles.

**Trust claim.** "No telemetry: the binary never opens a network connection" added wherever the boring-tech line appears. Verified: `go list -deps` shows no `net`/`net/http`/`crypto/tls` anywhere in the dependency graph; the only external process is `exec` of `git`.

**Small cuts.** The "read it with `cat`" flourish removed on all surfaces.

**Banner fidelity (review catch).** The first draft dropped ", 1 need-you" from the example banners to fix a cold unexplained token; review flagged that the real SessionStart banner prints that segment unconditionally (internal/hook/sessionstart.go:409), so the examples would have shown output the tool can never produce. The examples keep the exact real format, and the token is glossed in the example captions instead.

## Verification

- Docs-only diff; `go test ./... -race -count=1` green.
- ce:code-reviewer pass on the diff: install-section claims verified against install.sh (checksum verify, ~/.local/bin, default Claude Code wiring, --codex/--both/--no-wire), intra-doc anchors checked, no em dashes in added prose. Its two findings (banner fidelity, dangling "fold") are incorporated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
