### PR TITLE
feat(fold): completion-note refs conclude a workstream's handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ director emit --type decision|open-item|handoff|note --area <subsystem> \
   [--risk low|escalate] [--to <handle>] [--refs <ulid,ulid>] <body>
 ```
 
-`emit` prints the **new event's ULID to stdout**: note it; that is the id used to `--refs` or `resolve` the event later.
+`emit` prints the **new event's ULID to stdout**: note it; that is the id used to `--refs` or `resolve` the event later. (One `--refs` pairing is load-bearing: a `note` ref naming a **handoff** concludes it — see the kind table's lifecycle column below.)
 
 ### resolve: close an open-item
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ There are exactly four model-emitted semantic kinds. Pick by what the fact *is*:
 |---|---|---|
 | `decision` | a choice + what it affects | active → superseded (a later decision's `--refs`) or promoted (via `promote`); carries `--risk low\|escalate` |
 | `open-item` | an open loop / follow-up / deferred item, the canonical home for "documented, not dropped" | open → closed (via `resolve`) |
-| `handoff` | a positional snapshot: current task · next action · hypotheses · dead ends (tried X, failed: Y) | none |
+| `handoff` | a positional snapshot: current task · next action · hypotheses · dead ends (tried X, failed: Y) | active → concluded (a `note`'s `--refs`, emitted by `/director:complete` — the handoff leaves the digest, stays in the log) |
 | `note` | FYI / context for a parallel or future session | none |
 
 - **There is no `blocker` kind.** "Stuck, needs a human" is an `open-item` with `--risk escalate`, exactly the open-set that surfaces in `status`'s Needs-you band.

--- a/cmd/director/emit.go
+++ b/cmd/director/emit.go
@@ -21,7 +21,7 @@ func runEmit(args []string) int {
 	fs.StringVar(&area, "area", "", "subsystem/path tag")
 	fs.StringVar(&risk, "risk", "", "low|escalate (decisions and open-items)")
 	fs.StringVar(&to, "to", "", "addressed-to handle (optional)")
-	fs.StringVar(&refs, "refs", "", "comma-separated ULIDs this references/supersedes")
+	fs.StringVar(&refs, "refs", "", "comma-separated ULIDs this references/supersedes; a note ref naming a handoff CONCLUDES it (see /director:complete)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -338,7 +338,8 @@ At block boundaries, two slash commands (installed by `director install`) mark w
   move when a session has degraded (you keep repeating the same correction): hand off the distilled state,
   then `/clear` — a fresh session resuming from the checkpoint beats pushing a rotten context forward.
 - **`/director:complete`** when a workstream is done and merged. It closes out the workstream's open loops
-  with your confirmation and archives its fleet row. Nothing auto-resolves; close-out is human-confirmed.
+  with your confirmation, concludes its last handoff (so the digest stops offering a dead resume point),
+  and archives its fleet row. Nothing auto-resolves; close-out is human-confirmed.
   It also takes a workstream id (`/director:complete <id>`) to close out a *dead sibling*: a worktree
   that merged and was deleted before anyone ran the close-out. Its branch reads `gone` in `status`, and
   if it still owns open items, the next session you start on that repo will surface a "close-out pending"

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -51,6 +51,7 @@ const emitProtocol = "## Director protocol — keep this current as you work\n" 
 	"- an open-item the moment you defer a loop — `director emit --type open-item --area <area> --risk <low|escalate> \"<loop>\"`\n" +
 	"- a handoff at each natural boundary (sub-task done, switching focus, wrapping up) — `director emit --type handoff --area <area> \"current task · next · hypotheses · dead ends (tried X, failed: Y)\"`\n" +
 	"- when you FINISH an open-item, close it — `director resolve <ulid>` (use a ULID from the open-items listed below; resolve only when it is truly done — there is no reopen)\n" +
+	"Reserved: a note whose `--refs` names a handoff CONCLUDES it (retires that resume point from the digest) — only the `/director:complete` ceremony does this; never ref a handoff from a note otherwise.\n" +
 	"The digest below is an INDEX: entries are capped headlines, not full text. `director show <ulid>` prints any event in full — before touching an area, pull the full bodies of its listed decisions rather than guessing past a headline.\n" +
 	"At a WORKSTREAM boundary, suggest the matching close-out command to the human — the two are not interchangeable:\n" +
 	"- work DONE and merged → suggest `/director:complete`, BEFORE the branch/worktree is deleted — it reviews this workstream's open-items with the human, resolves the finished ones, and archives the workstream\n" +

--- a/internal/install/commands/complete.md
+++ b/internal/install/commands/complete.md
@@ -23,8 +23,8 @@ You are running the TERMINAL close-out for a workstream: its task is finished an
    `director resolve <ULID>`   (copy the exact ULID from the step-2 output — never invent or reconstruct one; `resolve` rejects any id it did not surface. It already works across workstreams — no flag needed.)
    Leave every genuine follow-up OPEN. Do not "tidy" them closed. The repo log is shared, so the next session on `main` inherits the still-open items automatically — they ARE the continuation, and need no handoff.
 
-5. **Emit a one-line completion summary** as a note (FYI for future / parallel sessions), naming the target workstream in the body:
-   `director emit --type note --area <subsystem> "<target-workstream> complete — <what shipped, e.g. PR #N merged>"`
+5. **Emit a one-line completion summary** as a note (FYI for future / parallel sessions), naming the target workstream in the body — and **conclude its resume point**: pass `--refs <ULID of the target's latest handoff>`. That ref retires the handoff (and any older ones of the workstream) from the digest's resume points, so the dead workstream stops surfacing as resumable; the handoff stays in the log, one `director show` away. Copy the ULID from the target's line in the `## handoffs` section of `director render`; if the target never emitted a handoff, omit `--refs`.
+   `director emit --type note --area <subsystem> --refs <handoff-ulid> "<target-workstream> complete — <what shipped, e.g. PR #N merged>"`
 
 6. **Archive the fleet row(s):**
    `director done`   (for a sibling: `director done --workstream <id>` — archives every row it left behind)

--- a/internal/render/fold.go
+++ b/internal/render/fold.go
@@ -20,9 +20,15 @@ import (
 type Projection struct {
 	Decisions     []event.Event          // active decisions (un-superseded), ULID-ascending
 	OpenItems     []event.Event          // the open-set: original open-items not yet closed, ULID-ascending
-	LatestHandoff map[string]event.Event // workstream → its highest-ULID handoff
+	LatestHandoff map[string]event.Event // workstream → its highest-ULID un-concluded handoff
 	Handoffs      []event.Event          // every handoff, ULID-ascending
 	Notes         []event.Event          // every note, ULID-ascending
+
+	// ConcludedHandoffs lists the handoff ids explicitly concluded by a note's
+	// Refs, ULID-ascending. It feeds the manifest (§9) so the one fold rule
+	// that removes digest content stays observable — which handoffs were
+	// retired, each one `director show`-able to find the concluding note.
+	ConcludedHandoffs []string
 }
 
 // Fold collapses an event set into a resolved Projection. It is a PURE function
@@ -44,6 +50,17 @@ type Projection struct {
 //     fold, which is also how pre-promote binaries degrade (identical active set).
 //   - latest handoff: iterating ULID-ascending, the highest-ULID handoff per
 //     workstream wins — the session's most recent position (§16).
+//   - concluded handoffs: a note whose Refs name a handoff CONCLUDES that
+//     workstream's trail up to and including it — a per-workstream high-water
+//     mark, so concluding the latest handoff can never resurface an even
+//     staler one as "latest". Concluded handoffs stay in Handoffs (history)
+//     and in the log, but leave LatestHandoff and therefore the digest: the
+//     same shape as resolve for open-items. This is how /director:complete
+//     retires a dead workstream's phantom resume point (the LIE-TEST gap,
+//     01KWZ6212N) — its completion note refs the target's last handoff. The
+//     meaning is reserved: a note refs a handoff ONLY to conclude it. A
+//     handoff emitted after the mark (a genuinely new position) surfaces
+//     normally.
 //
 // Bounded-read note: deriving the open-set correctly needs the full history (a
 // close-marker may sit arbitrarily far from its open-item), so v1 folds over the
@@ -63,10 +80,13 @@ func Fold(events []event.Event) Projection {
 
 	proj := Projection{LatestHandoff: make(map[string]event.Event)}
 
-	// Pass 1: build the two resolution sets — ids closed by a marker, and ids
-	// superseded by a later decision — independent of iteration order.
+	// Pass 1: build the resolution sets — ids closed by a marker, ids
+	// superseded by a later decision, and handoff ids concluded by a note —
+	// independent of iteration order.
 	closed := make(map[string]bool)
 	superseded := make(map[string]bool)
+	noteRefs := make(map[string]bool)
+	handoffWS := make(map[string]string) // handoff id → its workstream
 	for _, ev := range sorted {
 		switch ev.Type {
 		case event.KindOpenItem:
@@ -79,6 +99,28 @@ func Fold(events []event.Event) Projection {
 			for _, ref := range ev.Refs {
 				superseded[ref] = true
 			}
+		case event.KindHandoff:
+			handoffWS[ev.ID] = ev.Workstream
+		case event.KindNote:
+			for _, ref := range ev.Refs {
+				noteRefs[ref] = true
+			}
+		}
+	}
+	// A note ref concludes only ids that ARE handoffs (notes ref open-items
+	// and decisions for ordinary cross-linking — those keep their meaning).
+	// The per-workstream high-water mark is the highest concluded ULID: every
+	// handoff at or below it is retired from "latest".
+	concluded := make(map[string]bool)
+	maxConcluded := make(map[string]string)
+	for id := range noteRefs {
+		ws, isHandoff := handoffWS[id]
+		if !isHandoff {
+			continue
+		}
+		concluded[id] = true
+		if id > maxConcluded[ws] {
+			maxConcluded[ws] = id
 		}
 	}
 
@@ -98,8 +140,15 @@ func Fold(events []event.Event) Projection {
 			}
 		case event.KindHandoff:
 			proj.Handoffs = append(proj.Handoffs, ev)
-			// Ascending order means the last write per workstream is the highest ULID.
-			proj.LatestHandoff[ev.Workstream] = ev
+			if concluded[ev.ID] {
+				proj.ConcludedHandoffs = append(proj.ConcludedHandoffs, ev.ID)
+			}
+			// Ascending order means the last write per workstream is the
+			// highest ULID; anything at or below the conclusion high-water
+			// mark is retired and never becomes the resume point.
+			if ev.ID > maxConcluded[ev.Workstream] {
+				proj.LatestHandoff[ev.Workstream] = ev
+			}
 		case event.KindNote:
 			proj.Notes = append(proj.Notes, ev)
 		}

--- a/internal/render/fold.go
+++ b/internal/render/fold.go
@@ -48,8 +48,9 @@ type Projection struct {
 //     Refs drop the promoted decisions from the active set, and the marker
 //     itself stays active as the doc pointer — promotion IS supersession to the
 //     fold, which is also how pre-promote binaries degrade (identical active set).
-//   - latest handoff: iterating ULID-ascending, the highest-ULID handoff per
-//     workstream wins — the session's most recent position (§16).
+//   - latest handoff: iterating ULID-ascending, the highest-ULID UN-CONCLUDED
+//     handoff per workstream wins — the session's most recent position (§16);
+//     see the conclusion rule below for what "concluded" retires.
 //   - concluded handoffs: a note whose Refs name a handoff CONCLUDES that
 //     workstream's trail up to and including it — a per-workstream high-water
 //     mark, so concluding the latest handoff can never resurface an even

--- a/internal/render/fold_test.go
+++ b/internal/render/fold_test.go
@@ -244,3 +244,83 @@ func TestFoldDuplicatePromoteMarkers(t *testing.T) {
 		t.Error("duplicate-marker fold is order-dependent")
 	}
 }
+
+// TestFoldConcludedHandoffs locks the conclusion rule (decision 01KXMAZSKV,
+// fixing the 01KWZ6212N LIE-TEST gap): a note whose Refs name a handoff
+// concludes that workstream's trail up to and including it. Concluded
+// handoffs stay in Handoffs (history) but leave LatestHandoff — and,
+// crucially, an OLDER handoff never resurfaces as the resume point when the
+// newest one is concluded.
+func TestFoldConcludedHandoffs(t *testing.T) {
+	h1 := mint(t)     // ws1 older position
+	h2 := mint(t)     // ws1 final position — explicitly concluded
+	hOther := mint(t) // ws2, live and untouched
+	open := mint(t)   // ws1 open-item the note also refs (cross-kind guard)
+	note := mint(t)
+	events := []event.Event{
+		{ID: h1, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws1", Body: "older position"},
+		{ID: h2, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws1", Body: "final position"},
+		{ID: hOther, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws2", Body: "live position"},
+		{ID: open, SchemaVersion: event.SchemaVersion, Type: event.KindOpenItem, Workstream: "ws1", Status: event.StatusOpen, Body: "carried loop"},
+		{ID: note, SchemaVersion: event.SchemaVersion, Type: event.KindNote, Workstream: "ws1", Refs: []string{h2, open}, Body: "ws1 complete — PR merged"},
+	}
+
+	proj := Fold(events)
+	if _, ok := proj.LatestHandoff["ws1"]; ok {
+		t.Errorf("concluded workstream still has a latest handoff (older one resurfaced?): %+v", proj.LatestHandoff["ws1"])
+	}
+	if got := proj.LatestHandoff["ws2"].ID; got != hOther {
+		t.Errorf("unrelated workstream's latest handoff = %s, want %s", got, hOther)
+	}
+	if len(proj.Handoffs) != 3 {
+		t.Errorf("conclusion must not erase history: %d handoffs, want 3", len(proj.Handoffs))
+	}
+	// The manifest view lists exactly the EXPLICITLY concluded id — not the
+	// older handoff the high-water mark also retires, and never the note's
+	// non-handoff refs.
+	if !reflect.DeepEqual(proj.ConcludedHandoffs, []string{h2}) {
+		t.Errorf("ConcludedHandoffs = %v, want [%s]", proj.ConcludedHandoffs, h2)
+	}
+	// A note ref must not act as a close-marker: the open-item stays open.
+	if !containsID(proj.OpenItems, open) {
+		t.Error("note ref closed an open-item — conclusion must be handoff-only")
+	}
+
+	for _, seed := range []int64{1, 7, 99} {
+		if !reflect.DeepEqual(Fold(shuffled(events, seed)), proj) {
+			t.Fatalf("concluded-handoff fold is order-dependent (seed %d)", seed)
+		}
+	}
+}
+
+// TestFoldConclusionHighWaterMark pins the mark's direction: concluding an
+// OLDER handoff leaves a newer position untouched (a handoff emitted after
+// the conclusion is a genuinely new resume point and surfaces normally), and
+// multiple explicit conclusions list ULID-ascending regardless of Refs order.
+func TestFoldConclusionHighWaterMark(t *testing.T) {
+	h1 := mint(t)
+	h2 := mint(t)
+	events := []event.Event{
+		{ID: h1, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws1", Body: "old position"},
+		{ID: h2, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws1", Body: "new position"},
+		{ID: mint(t), SchemaVersion: event.SchemaVersion, Type: event.KindNote, Workstream: "ws1", Refs: []string{h1}, Body: "concludes only the old position"},
+	}
+	proj := Fold(events)
+	if got := proj.LatestHandoff["ws1"].ID; got != h2 {
+		t.Errorf("handoff above the mark must stay latest: got %s, want %s", got, h2)
+	}
+	if !reflect.DeepEqual(proj.ConcludedHandoffs, []string{h1}) {
+		t.Errorf("ConcludedHandoffs = %v, want [%s]", proj.ConcludedHandoffs, h1)
+	}
+
+	// Both concluded, refs listed newest-first: the workstream leaves
+	// LatestHandoff and the manifest view is still ULID-ascending.
+	events[2].Refs = []string{h2, h1}
+	proj = Fold(events)
+	if _, ok := proj.LatestHandoff["ws1"]; ok {
+		t.Error("fully concluded workstream still has a latest handoff")
+	}
+	if !reflect.DeepEqual(proj.ConcludedHandoffs, []string{h1, h2}) {
+		t.Errorf("ConcludedHandoffs = %v, want ULID-ascending [%s %s]", proj.ConcludedHandoffs, h1, h2)
+	}
+}

--- a/internal/render/fold_test.go
+++ b/internal/render/fold_test.go
@@ -312,6 +312,11 @@ func TestFoldConclusionHighWaterMark(t *testing.T) {
 	if !reflect.DeepEqual(proj.ConcludedHandoffs, []string{h1}) {
 		t.Errorf("ConcludedHandoffs = %v, want [%s]", proj.ConcludedHandoffs, h1)
 	}
+	for _, seed := range []int64{1, 7, 99} {
+		if !reflect.DeepEqual(Fold(shuffled(events, seed)), proj) {
+			t.Fatalf("mark-direction fold is order-dependent (seed %d)", seed)
+		}
+	}
 
 	// Both concluded, refs listed newest-first: the workstream leaves
 	// LatestHandoff and the manifest view is still ULID-ascending.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -165,16 +165,19 @@ type Manifest struct {
 // markers, so the raw count is passed separately to keep the diff honest).
 func BuildManifest(proj Projection, repoKey, source string, raw []event.Event) Manifest {
 	return Manifest{
-		RepoKey:           repoKey,
-		Source:            source,
-		Events:            len(raw),
-		Decisions:         len(proj.Decisions),
-		OpenItems:         len(proj.OpenItems),
-		Handoffs:          len(proj.Handoffs),
-		Notes:             len(proj.Notes),
-		LastID:            LastID(raw),
-		Workstreams:       sortedKeys(proj.LatestHandoff),
-		ConcludedHandoffs: proj.ConcludedHandoffs,
+		RepoKey:     repoKey,
+		Source:      source,
+		Events:      len(raw),
+		Decisions:   len(proj.Decisions),
+		OpenItems:   len(proj.OpenItems),
+		Handoffs:    len(proj.Handoffs),
+		Notes:       len(proj.Notes),
+		LastID:      LastID(raw),
+		Workstreams: sortedKeys(proj.LatestHandoff),
+		// Never nil: the sibling workstreams field always marshals as [], and
+		// the §9 artifact is diffable — the first conclusion must not flip the
+		// field null → [...].
+		ConcludedHandoffs: append([]string{}, proj.ConcludedHandoffs...),
 	}
 }
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -152,6 +152,12 @@ type Manifest struct {
 	Notes       int      `json:"notes"`       // raw note count
 	LastID      string   `json:"last_id"`     // highest event id read (last-verified)
 	Workstreams []string `json:"workstreams"` // workstreams with a latest handoff, sorted
+
+	// ConcludedHandoffs lists the handoff ids a note's Refs concluded, ULID
+	// order. Conclusion is the one fold rule that removes digest content, so
+	// the removal is recorded here rather than silent: each id is one
+	// `director show` away from the concluding note.
+	ConcludedHandoffs []string `json:"concluded_handoffs"`
 }
 
 // BuildManifest derives the manifest for one fold. rawCount is the number of
@@ -159,15 +165,16 @@ type Manifest struct {
 // markers, so the raw count is passed separately to keep the diff honest).
 func BuildManifest(proj Projection, repoKey, source string, raw []event.Event) Manifest {
 	return Manifest{
-		RepoKey:     repoKey,
-		Source:      source,
-		Events:      len(raw),
-		Decisions:   len(proj.Decisions),
-		OpenItems:   len(proj.OpenItems),
-		Handoffs:    len(proj.Handoffs),
-		Notes:       len(proj.Notes),
-		LastID:      LastID(raw),
-		Workstreams: sortedKeys(proj.LatestHandoff),
+		RepoKey:           repoKey,
+		Source:            source,
+		Events:            len(raw),
+		Decisions:         len(proj.Decisions),
+		OpenItems:         len(proj.OpenItems),
+		Handoffs:          len(proj.Handoffs),
+		Notes:             len(proj.Notes),
+		LastID:            LastID(raw),
+		Workstreams:       sortedKeys(proj.LatestHandoff),
+		ConcludedHandoffs: proj.ConcludedHandoffs,
 	}
 }
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -434,5 +435,49 @@ func TestDigestDates(t *testing.T) {
 		if got := Digest(Fold(shuffled(events, seed)), "widget"); got != d {
 			t.Fatalf("dated digest changed under input shuffle seed %d", seed)
 		}
+	}
+}
+
+// TestDigestConcludedHandoffs pins the user-visible outcome of conclusion at
+// the digest and manifest levels (the fold rule itself is locked in
+// fold_test.go): a concluded workstream's handoff line leaves ## handoffs, a
+// live sibling's stays, the section degrades to "(none)" when every
+// workstream is concluded, and the manifest records what was retired.
+func TestDigestConcludedHandoffs(t *testing.T) {
+	hDead := mint(t)
+	hLive := mint(t)
+	note := mint(t)
+	events := []event.Event{
+		{ID: hDead, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws-dead", Body: "READY FOR MERGE, awaiting user go"},
+		{ID: hLive, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws-live", Body: "mid-task position"},
+		{ID: note, SchemaVersion: event.SchemaVersion, Type: event.KindNote, Workstream: "ws-dead", Refs: []string{hDead}, Body: "ws-dead complete — PR merged"},
+	}
+	proj := Fold(events)
+	d := Digest(proj, "widget")
+
+	if strings.Contains(d, "[ws-dead]") || strings.Contains(d, "READY FOR MERGE") {
+		t.Errorf("concluded workstream's handoff still in the digest — the phantom resume point survives:\n%s", d)
+	}
+	if !strings.Contains(d, "[ws-live] mid-task position") {
+		t.Errorf("live workstream's handoff missing from the digest:\n%s", d)
+	}
+
+	m := BuildManifest(proj, "widget", "/some/log.ndjson", events)
+	if !reflect.DeepEqual(m.ConcludedHandoffs, []string{hDead}) {
+		t.Errorf("manifest concluded_handoffs = %v, want [%s]", m.ConcludedHandoffs, hDead)
+	}
+	if !reflect.DeepEqual(m.Workstreams, []string{"ws-live"}) {
+		t.Errorf("manifest workstreams = %v, want [ws-live]", m.Workstreams)
+	}
+
+	// Every workstream concluded → the section is an explicit "(none)", never
+	// a missing header.
+	all := Digest(Fold(events[:1:1]), "widget") // dead handoff alone, un-concluded control
+	if !strings.Contains(all, "[ws-dead]") {
+		t.Fatalf("control digest missing the un-concluded handoff:\n%s", all)
+	}
+	solo := Digest(Fold([]event.Event{events[0], events[2]}), "widget")
+	if !strings.Contains(solo, "## handoffs\n(none)\n") {
+		t.Errorf("fully concluded log must render an explicit empty handoffs section:\n%s", solo)
 	}
 }

--- a/skills/director/SKILL.md
+++ b/skills/director/SKILL.md
@@ -50,6 +50,11 @@ There are exactly four model-emitted kinds. Pick by what the fact *is*:
 | `handoff` | current task · next action · hypotheses · dead ends (positional snapshot at a boundary) | `director emit --type handoff --area store "Done: NDJSON append. Next: wire emit dispatch. Hypothesis: O_APPEND is line-atomic on POSIX. Dead end: fsync-per-line, 30x too slow"` |
 | `note` | FYI / context for a parallel or future session | `director emit --type note --to @next-on-hooks --area hooks "settings.json merge is _managedBy-tagged — don't strip GSD entries"` |
 
+One **reserved ref meaning**: a `note` whose `--refs` names a **handoff** CONCLUDES it — that
+handoff (and the workstream's older ones) leaves the digest's resume points, staying in the log.
+`/director:complete` uses this to retire a dead workstream's last handoff. Never ref a handoff
+from a note casually; refs to decisions and open-items carry no such effect.
+
 Routing rule: an **open loop you carry forward** → an `open-item` event (its one home).
 **Durable structured knowledge** (intent, architecture, a decision's full rationale) → the living
 docs (CHARTER, README, ADRs), with the `decision`/`open-item` body holding a short pointer, not


### PR DESCRIPTION
Fixes the `01KWZ6212N` LIE-TEST gap: after `/director:complete`, a dead workstream's last handoff kept surfacing in the injected digest as an apparent resume point, forever. Design ratified as decision `01KXMAZSKV` (option B of three considered; A = fleet-aware render was rejected because the digest would depend on mutable per-machine fleet state, C = mark-only would leave the payload weight in place).

## The rule

A `note` whose `--refs` name a handoff **concludes** that workstream's trail up to and including it (a per-workstream ULID high-water mark, so concluding the latest handoff can never resurface an older, staler one). Concluded handoffs stay in the log and in `Projection.Handoffs`; they leave `LatestHandoff` and therefore the digest and brief. Same shape as `resolve` for open-items.

- **Determinism (§13 t4) untouched**: the conclusion is itself an append-only event, so the digest remains a pure function of the event set; `--verify` rides unchanged. Order-independence is shuffle-asserted in every new test.
- **Self-healing**: a handoff emitted after the mark is a genuinely new position and surfaces normally, so a mistaken conclusion is recoverable by emitting a fresh handoff.
- **Observable**: the render manifest (§9) gains `concluded_handoffs` (explicitly concluded ULIDs, ULID-ascending, never null). Conclusion is the one fold rule that removes digest content, so the removal is recorded — and provably, every digest-visible removal appears in the list.
- **Old binaries degrade to today's behavior** (the note folds as a plain note). No new event kind, no schema change, no CLI change.

## Ceremony + guardrails

`/director:complete` step 5 now passes `--refs <target's latest handoff ULID>` on its completion note. The reserved meaning ("a note refs a handoff ONLY to conclude it") is planted where agents actually learn habits: the injected emit-protocol, `emit --refs` flag help, the director skill, README (emit section + kind-table lifecycle), and getting-started.

## Measured payoff (live hub, dogfood)

With the retro conclusion notes emitted for the 8 already-closed-out workstreams, `director render` drops from **27,129B to 22,358B (−4.8KB)**; the `## handoffs` section goes from 9 entries (8 of them dead, including one literally reading "READY FOR MERGE, awaiting user go" for a PR merged 8 days ago) to exactly 1: the live workstream's own resume point. Manifest records `concluded: 8`.

## Review

Pre-push ce code review: **approve** — order-independence verified by construction and test, high-water-mark edges probed, the retroactive-reinterpretation risk checked against the actual live logs (no historical note→handoff ref exists that wasn't emitted deliberately as a conclusion supplement). Its one important ask (the reserved-meaning caution must ride the injected protocol, since SKILL.md never enters working context) plus all suggestions (never-nil manifest field, `--refs` flag-help caution, README emit-section cross-ref, mark-direction shuffle assertion) are folded in as the second commit.

Gate: `go test ./... -race -count=1`, `go vet`, `gofmt -l` green (the injected-protocol growth fit inside the budget-ladder fixture's re-tuned window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
