### PR TITLE
feat(install): OpenCode adapter (--opencode): managed plugin, flat commands, flavor-aware injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Codex's hook contract mirrors Claude Code's, so the **same shims serve both agen
 
 Everything below uses the Claude Code command names (`/director:adopt` etc.); on Codex, read each as its `$director-*` skill twin: same command, same behavior.
 
+### Wire into OpenCode
+
+```bash
+director install --opencode
+```
+
+OpenCode hooks are in-process plugin calls, not command hooks, so instead of shims the `--opencode` form drops **one self-contained managed plugin** at `~/.config/opencode/plugin/director.js` (a pure file drop: OpenCode loads it with no registration, and no config file of yours is ever merged or modified) plus the boundary commands as custom commands at `~/.config/opencode/command/`, invoked as `/director-adopt`, `/director-complete`, `/director-handoff`. Works standalone; nothing else is required. Ground truth injection (first message of each session, re-injected after compaction), liveness, and close-out work as on Claude Code; the Stop emit-guard and the context-fill handoff nudge read CC's transcript format and stay safely inert on OpenCode. Details in [`docs/getting-started.md`](docs/getting-started.md).
+
 ### Environment variables
 
 Install paths and runtime knobs, common to both agents unless a default says otherwise:
@@ -136,6 +144,8 @@ Install paths and runtime knobs, common to both agents unless a default says oth
 | `DIRECTOR_COMMANDS_DIR` | `~/.claude/commands/director` | where `install` writes the `/director:*` slash commands |
 | `DIRECTOR_CODEX_HOOKS_PATH` | `~/.codex/hooks.json` | the Codex hooks file `install --codex` merges into |
 | `DIRECTOR_CODEX_SKILLS_DIR` | `~/.agents/skills` | where `install --codex` writes the `$director-*` agent skills |
+| `DIRECTOR_OPENCODE_PLUGIN_PATH` | `~/.config/opencode/plugin/director.js` | the managed plugin file `install --opencode` drops |
+| `DIRECTOR_OPENCODE_COMMANDS_DIR` | `~/.config/opencode/command` | where `install --opencode` writes the `/director-*` custom commands |
 | `DIRECTOR_HUB` | `~/.director` | the central hub that holds all cross-repo coordination state |
 | `DIRECTOR_BIN` | (PATH) | which `director` binary the shims invoke (defaults to `director` on `PATH`, then the symlink `install` drops next to the shims at `<hooks dir>/../bin/director`, `~/.claude/director/bin/director` by default) |
 | `DIRECTOR_HANDOFF_NUDGE_TOKENS` | (unset) | the context-fill handoff nudge (Claude Code-only for now): an absolute token threshold at which sessions are nudged toward `/director:handoff`; unset or `0` disables it. Fires once per crossing and re-arms only after context falls below half the threshold (a compaction or a context clear) |
@@ -189,8 +199,9 @@ fleet lifecycle (hook-emitted):
 adoption & install:
   adopt       register an existing repo (identity + CHARTER stub + fleet row)
   install     idempotent merge of Director hooks into settings.json
-              (--codex: Codex's hooks.json + $director-* agent skills instead)
-  uninstall   remove only Director-managed hook entries (--codex: Codex's)
+              (--codex: Codex's hooks.json + $director-* agent skills instead;
+               --opencode: managed plugin + /director-* custom commands instead)
+  uninstall   remove only Director-managed hook entries (--codex / --opencode: theirs)
   doctor      check the install is wired and the hooks will actually fire
 
 misc:

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -171,12 +171,24 @@ func doctorInputsFromEnv() (doctorInputs, error) {
 func diagnose(in doctorInputs) doctorReport {
 	var r doctorReport
 	r.checks = append(r.checks, binaryResolutionCheck(in))
-	r.checks = append(r.checks, claudeHooksCheck(in))
-	if c, ok := codexHooksCheck(in); ok {
-		r.checks = append(r.checks, c)
+	// Targets are assessed symmetrically: each installed agent gets its check,
+	// and the Claude Code check — historically unconditional — is skipped only
+	// when CC is genuinely absent (no managed entries AND no parse error, which
+	// would hide a broken file) while another agent IS wired. A machine with no
+	// target at all keeps the CC fail as its "run director install" guidance;
+	// without this gate an OpenCode- or Codex-only install (documented as
+	// standalone) would deterministically exit unhealthy.
+	codexCheck, codexPresent := codexHooksCheck(in)
+	opencodeCheck, opencodePresent := opencodeHooksCheck(in)
+	claudeAbsent := !install.ManagedEntriesPresent(in.settingsPath) && install.SettingsParseError(in.settingsPath) == nil
+	if !claudeAbsent || (!codexPresent && !opencodePresent) {
+		r.checks = append(r.checks, claudeHooksCheck(in))
 	}
-	if c, ok := opencodeHooksCheck(in); ok {
-		r.checks = append(r.checks, c)
+	if codexPresent {
+		r.checks = append(r.checks, codexCheck)
+	}
+	if opencodePresent {
+		r.checks = append(r.checks, opencodeCheck)
 	}
 	r.checks = append(r.checks, hubCheck(in.hub))
 

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -70,6 +70,7 @@ type doctorInputs struct {
 	hooksDir                string                // where the shims live
 	binPath                 string                // the install symlink tier (<hooks root>/bin/director)
 	codexHooks              string                // ~/.codex/hooks.json
+	opencodePlugin          string                // ~/.config/opencode/plugin/director.js
 	hub                     string                // the coordination hub root
 }
 
@@ -129,6 +130,10 @@ func doctorInputsFromEnv() (doctorInputs, error) {
 	if err != nil {
 		return doctorInputs{}, err
 	}
+	opencodePlugin, err := install.DefaultOpenCodePluginPath()
+	if err != nil {
+		return doctorInputs{}, err
+	}
 	hub, err := hubRoot()
 	if err != nil {
 		return doctorInputs{}, err
@@ -156,6 +161,7 @@ func doctorInputsFromEnv() (doctorInputs, error) {
 		hooksDir:                hooksDir,
 		binPath:                 binPath,
 		codexHooks:              codexHooks,
+		opencodePlugin:          opencodePlugin,
 		hub:                     hub,
 	}, nil
 }
@@ -167,6 +173,9 @@ func diagnose(in doctorInputs) doctorReport {
 	r.checks = append(r.checks, binaryResolutionCheck(in))
 	r.checks = append(r.checks, claudeHooksCheck(in))
 	if c, ok := codexHooksCheck(in); ok {
+		r.checks = append(r.checks, c)
+	}
+	if c, ok := opencodeHooksCheck(in); ok {
 		r.checks = append(r.checks, c)
 	}
 	r.checks = append(r.checks, hubCheck(in.hub))
@@ -256,6 +265,18 @@ func codexHooksCheck(in doctorInputs) (check, bool) {
 			"%s references Director hooks, but shims are missing from %s (%s) — re-run `director install --codex`.", in.codexHooks, in.hooksDir, strings.Join(missing, ", "))}, true
 	}
 	return check{"codex hooks", levelOK, fmt.Sprintf("wired in %s", in.codexHooks)}, true
+}
+
+// opencodeHooksCheck reports the OpenCode side only when its managed plugin is
+// present, so it never nags a user on another agent. The plugin needs no shims
+// (it shells out to the binary itself), so presence of the managed file is the
+// whole wiring check — binary reachability is already covered by
+// binaryResolutionCheck, whose resolution ladder the plugin mirrors.
+func opencodeHooksCheck(in doctorInputs) (check, bool) {
+	if !install.OpenCodePluginPresent(in.opencodePlugin) {
+		return check{}, false
+	}
+	return check{"opencode hooks", levelOK, fmt.Sprintf("plugin present at %s", in.opencodePlugin)}, true
 }
 
 // hubCheck confirms coordination state can actually be written. A not-yet-created

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -280,15 +282,42 @@ func codexHooksCheck(in doctorInputs) (check, bool) {
 }
 
 // opencodeHooksCheck reports the OpenCode side only when its managed plugin is
-// present, so it never nags a user on another agent. The plugin needs no shims
-// (it shells out to the binary itself), so presence of the managed file is the
-// whole wiring check — binary reachability is already covered by
-// binaryResolutionCheck, whose resolution ladder the plugin mirrors.
+// present, so it never nags a user on another agent. Presence alone is NOT the
+// whole check: the plugin resolves the director binary itself (process env →
+// PATH → the fallback path BAKED into it at install time), and its ladder
+// deliberately differs from the shims' in two ways doctor must model — a
+// DIRECTOR_BIN pinned in settings.json "env" is injected by Claude Code into
+// hook processes but never reaches the OpenCode server, and the baked
+// fallback is absolute, so a DIRECTOR_HOOKS_DIR move leaves the plugin
+// probing the OLD path while binaryResolutionCheck happily verifies the new
+// one. Without this, a settings-pinned machine with a dead PATH/symlink reads
+// all-healthy while OpenCode coordination is silently dead.
 func opencodeHooksCheck(in doctorInputs) (check, bool) {
 	if !install.OpenCodePluginPresent(in.opencodePlugin) {
 		return check{}, false
 	}
-	return check{"opencode hooks", levelOK, fmt.Sprintf("plugin present at %s", in.opencodePlugin)}, true
+	baked := false
+	if data, err := os.ReadFile(in.opencodePlugin); err == nil {
+		if lit, err := json.Marshal(in.binPath); err == nil {
+			baked = bytes.Contains(data, lit)
+		}
+	}
+	envBin := in.directorBin != "" && !in.directorBinFromSettings
+	_, pathHit := in.lookDirector()
+	symlinkOK := false
+	if fi, err := os.Stat(in.binPath); err == nil && !fi.IsDir() {
+		symlinkOK = true
+	}
+	switch {
+	case envBin || pathHit || (baked && symlinkOK):
+		return check{"opencode hooks", levelOK, fmt.Sprintf("plugin present at %s", in.opencodePlugin)}, true
+	case !baked:
+		return check{"opencode hooks", levelFail, fmt.Sprintf(
+			"plugin at %s bakes a fallback path that is not the current %s (hooks dir moved, or the file is untemplated) — re-run `director install --opencode`.", in.opencodePlugin, in.binPath)}, true
+	default:
+		return check{"opencode hooks", levelFail, fmt.Sprintf(
+			"plugin present at %s but its binary ladder resolves nothing: no DIRECTOR_BIN in the environment (a settings.json env pin does NOT reach the OpenCode server), `director` not on PATH, and the fallback %s is missing — re-run `director install --opencode`.", in.opencodePlugin, in.binPath)}, true
+	}
 }
 
 // hubCheck confirms coordination state can actually be written. A not-yet-created

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -304,10 +304,10 @@ func opencodeHooksCheck(in doctorInputs) (check, bool) {
 	}
 	envBin := in.directorBin != "" && !in.directorBinFromSettings
 	_, pathHit := in.lookDirector()
-	symlinkOK := false
-	if fi, err := os.Stat(in.binPath); err == nil && !fi.IsDir() {
-		symlinkOK = true
-	}
+	// Same executability bar as the main ladder: a present-but-non-executable
+	// fallback dies with EACCES in the plugin's spawn, and it is the LAST
+	// candidate — nothing behind it to degrade to.
+	symlinkOK := isExecutable(in.binPath)
 	switch {
 	case envBin || pathHit || (baked && symlinkOK):
 		return check{"opencode hooks", levelOK, fmt.Sprintf("plugin present at %s", in.opencodePlugin)}, true

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -95,6 +95,49 @@ func TestDoctorHealthy(t *testing.T) {
 	}
 }
 
+// TestDoctorOpenCodeOnlyIsHealthy: an OpenCode-only machine (no Claude Code
+// settings.json at all) must read healthy — the README documents --opencode as
+// standalone, so the CC check stands down when CC is absent and another target
+// is wired. The "no target anywhere" case keeps its fail (TestDoctorNoHooksFails).
+func TestDoctorOpenCodeOnlyIsHealthy(t *testing.T) {
+	skipUnixOnlyDoctor(t)
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, "hooks")
+	t.Setenv("DIRECTOR_HOOKS_DIR", hooksDir)
+	pluginPath := filepath.Join(root, "plugin", "director.js")
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", pluginPath)
+	t.Setenv("DIRECTOR_OPENCODE_COMMANDS_DIR", filepath.Join(root, "oc-command"))
+	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", filepath.Join(root, "codex-hooks.json"))
+	if err := install.InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode fixture: %v", err)
+	}
+	binPath, err := install.DefaultBinPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := doctorInputs{
+		directorBin:    "",
+		lookDirector:   func() (string, bool) { return "", false },
+		settingsPath:   filepath.Join(root, "no-settings.json"), // absent: no CC install
+		hooksDir:       hooksDir,
+		binPath:        binPath,
+		codexHooks:     filepath.Join(root, "no-codex.json"),
+		opencodePlugin: pluginPath,
+		hub:            root,
+	}
+
+	rep := diagnose(in)
+	if !rep.healthy {
+		t.Fatalf("opencode-only install must be healthy, got %+v", rep.checks)
+	}
+	if hasCheck(rep, "claude code hooks") {
+		t.Errorf("claude check must stand down when CC is absent and OpenCode is wired")
+	}
+	if lv := levelOf(t, rep, "opencode hooks"); lv != levelOK {
+		t.Errorf("opencode check: got %v, want OK", lv)
+	}
+}
+
 // TestDoctorOpenCodePresent: with a managed plugin on disk the opencode check
 // appears and reads OK; the fixture's zero opencodePlugin path keeps it absent
 // everywhere else (OpenCodePluginPresent fails closed on "").

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -138,6 +138,142 @@ func TestDoctorOpenCodeOnlyIsHealthy(t *testing.T) {
 	}
 }
 
+// TestDoctorCodexOnlyIsHealthy pins the one pre-existing behavior the
+// target-symmetry gate changed: a Codex-only machine (documented standalone)
+// previously failed doctor on the unconditional CC check and must now read
+// healthy.
+func TestDoctorCodexOnlyIsHealthy(t *testing.T) {
+	skipUnixOnlyDoctor(t)
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, "hooks")
+	t.Setenv("DIRECTOR_HOOKS_DIR", hooksDir)
+	t.Setenv("DIRECTOR_CODEX_SKILLS_DIR", filepath.Join(root, "skills"))
+	t.Setenv("DIRECTOR_SETTINGS_PATH", filepath.Join(root, "no-settings.json"))
+	codexHooks := filepath.Join(root, "codex-hooks.json")
+	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", codexHooks)
+	if err := install.InstallCodex(codexHooks); err != nil {
+		t.Fatalf("InstallCodex fixture: %v", err)
+	}
+	binPath, err := install.DefaultBinPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := doctorInputs{
+		lookDirector:   func() (string, bool) { return "", false },
+		settingsPath:   filepath.Join(root, "no-settings.json"),
+		hooksDir:       hooksDir,
+		binPath:        binPath,
+		codexHooks:     codexHooks,
+		opencodePlugin: filepath.Join(root, "no-plugin.js"),
+		hub:            root,
+	}
+
+	rep := diagnose(in)
+	if !rep.healthy {
+		t.Fatalf("codex-only install must be healthy, got %+v", rep.checks)
+	}
+	if hasCheck(rep, "claude code hooks") {
+		t.Errorf("claude check must stand down when CC is absent and Codex is wired")
+	}
+	if lv := levelOf(t, rep, "codex hooks"); lv != levelOK {
+		t.Errorf("codex check: got %v, want OK", lv)
+	}
+}
+
+// TestDoctorMalformedSettingsWithOpenCodeStillFails pins the load-bearing half
+// of the stand-down gate: a PRESENT-but-malformed settings.json is not
+// "absent", so a wired OpenCode install must not hide the broken file — the CC
+// check stays, fails, and names the real remedy.
+func TestDoctorMalformedSettingsWithOpenCodeStillFails(t *testing.T) {
+	skipUnixOnlyDoctor(t)
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, "hooks")
+	t.Setenv("DIRECTOR_HOOKS_DIR", hooksDir)
+	pluginPath := filepath.Join(root, "plugin", "director.js")
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", pluginPath)
+	t.Setenv("DIRECTOR_OPENCODE_COMMANDS_DIR", filepath.Join(root, "oc-command"))
+	if err := install.InstallOpenCode(pluginPath); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(root, "settings.json")
+	if err := os.WriteFile(bad, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binPath, err := install.DefaultBinPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := doctorInputs{
+		lookDirector:   func() (string, bool) { return "", false },
+		settingsPath:   bad,
+		hooksDir:       hooksDir,
+		binPath:        binPath,
+		codexHooks:     filepath.Join(root, "no-codex.json"),
+		opencodePlugin: pluginPath,
+		hub:            root,
+	}
+
+	rep := diagnose(in)
+	if rep.healthy {
+		t.Fatal("a malformed settings.json must sink doctor even with OpenCode wired")
+	}
+	if lv := levelOf(t, rep, "claude code hooks"); lv != levelFail {
+		t.Errorf("claude check must stay and fail on a malformed file, got %v", lv)
+	}
+}
+
+// TestDoctorOpenCodeDeadLadderFails is the false-healthy hole the adversarial
+// review reproduced: a DIRECTOR_BIN pinned only in settings.json (which the
+// OpenCode server never inherits) + no PATH hit + a missing fallback symlink
+// means the plugin's entire ladder no-ops — the opencode check must FAIL, not
+// hide behind the settings-pin-satisfied binary check.
+func TestDoctorOpenCodeDeadLadderFails(t *testing.T) {
+	in := installedFixture(t)
+	pluginPath := filepath.Join(t.TempDir(), "plugin", "director.js")
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", pluginPath)
+	t.Setenv("DIRECTOR_OPENCODE_COMMANDS_DIR", filepath.Join(t.TempDir(), "oc-command"))
+	if err := install.InstallOpenCode(pluginPath); err != nil {
+		t.Fatal(err)
+	}
+	in.opencodePlugin = pluginPath
+	in.directorBin = os.Args[0] // a VALID binary, pinned via settings only
+	in.directorBinFromSettings = true
+	if err := os.Remove(in.binPath); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := diagnose(in)
+	if lv := levelOf(t, rep, "opencode hooks"); lv != levelFail {
+		t.Errorf("dead plugin ladder must FAIL the opencode check, got %v", lv)
+	}
+	for _, c := range rep.checks {
+		if c.title == "opencode hooks" && !strings.Contains(c.detail, "does NOT reach the OpenCode server") {
+			t.Errorf("failure should explain the settings-pin gap, got: %s", c.detail)
+		}
+	}
+}
+
+// TestDoctorOpenCodeStaleBakedPathFails: the plugin bakes its fallback path at
+// install time; after a DIRECTOR_HOOKS_DIR move doctor would otherwise verify
+// the NEW symlink while the plugin probes the OLD path — the mismatch must
+// surface with a re-install remedy.
+func TestDoctorOpenCodeStaleBakedPathFails(t *testing.T) {
+	in := installedFixture(t)
+	pluginPath := filepath.Join(t.TempDir(), "plugin", "director.js")
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", pluginPath)
+	t.Setenv("DIRECTOR_OPENCODE_COMMANDS_DIR", filepath.Join(t.TempDir(), "oc-command"))
+	if err := install.InstallOpenCode(pluginPath); err != nil {
+		t.Fatal(err)
+	}
+	in.opencodePlugin = pluginPath
+	in.binPath = filepath.Join(t.TempDir(), "moved", "bin", "director") // hooks dir moved after install
+
+	rep := diagnose(in)
+	if lv := levelOf(t, rep, "opencode hooks"); lv != levelFail {
+		t.Errorf("stale baked fallback path must FAIL the opencode check, got %v", lv)
+	}
+}
+
 // TestDoctorOpenCodePresent: with a managed plugin on disk the opencode check
 // appears and reads OK; the fixture's zero opencodePlugin path keeps it absent
 // everywhere else (OpenCodePluginPresent fails closed on "").
@@ -276,6 +412,7 @@ func TestRunDoctorSandboxed(t *testing.T) {
 	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
 	t.Setenv("DIRECTOR_SETTINGS_PATH", settings)
 	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", filepath.Join(root, "no-codex.json"))
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", filepath.Join(root, "no-plugin.js"))
 	t.Setenv("DIRECTOR_HUB", root)
 	t.Setenv("DIRECTOR_BIN", "") // unset override → rely on the symlink tier
 	if err := install.Install(settings); err != nil {
@@ -306,6 +443,7 @@ func TestDoctorSettingsPinnedBinBroken(t *testing.T) {
 	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
 	t.Setenv("DIRECTOR_SETTINGS_PATH", settings)
 	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", filepath.Join(root, "no-codex.json"))
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", filepath.Join(root, "no-plugin.js"))
 	t.Setenv("DIRECTOR_HUB", root)
 	t.Setenv("DIRECTOR_BIN", "") // NOT pinned in the shell
 	if err := install.Install(settings); err != nil {

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -90,6 +90,28 @@ func TestDoctorHealthy(t *testing.T) {
 	if hasCheck(rep, "codex hooks") {
 		t.Errorf("codex check must be absent without a Codex install")
 	}
+	if hasCheck(rep, "opencode hooks") {
+		t.Errorf("opencode check must be absent without an OpenCode install")
+	}
+}
+
+// TestDoctorOpenCodePresent: with a managed plugin on disk the opencode check
+// appears and reads OK; the fixture's zero opencodePlugin path keeps it absent
+// everywhere else (OpenCodePluginPresent fails closed on "").
+func TestDoctorOpenCodePresent(t *testing.T) {
+	in := installedFixture(t)
+	pluginPath := filepath.Join(t.TempDir(), "plugin", "director.js")
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", pluginPath)
+	t.Setenv("DIRECTOR_OPENCODE_COMMANDS_DIR", filepath.Join(t.TempDir(), "oc-command"))
+	if err := install.InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode fixture: %v", err)
+	}
+	in.opencodePlugin = pluginPath
+
+	rep := diagnose(in)
+	if lv := levelOf(t, rep, "opencode hooks"); lv != levelOK {
+		t.Errorf("opencode check: got %v, want OK", lv)
+	}
 }
 
 func TestDoctorDirectorBinBrokenFails(t *testing.T) {

--- a/cmd/director/installcmd.go
+++ b/cmd/director/installcmd.go
@@ -148,7 +148,13 @@ func runUninstall(args []string) int {
 		fmt.Fprintf(os.Stderr, "uninstall: %v\n", err)
 		return 1
 	}
-	fmt.Printf("removed Director hooks from %s\n", path)
+	// The CC/Codex forms strip tagged entries FROM the target file; the OpenCode
+	// form removes the managed files themselves — say what actually happened.
+	if target == "opencode" {
+		fmt.Printf("removed Director plugin %s and its /director-* commands\n", path)
+	} else {
+		fmt.Printf("removed Director hooks from %s\n", path)
+	}
 	return 0
 }
 

--- a/cmd/director/installcmd.go
+++ b/cmd/director/installcmd.go
@@ -19,25 +19,44 @@ var installGOOS = runtime.GOOS
 // self-contained with no manual copy step. Default target is Claude Code
 // (settings.json); --codex targets Codex (hooks.json + agent skills) instead.
 func runInstall(args []string) int {
-	path, codex, code := installTargetFlags("install", args)
+	path, target, code := installTargetFlags("install", args)
 	if path == "" {
 		return code
 	}
 
 	// The shims install writes are bash scripts, which neither Claude Code nor
 	// Codex can execute on native Windows — installing would plant hooks that
-	// can never fire (or worse, pop an editor at session start). Refuse before
-	// touching anything; the guard sits after flag parsing so --help still
-	// works. Uninstall stays available as a cleanup path.
+	// can never fire (or worse, pop an editor at session start). The OpenCode
+	// plugin is JS (no shims), but its fallback tier is the unix-only install
+	// symlink, so that target is refused too until the Windows story exists.
+	// Refuse before touching anything; the guard sits after flag parsing so
+	// --help still works. Uninstall stays available as a cleanup path.
 	if installGOOS == "windows" {
-		fmt.Fprintln(os.Stderr, "install: native Windows is not supported yet — the hook shims are bash scripts, which Claude Code on Windows cannot execute.")
+		if target == "opencode" {
+			fmt.Fprintln(os.Stderr, "install: native Windows is not supported yet — the install symlink the plugin's binary fallback probes is unix-only.")
+		} else {
+			fmt.Fprintln(os.Stderr, "install: native Windows is not supported yet — the hook shims are bash scripts, which Claude Code on Windows cannot execute.")
+		}
 		fmt.Fprintln(os.Stderr, "  Use WSL with the Linux binary for the full ambient layer (hooks included).")
 		fmt.Fprintln(os.Stderr, "  The manual CLI verbs (emit, render, status, brief, show, resolve) all work natively without install.")
 		fmt.Fprintln(os.Stderr, "  Details: https://github.com/colinsurprenant/director/blob/main/docs/getting-started.md")
 		return 1
 	}
 
-	if codex {
+	if target == "opencode" {
+		if err := install.InstallOpenCode(path); err != nil {
+			fmt.Fprintf(os.Stderr, "install: %v\n", err)
+			return 1
+		}
+		fmt.Printf("installed Director plugin at %s (set DIRECTOR_OPENCODE_PLUGIN_PATH to override)\n", path)
+		if commandsDir, err := install.DefaultOpenCodeCommandsDir(); err == nil {
+			fmt.Printf("  commands written to %s (%s; set DIRECTOR_OPENCODE_COMMANDS_DIR to override)\n", commandsDir, install.OpenCodeCommandNames())
+		}
+		printBinLine()
+		return 0
+	}
+
+	if target == "codex" {
 		if err := install.InstallCodex(path); err != nil {
 			fmt.Fprintf(os.Stderr, "install: %v\n", err)
 			return 1
@@ -112,50 +131,69 @@ func printBinLine() {
 // form only while the OTHER agent's install still references them; once neither
 // does, they are reclaimed.
 func runUninstall(args []string) int {
-	path, codex, code := installTargetFlags("uninstall", args)
+	path, target, code := installTargetFlags("uninstall", args)
 	if path == "" {
 		return code
 	}
-	if codex {
-		if err := install.UninstallCodex(path); err != nil {
-			fmt.Fprintf(os.Stderr, "uninstall: %v\n", err)
-			return 1
-		}
-	} else {
-		if err := install.Uninstall(path); err != nil {
-			fmt.Fprintf(os.Stderr, "uninstall: %v\n", err)
-			return 1
-		}
+	var err error
+	switch target {
+	case "opencode":
+		err = install.UninstallOpenCode(path)
+	case "codex":
+		err = install.UninstallCodex(path)
+	default:
+		err = install.Uninstall(path)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "uninstall: %v\n", err)
+		return 1
 	}
 	fmt.Printf("removed Director hooks from %s\n", path)
 	return 0
 }
 
-// installTargetFlags parses the shared install/uninstall flags: --codex selects
-// the agent, --settings overrides the target file (default:
-// ~/.claude/settings.json, or ~/.codex/hooks.json with --codex). It returns
-// ("", false, code) when parsing fails or the default can't be resolved, so
-// callers return code directly.
-func installTargetFlags(name string, args []string) (path string, codex bool, code int) {
+// installTargetFlags parses the shared install/uninstall flags: --codex /
+// --opencode select the agent (mutually exclusive), --settings overrides the
+// target file (default: ~/.claude/settings.json; ~/.codex/hooks.json with
+// --codex; the managed plugin file with --opencode). It returns ("", "", code)
+// when parsing fails or the default can't be resolved, so callers return code
+// directly; target is "claude", "codex", or "opencode".
+func installTargetFlags(name string, args []string) (path, target string, code int) {
+	var codex, opencode bool
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
-	fs.StringVar(&path, "settings", "", "target hooks file (default: ~/.claude/settings.json, or ~/.codex/hooks.json with --codex)")
+	fs.StringVar(&path, "settings", "", "target file (default: ~/.claude/settings.json, ~/.codex/hooks.json with --codex, or the plugin file with --opencode)")
 	fs.BoolVar(&codex, "codex", false, "target Codex (hooks.json + $director-* agent skills) instead of Claude Code")
+	fs.BoolVar(&opencode, "opencode", false, "target OpenCode (managed plugin + /director-* custom commands) instead of Claude Code")
 	if err := fs.Parse(args); err != nil {
-		return "", false, 2
+		return "", "", 2
+	}
+	if codex && opencode {
+		fmt.Fprintf(os.Stderr, "%s: --codex and --opencode are mutually exclusive\n", name)
+		return "", "", 2
+	}
+	target = "claude"
+	if codex {
+		target = "codex"
+	}
+	if opencode {
+		target = "opencode"
 	}
 	if path != "" {
-		return path, codex, 0
+		return path, target, 0
 	}
 	var def string
 	var err error
-	if codex {
+	switch target {
+	case "codex":
 		def, err = install.DefaultCodexHooksPath()
-	} else {
+	case "opencode":
+		def, err = install.DefaultOpenCodePluginPath()
+	default:
 		def, err = install.DefaultSettingsPath()
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
-		return "", false, 1
+		return "", "", 1
 	}
-	return def, codex, 0
+	return def, target, 0
 }

--- a/cmd/director/installcmd_test.go
+++ b/cmd/director/installcmd_test.go
@@ -10,6 +10,35 @@ import (
 // touching anything — the shims are bash, so installing there plants hooks the
 // agent can never execute. Both the Claude Code and Codex forms are guarded
 // (the shims are shared). Uninstall stays available as a cleanup path.
+// TestInstallTargetFlagsMutuallyExclusive: --codex and --opencode name
+// different agents; combining them must be a usage error (exit 2) for both
+// verbs, before any default-path resolution.
+func TestInstallTargetFlagsMutuallyExclusive(t *testing.T) {
+	if code := runInstall([]string{"--codex", "--opencode"}); code != 2 {
+		t.Errorf("install --codex --opencode: exit = %d, want 2", code)
+	}
+	if code := runUninstall([]string{"--codex", "--opencode"}); code != 2 {
+		t.Errorf("uninstall --codex --opencode: exit = %d, want 2", code)
+	}
+}
+
+// TestInstallOpenCodeRefusesNativeWindows: the --opencode target is refused on
+// native Windows too (its fallback tier is the unix-only symlink), with the
+// refusal happening before any file is written.
+func TestInstallOpenCodeRefusesNativeWindows(t *testing.T) {
+	old := installGOOS
+	installGOOS = "windows"
+	t.Cleanup(func() { installGOOS = old })
+
+	pluginPath := filepath.Join(t.TempDir(), "director.js")
+	if code := runInstall([]string{"--opencode", "--settings", pluginPath}); code != 1 {
+		t.Fatalf("install --opencode on native windows: exit = %d, want 1", code)
+	}
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Fatal("refused install must not write the plugin file")
+	}
+}
+
 func TestInstallRefusesNativeWindows(t *testing.T) {
 	old := installGOOS
 	installGOOS = "windows"

--- a/cmd/director/main.go
+++ b/cmd/director/main.go
@@ -134,8 +134,9 @@ fleet lifecycle (hook-emitted):
 adoption & install:
   adopt       register an existing repo (identity + CHARTER stub + fleet row)
   install     idempotent merge of Director hooks into settings.json
-              (--codex: Codex's hooks.json + $director-* agent skills instead)
-  uninstall   remove only Director-managed hook entries (--codex: Codex's)
+              (--codex: Codex's hooks.json + $director-* agent skills instead;
+               --opencode: managed plugin + /director-* custom commands instead)
+  uninstall   remove only Director-managed hook entries (--codex / --opencode: theirs)
   doctor      check the install is healthy: hooks wired and the binary reachable
               the way the shims resolve it (exits non-zero if not)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -200,8 +200,10 @@ at `~/.config/opencode/command/`, invoked as `/director-adopt`, `/director-compl
 `/director-handoff`. OpenCode-specific notes:
 
 - **Injection rides the first message.** OpenCode has no injectable session-start hook, so the plugin
-  prepends the ground truth to the first user message of each session (and re-injects after a
-  compaction). Behavior is otherwise identical to Claude Code's session-start injection.
+  prepends the ground truth to the first user message of each session. After a compaction the resumed
+  turn is re-grounded through the system prompt (OpenCode's auto-continuation bypasses the message
+  hook), and the next user message re-injects the state durably. Behavior is otherwise identical to
+  Claude Code's session-start injection.
 - The Stop emit-guard and the context-fill handoff nudge read CC's transcript format and stay safely
   inert on OpenCode; end-of-turn fleet bookkeeping still runs (OpenCode's `session.idle` is a
   turn-end signal, so liveness matches Claude Code's).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,6 +186,32 @@ shims are shared between the two agents: either uninstall form leaves them in pl
 agent's install still references them, and reclaims them once neither does, so uninstalling one agent
 never silently breaks the other, and uninstalling the last one leaves no shim files behind.
 
+### Using OpenCode?
+
+```bash
+director install --opencode
+```
+
+OpenCode's hooks are in-process plugin function calls, not command hooks, so there are no shims on
+this path: the `--opencode` form drops one self-contained managed plugin at
+`~/.config/opencode/plugin/director.js` (a pure file drop: OpenCode loads it with no registration,
+and none of your config files are merged or modified) and the boundary commands as custom commands
+at `~/.config/opencode/command/`, invoked as `/director-adopt`, `/director-complete`,
+`/director-handoff`. OpenCode-specific notes:
+
+- **Injection rides the first message.** OpenCode has no injectable session-start hook, so the plugin
+  prepends the ground truth to the first user message of each session (and re-injects after a
+  compaction). Behavior is otherwise identical to Claude Code's session-start injection.
+- The Stop emit-guard and the context-fill handoff nudge read CC's transcript format and stay safely
+  inert on OpenCode; end-of-turn fleet bookkeeping still runs (OpenCode's `session.idle` is a
+  turn-end signal, so liveness matches Claude Code's).
+- The plugin resolves the `director` binary the same way the shims do: `DIRECTOR_BIN`, then `PATH`,
+  then the symlink `install` drops at `<hooks root>/bin/director`.
+
+`director uninstall --opencode` removes only the managed plugin (it refuses to touch a
+`director.js` it does not own) and the `/director-*` command files; the shared bin symlink survives
+while a Claude Code or Codex install still references it.
+
 ---
 
 ## 2. Adopt a repo

--- a/internal/hook/adapter.go
+++ b/internal/hook/adapter.go
@@ -83,6 +83,12 @@ type Input struct {
 
 	// PreCompact: manual | auto. Unused in v1 beyond presence.
 	Trigger string `json:"trigger"`
+
+	// Agent is a Director extension, NOT a CC wire field: an adapter that
+	// fabricates payloads (the OpenCode plugin) names itself here so flavor
+	// detection doesn't depend on heuristics. CC and the Codex shims never set
+	// it; absent means "detect from the payload" (see agentFlavor).
+	Agent string `json:"agent"`
 }
 
 // parseInput decodes CC's stdin JSON into an Input. A malformed or empty body is

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -484,6 +484,35 @@ func TestSessionStartCodexCommandNames(t *testing.T) {
 	}
 }
 
+// TestSessionStartOpenCodeCommandNames: an OpenCode session (the plugin names
+// itself in the payload's agent field — there is no transcript to detect from)
+// gets the protocol block with OpenCode's flat custom-command names
+// (/director-complete), never the CC or Codex forms.
+func TestSessionStartOpenCodeCommandNames(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+
+	// Non-empty log opens the adopted-repo gate so the protocol block is present.
+	store := event.NewStore(hub, ws.RepoKey)
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindNote, Area: "x", Body: "working"}); err != nil {
+		t.Fatalf("seed note: %v", err)
+	}
+
+	in := `{"session_id":"s-oc","transcript_path":"","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup","agent":"opencode"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	got := out.String()
+	if !strings.Contains(got, "/director-complete") || !strings.Contains(got, "/director-handoff") {
+		t.Errorf("opencode session should get flat /director-* command names in the protocol:\n%s", got)
+	}
+	if strings.Contains(got, "/director:complete") || strings.Contains(got, "$director-complete") {
+		t.Errorf("opencode session must not be told CC or Codex command names:\n%s", got)
+	}
+}
+
 // TestSessionStartCloseOutNudgeForGoneSibling: the "later session" surface of
 // the branch-gone signal. A worktree session leaves an open-item, its branch
 // merges away and is deleted; the NEXT session on the repo (a different

--- a/internal/hook/posttooluse.go
+++ b/internal/hook/posttooluse.go
@@ -59,8 +59,12 @@ func handlePostToolUse(in Input, out io.Writer, hub string) error {
 			// Handoff-threshold nudge (handoffnudge.go): it has the real context-fill
 			// signal, so when it fires this call carries ITS nudge alone — never
 			// stacked with the blind flush nudge below on the same tool call.
+			// The nudge text names /director:handoff — rewrite it for the starting
+			// agent's command namespace, same rule as the session-start protocol.
+			// (Inert off Claude Code today — the nudge needs a CC transcript — but
+			// the rewrite must not be the thing that breaks when that changes.)
 			if text, usage := runHandoffNudge(in, hub, ws); text != "" {
-				if err := writePostToolUseContext(out, text); err != nil {
+				if err := writePostToolUseContext(out, commandNamesFor(text, agentFlavor(in))); err != nil {
 					return fmt.Errorf("write handoff nudge: %w", err)
 				}
 				logSuccess(hub, EventPostToolUse, in.SessionID, fmt.Sprintf("handoff nudge fired at ~%d context tokens", usage))

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -90,7 +90,7 @@ func handleSessionStart(in Input, out io.Writer, hub string) error {
 		}
 	}
 
-	ctx, err := buildGroundTruth(hub, ws.RepoKey, ws.ID, in.SessionID, sessionUUID(in), isCodexTranscript(in.TranscriptPath))
+	ctx, err := buildGroundTruth(hub, ws.RepoKey, ws.ID, in.SessionID, sessionUUID(in), agentFlavor(in))
 	if err != nil {
 		logFailure(hub, EventSessionStart, in.SessionID, fmt.Sprintf("build ground truth: %v", err))
 		return nil
@@ -160,9 +160,9 @@ const injectionBudgetBytes = 16 * 1024
 // digest itself and health-logged. sessionID is only for health-logging a
 // nudge/concurrency failure (both fail-open, never blocking the injection);
 // uuid is this session's fleet-row key, used to exclude its own row from the
-// concurrent-session count. codex switches the protocol/nudge command names to
-// Codex's skill-mention namespace (see codexCommandNames).
-func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid string, codex bool) (string, error) {
+// concurrent-session count. flavor switches the protocol/nudge command names to
+// the starting agent's namespace (see commandNamesFor).
+func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid, flavor string) (string, error) {
 	store := event.NewStore(hub, repoKey)
 	events, err := store.ReadAll()
 	if err != nil {
@@ -180,14 +180,14 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid string, codex 
 	// must not run it twice.
 	var protocol, nudge, banner, concurrent, resume string
 	if managed {
-		protocol = codexCommandNames(emitProtocol, codex)
+		protocol = commandNamesFor(emitProtocol, flavor)
 		n, err := closeOutNudge(hub, repoKey, workstreamID, proj, time.Now().UTC())
 		if err != nil {
 			// Fail open: the nudge is advisory — a fleet read problem must never
 			// cost the session its Ground Truth. Log it and inject without.
 			logFailure(hub, EventSessionStart, sessionID, fmt.Sprintf("close-out nudge: %v", err))
 		} else if n != "" {
-			nudge = codexCommandNames(n, codex)
+			nudge = commandNamesFor(n, flavor)
 		}
 		// Sibling sessions live on this same workstream (same checkout). "Live"
 		// is a row with a heartbeat younger than the idle TTL — but note what a
@@ -325,17 +325,37 @@ func isCodexTranscript(path string) bool {
 	return strings.Contains(filepath.ToSlash(path), "/.codex/")
 }
 
-// codexCommandNames rewrites CC-namespaced command references
-// (/director:complete) to their Codex skill mentions ($director-complete —
-// the boundary commands install as agent skills there) when the starting
-// session is a Codex one. Applied ONLY to the protocol and nudge blocks
-// Director authors — never to the digest, which must stay byte-for-byte the
-// render output.
-func codexCommandNames(s string, codex bool) string {
-	if !codex {
+// agentFlavor resolves which agent's command namespace the injected
+// protocol/nudge blocks should use. An adapter that fabricates its own payloads
+// (the OpenCode plugin) names itself in the `agent` field; otherwise Codex is
+// detected from the transcript path and everything else reads as Claude Code —
+// the same best-effort stance as isCodexTranscript (a wrong guess costs only a
+// command name the human can map, never state).
+func agentFlavor(in Input) string {
+	if in.Agent != "" {
+		return in.Agent
+	}
+	if isCodexTranscript(in.TranscriptPath) {
+		return "codex"
+	}
+	return "claude"
+}
+
+// commandNamesFor rewrites CC-namespaced command references
+// (/director:complete) to the starting agent's namespace: Codex skill mentions
+// ($director-complete — the boundary commands install as agent skills there)
+// or OpenCode's flat custom commands (/director-complete). Applied ONLY to the
+// protocol and nudge blocks Director authors — never to the digest, which must
+// stay byte-for-byte the render output.
+func commandNamesFor(s, flavor string) string {
+	switch flavor {
+	case "codex":
+		return strings.ReplaceAll(s, "/director:", "$director-")
+	case "opencode":
+		return strings.ReplaceAll(s, "/director:", "/director-")
+	default:
 		return s
 	}
-	return strings.ReplaceAll(s, "/director:", "$director-")
 }
 
 // closeOutNudge surfaces dead SIBLING workstreams of this repo — branch gone,

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -127,7 +127,11 @@ func UninstallCodex(hooksPath string) error {
 	if !claudeInstallPresent() && !codexInstallPresent() {
 		if hooksDir, err := DefaultHooksDir(); err == nil {
 			removeShims(hooksDir)
-			removeBinSymlink(hooksDir)
+			// The bin symlink outlives the shims when an OpenCode install remains:
+			// its plugin probes the same fallback path without using the shims.
+			if !opencodeInstallPresent() {
+				removeBinSymlink(hooksDir)
+			}
 		}
 	}
 	return nil

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -49,6 +49,8 @@ func setupCodex(t *testing.T, fixture string) (hooksPath, hooksDir, skillsDir st
 	t.Setenv(codexSkillsDirEnv, skillsDir)
 	t.Setenv(settingsPathEnv, filepath.Join(t.TempDir(), "settings.json"))
 	t.Setenv(commandsDirEnv, filepath.Join(t.TempDir(), "commands"))
+	t.Setenv(opencodePluginPathEnv, filepath.Join(t.TempDir(), "director.js"))
+	t.Setenv(opencodeCommandsDirEnv, filepath.Join(t.TempDir(), "oc-command"))
 	hooksPath = filepath.Join(t.TempDir(), "hooks.json")
 	t.Setenv(codexHooksPathEnv, hooksPath)
 	if fixture != "" {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -263,12 +263,15 @@ func Uninstall(settingsPath string) error {
 	// (best-effort: only the exact Director filenames, never foreign files) —
 	// UNLESS a Codex install still references them: the shims are shared, and a
 	// CC uninstall must not silently break a coexisting Codex install (the
-	// mirror of UninstallCodex leaving them for CC). The bin symlink shares the
-	// shims' lifecycle exactly: it exists only to be found by them.
+	// mirror of UninstallCodex leaving them for CC). The bin symlink is wider
+	// than the shims: the OpenCode plugin's fallback tier probes it too (no
+	// shims involved), so its reclaim additionally gates on that install.
 	if !codexInstallPresent() {
 		if hooksDir, err := DefaultHooksDir(); err == nil {
 			removeShims(hooksDir)
-			removeBinSymlink(hooksDir)
+			if !opencodeInstallPresent() {
+				removeBinSymlink(hooksDir)
+			}
 		}
 	}
 	// And the Director-owned slash commands — the inverse of writeCommands, same

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -49,6 +49,8 @@ func writeFixture(t *testing.T, contents string) (path, hooksDir string) {
 	t.Setenv(commandsDirEnv, filepath.Join(t.TempDir(), "commands"))
 	t.Setenv(codexHooksPathEnv, filepath.Join(t.TempDir(), "codex-hooks.json"))
 	t.Setenv(codexSkillsDirEnv, filepath.Join(t.TempDir(), "skills"))
+	t.Setenv(opencodePluginPathEnv, filepath.Join(t.TempDir(), "director.js"))
+	t.Setenv(opencodeCommandsDirEnv, filepath.Join(t.TempDir(), "oc-command"))
 	dir := t.TempDir()
 	path = filepath.Join(dir, "settings.json")
 	// Point the default CC settings at the fixture itself, so UninstallCodex's

--- a/internal/install/opencode.go
+++ b/internal/install/opencode.go
@@ -145,12 +145,14 @@ func UninstallOpenCode(pluginPath string) error {
 		// included, mirroring the CC/Codex missing-file stance.
 		return nil
 	case err != nil:
-		return fmt.Errorf("uninstall: read plugin %s: %w", pluginPath, err)
+		// No package prefix on the uninstall-path errors (house convention, see
+		// removeManagedEntries): the CLI wraps them with its verb.
+		return fmt.Errorf("read plugin %s: %w", pluginPath, err)
 	case !bytes.Contains(data, []byte(opencodeManagedMarker)):
-		return fmt.Errorf("uninstall: refusing to remove %s: it does not carry the %q marker (not a Director-managed file)", pluginPath, opencodeManagedMarker)
+		return fmt.Errorf("refusing to remove %s: it does not carry the %q marker (not a Director-managed file)", pluginPath, opencodeManagedMarker)
 	}
 	if err := os.Remove(pluginPath); err != nil {
-		return fmt.Errorf("uninstall: remove plugin %s: %w", pluginPath, err)
+		return fmt.Errorf("remove plugin %s: %w", pluginPath, err)
 	}
 	_ = os.Remove(filepath.Dir(pluginPath)) // succeeds only if empty; foreign plugins keep it intact
 	if commandsDir, err := DefaultOpenCodeCommandsDir(); err == nil {
@@ -192,12 +194,12 @@ func OpenCodePluginPresent(path string) bool {
 // writeOpenCodePlugin materializes the embedded plugin at pluginPath with the
 // fallback-binary placeholder templated to this install's symlink path. The
 // placeholder in the source is an UNQUOTED identifier and the substitution is
-// a complete JSON-encoded string literal (Go's encoder emits pure-ASCII JSON,
-// escaping quotes, backslashes, control characters, and the U+2028/U+2029
-// line separators, all of which are valid JavaScript string escapes), so no
-// path content can escape the literal and corrupt the generated file. The
-// write is atomic (temp + rename) and idempotent: re-install reproduces the
-// same bytes for the same hooks root.
+// a complete JSON-encoded string literal (Go's encoder escapes quotes,
+// backslashes, control characters, and the U+2028/U+2029 line separators;
+// other non-ASCII passes through as raw UTF-8, which is valid inside a
+// JavaScript string), so no path content can escape the literal and corrupt
+// the generated file. The write is atomic (temp + rename) and idempotent:
+// re-install reproduces the same bytes for the same hooks root.
 func writeOpenCodePlugin(pluginPath, hooksDir string) error {
 	data, err := opencodeFS.ReadFile("opencode/director.js")
 	if err != nil {

--- a/internal/install/opencode.go
+++ b/internal/install/opencode.go
@@ -1,0 +1,254 @@
+// opencode.go is the OpenCode delivery target (spike + design: LOG decisions
+// 01KXRDKM2N / 01KXRDY28E). OpenCode's hooks are in-process plugin function
+// calls, not command hooks, so the bash shims don't port; instead the adapter
+// ships ONE embedded zero-dependency JS plugin that fabricates CC-shaped
+// payloads for the same agent-agnostic `director _hook` verbs. Install is a
+// pure file drop — OpenCode loads every file in its plugin dir with no
+// registration — so unlike the CC settings.json merge there is NO shared config
+// file to clobber and no merge machinery at all.
+//
+// The plugin's binary fallback tier probes the same install symlink the shims
+// probe, so InstallOpenCode provisions it too and the uninstall reclaim gates
+// on all three agents (see UninstallOpenCode).
+package install
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// opencodeFS embeds the Director OpenCode plugin, the same self-contained
+// pattern as shimFS/commandsFS: internal/install/opencode/ is the single source
+// of truth, and the on-disk copy install writes can never drift from the binary.
+//
+//go:embed opencode/director.js
+var opencodeFS embed.FS
+
+// opencodePluginPathEnv / opencodeCommandsDirEnv let a caller (and the tests)
+// redirect the OpenCode targets, mirroring DIRECTOR_CODEX_HOOKS_PATH /
+// DIRECTOR_CODEX_SKILLS_DIR.
+const (
+	opencodePluginPathEnv  = "DIRECTOR_OPENCODE_PLUGIN_PATH"
+	opencodeCommandsDirEnv = "DIRECTOR_OPENCODE_COMMANDS_DIR"
+)
+
+// opencodeManagedMarker tags the plugin file as Director-owned. The filename
+// alone is a weak claim (a user could have their own director.js), so both the
+// uninstall and the presence probe require this marker before touching or
+// counting the file — the file-drop analog of the settings-merge _managedBy tag.
+const opencodeManagedMarker = "_managedBy: director"
+
+// opencodeBinPlaceholder is the templating token in the embedded plugin that
+// install replaces with the resolved install-symlink path — the plugin's
+// PATH-independent fallback tier. The plugin lives in OpenCode's config dir,
+// not next to the shims, so it cannot derive the path relatively the way the
+// bash shims do.
+const opencodeBinPlaceholder = "__DIRECTOR_BIN_FALLBACK__"
+
+// DefaultOpenCodePluginPath resolves the managed plugin file,
+// ~/.config/opencode/plugin/director.js — OpenCode's global drop-in plugin dir
+// (verified live: files there load with no registration, opencode 1.18.3).
+func DefaultOpenCodePluginPath() (string, error) {
+	if p := os.Getenv(opencodePluginPathEnv); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("install: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".config", "opencode", "plugin", "director.js"), nil
+}
+
+// DefaultOpenCodeCommandsDir resolves OpenCode's global custom-command dir,
+// ~/.config/opencode/command. Unlike CC (which namespaces via a director/
+// subdir), OpenCode maps command name = filename with no subdir namespacing, so
+// the boundary commands land directly here as director-*.md — the `director-`
+// prefix is the collision guard, invoked as /director-complete etc.
+func DefaultOpenCodeCommandsDir() (string, error) {
+	if d := os.Getenv(opencodeCommandsDirEnv); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("install: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".config", "opencode", "command"), nil
+}
+
+// opencodeCommandFilename maps an embedded command filename to its on-disk
+// name: complete.md → director-complete.md, which OpenCode exposes as
+// /director-complete.
+func opencodeCommandFilename(filename string) string {
+	return "director-" + filename
+}
+
+// InstallOpenCode wires Director into OpenCode: the bin symlink (the plugin's
+// fallback tier), the boundary commands as OpenCode custom commands, and the
+// templated plugin file last. Same ordering discipline as Install: the plugin —
+// the piece that makes hooks fire — lands only after everything it depends on
+// is in place, so a failure never leaves a live plugin probing a fallback that
+// isn't there.
+func InstallOpenCode(pluginPath string) error {
+	hooksDir, err := DefaultHooksDir()
+	if err != nil {
+		return err
+	}
+	// The plugin's last resolution tier probes the install symlink; provision it
+	// exactly like the CC/Codex forms so an OpenCode-only machine gets the same
+	// PATH-independence guarantee.
+	if err := writeBinSymlink(hooksDir); err != nil {
+		return err
+	}
+	commandsDir, err := DefaultOpenCodeCommandsDir()
+	if err != nil {
+		return err
+	}
+	if err := writeOpenCodeCommands(commandsDir); err != nil {
+		return err
+	}
+	return writeOpenCodePlugin(pluginPath, hooksDir)
+}
+
+// UninstallOpenCode removes the managed plugin file and the Director-owned
+// command files. The plugin is removed ONLY when it carries the managed marker —
+// a foreign director.js is never touched. The bin symlink is reclaimed only
+// when neither a CC nor a Codex install still references it (their shims probe
+// the same path); the shims themselves are never touched here — OpenCode never
+// wrote them.
+func UninstallOpenCode(pluginPath string) error {
+	data, err := os.ReadFile(pluginPath)
+	switch {
+	case os.IsNotExist(err):
+		// No plugin means no OpenCode install to undo — touch NOTHING, commands
+		// included, mirroring the CC/Codex missing-file stance.
+		return nil
+	case err != nil:
+		return fmt.Errorf("uninstall: read plugin %s: %w", pluginPath, err)
+	case !bytes.Contains(data, []byte(opencodeManagedMarker)):
+		return fmt.Errorf("uninstall: refusing to remove %s: it does not carry the %q marker (not a Director-managed file)", pluginPath, opencodeManagedMarker)
+	}
+	if err := os.Remove(pluginPath); err != nil {
+		return fmt.Errorf("uninstall: remove plugin %s: %w", pluginPath, err)
+	}
+	_ = os.Remove(filepath.Dir(pluginPath)) // succeeds only if empty; foreign plugins keep it intact
+	if commandsDir, err := DefaultOpenCodeCommandsDir(); err == nil {
+		removeOpenCodeCommands(commandsDir)
+	}
+	if !claudeInstallPresent() && !codexInstallPresent() {
+		if hooksDir, err := DefaultHooksDir(); err == nil {
+			removeBinSymlink(hooksDir)
+		}
+	}
+	return nil
+}
+
+// opencodeInstallPresent reports whether the default OpenCode plugin path holds
+// a Director-managed plugin — the signal the CC/Codex uninstalls use to spare
+// the shared bin symlink. Same fail-open stance and KNOWN LIMIT as
+// codexInstallPresent: an unreadable/missing file reads as "no OpenCode
+// install" (anything else would make symlink reclaim permanently leaky), and
+// only the default path (or its env override) is consulted.
+func opencodeInstallPresent() bool {
+	pluginPath, err := DefaultOpenCodePluginPath()
+	if err != nil {
+		return false
+	}
+	return OpenCodePluginPresent(pluginPath)
+}
+
+// OpenCodePluginPresent reports whether path holds a Director-managed plugin
+// file (exists AND carries the managed marker) — the shared probe behind
+// opencodeInstallPresent and `director doctor`.
+func OpenCodePluginPresent(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(data, []byte(opencodeManagedMarker))
+}
+
+// writeOpenCodePlugin materializes the embedded plugin at pluginPath with the
+// fallback-binary placeholder templated to this install's symlink path. The
+// write is atomic (temp + rename) and idempotent — re-install reproduces the
+// same bytes for the same hooks root.
+func writeOpenCodePlugin(pluginPath, hooksDir string) error {
+	data, err := opencodeFS.ReadFile("opencode/director.js")
+	if err != nil {
+		return fmt.Errorf("install: read embedded opencode plugin: %w", err)
+	}
+	binPath := filepath.Join(binDirFor(hooksDir), "director")
+	data = bytes.ReplaceAll(data, []byte(opencodeBinPlaceholder), []byte(binPath))
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		return fmt.Errorf("install: create plugin dir %s: %w", filepath.Dir(pluginPath), err)
+	}
+	return writeFileAtomic(pluginPath, data, 0o644)
+}
+
+// writeOpenCodeCommands materializes the embedded boundary commands as OpenCode
+// custom commands: one <commandsDir>/director-<name>.md per command. One
+// transform against the CC copies: every cross-reference to a CC-namespaced
+// command (`/director:<cmd>`) is rewritten to OpenCode's flat form
+// (`/director-<cmd>`) so a command's advice to run its sibling resolves on the
+// agent it's installed into. The frontmatter needs no change — OpenCode reads
+// the same `description:` field and takes the command name from the filename.
+func writeOpenCodeCommands(commandsDir string) error {
+	if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+		return fmt.Errorf("install: create commands dir %s: %w", commandsDir, err)
+	}
+	entries, err := fs.ReadDir(commandsFS, "commands")
+	if err != nil {
+		return fmt.Errorf("install: read embedded commands: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := commandsFS.ReadFile("commands/" + e.Name())
+		if err != nil {
+			return fmt.Errorf("install: read embedded command %s: %w", e.Name(), err)
+		}
+		data = bytes.ReplaceAll(data, []byte("/director:"), []byte("/director-"))
+		if err := writeFileAtomic(filepath.Join(commandsDir, opencodeCommandFilename(e.Name())), data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeOpenCodeCommands deletes the Director-owned command files — exact
+// director-*.md names only, so a user's own commands in the shared dir are
+// never touched — then drops the dir if left empty. Best-effort, mirroring
+// removeCommands.
+func removeOpenCodeCommands(commandsDir string) {
+	entries, err := fs.ReadDir(commandsFS, "commands")
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		_ = os.Remove(filepath.Join(commandsDir, opencodeCommandFilename(e.Name())))
+	}
+	_ = os.Remove(commandsDir) // succeeds only if now empty; foreign commands keep it intact
+}
+
+// OpenCodeCommandNames lists the installed command names for the install
+// confirmation output, derived from the embedded set so the message can never
+// drift from what was written.
+func OpenCodeCommandNames() string {
+	entries, err := fs.ReadDir(commandsFS, "commands")
+	if err != nil {
+		return ""
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		names = append(names, "/director-"+strings.TrimSuffix(e.Name(), ".md"))
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/install/opencode.go
+++ b/internal/install/opencode.go
@@ -15,6 +15,7 @@ package install
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -94,6 +95,22 @@ func opencodeCommandFilename(filename string) string {
 // is in place, so a failure never leaves a live plugin probing a fallback that
 // isn't there.
 func InstallOpenCode(pluginPath string) error {
+	// Ownership preflight FIRST, before any artifact is written: the plugin
+	// lands in OpenCode's SHARED plugin dir, where a user can legitimately have
+	// their own director.js — and unlike the CC/Codex targets (whose overwrites
+	// stay inside Director-owned dirs or merge tagged entries), a blind write
+	// here would irreversibly destroy a foreign file. Absent or Director-marked
+	// is writable; anything else refuses the whole install. The command files
+	// need no marker gate: their exact `director-` prefixed names in the shared
+	// command dir are the ownership claim, the same convention the Codex
+	// `director-*` skill dirs rely on.
+	if data, err := os.ReadFile(pluginPath); err == nil {
+		if !bytes.Contains(data, []byte(opencodeManagedMarker)) {
+			return fmt.Errorf("install: refusing to overwrite %s: it exists and does not carry the %q marker (not a Director-managed file); move it aside or set %s", pluginPath, opencodeManagedMarker, opencodePluginPathEnv)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("install: inspect plugin path %s: %w", pluginPath, err)
+	}
 	hooksDir, err := DefaultHooksDir()
 	if err != nil {
 		return err
@@ -174,7 +191,12 @@ func OpenCodePluginPresent(path string) bool {
 
 // writeOpenCodePlugin materializes the embedded plugin at pluginPath with the
 // fallback-binary placeholder templated to this install's symlink path. The
-// write is atomic (temp + rename) and idempotent — re-install reproduces the
+// placeholder in the source is an UNQUOTED identifier and the substitution is
+// a complete JSON-encoded string literal (Go's encoder emits pure-ASCII JSON,
+// escaping quotes, backslashes, control characters, and the U+2028/U+2029
+// line separators, all of which are valid JavaScript string escapes), so no
+// path content can escape the literal and corrupt the generated file. The
+// write is atomic (temp + rename) and idempotent: re-install reproduces the
 // same bytes for the same hooks root.
 func writeOpenCodePlugin(pluginPath, hooksDir string) error {
 	data, err := opencodeFS.ReadFile("opencode/director.js")
@@ -182,7 +204,11 @@ func writeOpenCodePlugin(pluginPath, hooksDir string) error {
 		return fmt.Errorf("install: read embedded opencode plugin: %w", err)
 	}
 	binPath := filepath.Join(binDirFor(hooksDir), "director")
-	data = bytes.ReplaceAll(data, []byte(opencodeBinPlaceholder), []byte(binPath))
+	literal, err := json.Marshal(binPath)
+	if err != nil {
+		return fmt.Errorf("install: encode fallback bin path: %w", err)
+	}
+	data = bytes.ReplaceAll(data, []byte(opencodeBinPlaceholder), literal)
 	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
 		return fmt.Errorf("install: create plugin dir %s: %w", filepath.Dir(pluginPath), err)
 	}

--- a/internal/install/opencode/director.js
+++ b/internal/install/opencode/director.js
@@ -32,19 +32,31 @@
 
 import { spawn } from "node:child_process"
 
-// FALLBACK_BIN is templated by `director install --opencode` to the install
-// symlink (<hooks root>/bin/director) — the same PATH-independent tier the bash
-// shims probe, for GUI/launchd processes whose PATH misses `director`. The
-// placeholder is an UNQUOTED identifier and install substitutes a complete
-// JSON-encoded string literal, so no path character can escape the literal; an
-// untemplated copy throws a ReferenceError inside runHook, which the handlers'
-// catch-all turns into the standard silent degrade.
-const FALLBACK_BIN = __DIRECTOR_BIN_FALLBACK__
+// fallbackBin resolves the install-symlink tier (<hooks root>/bin/director) —
+// the same PATH-independent tier the bash shims probe, for GUI/launchd
+// processes whose PATH misses `director`. `director install --opencode`
+// substitutes the UNQUOTED placeholder identifier with a complete JSON-encoded
+// string literal, so no path character can escape the literal. The identifier
+// is referenced only INSIDE this function so that an untemplated copy (someone
+// hand-copying the repo source instead of running install) stays importable —
+// the ReferenceError is confined here and read as "no fallback tier", instead
+// of failing the whole module at evaluation time where only OpenCode's loader
+// isolation would save the session.
+function fallbackBin() {
+  try {
+    return __DIRECTOR_BIN_FALLBACK__
+  } catch {
+    return null
+  }
+}
 
 // hookTimeoutMs bounds one `director _hook` invocation so a wedged subprocess
 // can't stall the session's turn. The Go verbs are fast (ms-scale folds); ten
 // seconds is generous headroom, and on expiry the child is killed and the hook
-// degrades to a no-op.
+// degrades to a no-op. The bound is PER CANDIDATE: a non-executable PATH entry
+// that dies fast then a hanging fallback can stack to ~2x this before the
+// degrade — still bounded, and only on a machine whose director install is
+// already broken.
 const hookTimeoutMs = 10_000
 
 // runHook pipes a CC-shaped payload to `director _hook <event>` and returns the
@@ -54,7 +66,7 @@ const hookTimeoutMs = 10_000
 function runHook(event, payload) {
   const candidates = process.env.DIRECTOR_BIN
     ? [process.env.DIRECTOR_BIN]
-    : ["director", FALLBACK_BIN]
+    : ["director", fallbackBin()].filter(Boolean)
   return tryCandidates(candidates, event, payload)
 }
 
@@ -135,31 +147,38 @@ export const DirectorPlugin = async ({ directory, client }) => {
   // spawn a hook per LLM call. A server restart clears all of this; injected/
   // compacted degrade to a benign re-injection (what CC does on resume), and
   // the child classification is RECOVERED, not guessed: an unknown session id
-  // is looked up via client.session.get (see isChild) so a resumed child
-  // doesn't come back as a top-level session with a fleet row.
+  // is looked up via client.session.get (see classify) so a resumed child
+  // doesn't come back as a top-level session with a fleet row. One known
+  // upstream race, self-healing: session.compacted is delivered to plugins
+  // unawaited, so the very first post-compaction LLM request can beat the
+  // re-arm and miss the bridge; every subsequent request in the turn carries it.
   const injected = new Set()
   const children = new Set()
   const tops = new Set()
   const compacted = new Set()
   const compactCtx = new Map()
 
-  // isChild classifies a session, surviving server restarts: the created-event
-  // cache first, then one client.session.get lookup for an unknown id (cached
-  // on success). On lookup failure it reports top-level WITHOUT caching — the
-  // pre-recovery behavior, retried on the next call — because permanently
-  // mis-caching on a transient error would be worse than a redundant lookup.
-  const isChild = async (sid) => {
-    if (children.has(sid)) return true
-    if (tops.has(sid)) return false
+  // classify resolves a session to "child" | "top" | "unknown", surviving
+  // server restarts: the created-event cache first, then one
+  // client.session.get lookup for an unknown id (cached on success). A failed
+  // lookup is reported as "unknown", never guessed: every consumer SKIPS its
+  // action on unknown and retries on its next firing, because acting on a
+  // guess is worse in both directions — injecting the full ground truth into a
+  // subagent, or materializing a fleet row for one, pollutes the sibling
+  // counts other sessions see. Nothing is cached on failure, so a transient
+  // client error costs one skipped beat, not a permanent misclassification.
+  const classify = async (sid) => {
+    if (children.has(sid)) return "child"
+    if (tops.has(sid)) return "top"
     try {
       const res = await client.session.get({ path: { id: sid } })
       const info = res?.data ?? res
       if (info && typeof info === "object" && "id" in info) {
         ;(info.parentID ? children : tops).add(sid)
-        return !!info.parentID
+        return info.parentID ? "child" : "top"
       }
     } catch {}
-    return false
+    return "unknown"
   }
 
   // cwd is the server-level directory captured at init: OpenCode runs one
@@ -179,11 +198,18 @@ export const DirectorPlugin = async ({ directory, client }) => {
       try {
         const sid = event?.properties?.sessionID ?? event?.properties?.info?.id
         switch (event?.type) {
-          case "session.created":
-            ;(event.properties?.info?.parentID ? children : tops).add(event.properties.info.id)
+          case "session.created": {
+            const id = event.properties?.info?.id
+            if (id) (event.properties.info.parentID ? children : tops).add(id)
             return
+          }
           case "session.compacted":
-            if (sid && !(await isChild(sid))) {
+            // Gate on injected, not on a classification lookup: only sessions
+            // this server-life already classified top-level ever get injected,
+            // so injected.has IS the classification here — and a session that
+            // was never injected (post-restart) needs no re-arm, its next
+            // chat.message injects durably anyway.
+            if (sid && injected.has(sid)) {
               injected.delete(sid)
               compacted.add(sid)
               compactCtx.delete(sid)
@@ -197,7 +223,7 @@ export const DirectorPlugin = async ({ directory, client }) => {
             compactCtx.delete(sid)
             return
           case "session.idle":
-            if (!sid || (await isChild(sid))) return
+            if (!sid || (await classify(sid)) !== "top") return
             // End-of-turn Stop: fleet bookkeeping only. The emit-guard needs a
             // transcript to ever block, and this payload carries none, so any
             // control output is ignored by design — a block here would have
@@ -222,7 +248,12 @@ export const DirectorPlugin = async ({ directory, client }) => {
         let ctx = compactCtx.get(sid)
         if (ctx === undefined) {
           const control = await runHook("sessionstart", { ...basePayload("SessionStart", sid), source: "compact" })
-          ctx = control?.hookSpecificOutput?.additionalContext ?? ""
+          ctx = control?.hookSpecificOutput?.additionalContext
+          if (typeof ctx !== "string") ctx = "" // a foreign binary on PATH can emit any shape; only a string may enter the prompt
+          // The window may have closed during the await (session deleted, or a
+          // user message handed over to the durable injection) — re-check
+          // before caching, or a dead session's entry leaks until restart.
+          if (!compacted.has(sid)) return
           compactCtx.set(sid, ctx) // cache "" too — a failed/empty fetch must not re-spawn per request
         }
         if (ctx) output.system.push(ctx)
@@ -232,19 +263,23 @@ export const DirectorPlugin = async ({ directory, client }) => {
     "chat.message": async (input, output) => {
       try {
         const sid = input.sessionID
-        if (!sid || injected.has(sid) || (await isChild(sid))) return
-        // Marking BEFORE the await is the dedupe for concurrent fires — and it
-        // is deliberately not rolled back on a null control result: null can't
-        // distinguish "hook failed" from "nothing to inject" (a non-git dir),
-        // and retrying the latter would spawn a process on every message
-        // forever. The cost is that a genuinely broken setup stays uninjected
-        // until the server restarts — the same silent-degrade the shims choose.
+        if (!sid || injected.has(sid)) return
+        if ((await classify(sid)) !== "top") return
+        // The classify call suspended, so a concurrent fire for the same
+        // session may have passed the guard above in the meantime — re-check
+        // before claiming the injection, then mark. The mark is deliberately
+        // not rolled back on a null control result: null can't distinguish
+        // "hook failed" from "nothing to inject" (a non-git dir), and retrying
+        // the latter would spawn a process on every message forever. The cost
+        // is that a genuinely broken setup stays uninjected until the server
+        // restarts — the same silent-degrade the shims choose.
+        if (injected.has(sid)) return
         injected.add(sid)
         const source = compacted.delete(sid) ? "compact" : "startup"
         compactCtx.delete(sid) // hand-over: the durable part injection replaces the system-prompt bridge
         const control = await runHook("sessionstart", { ...basePayload("SessionStart", sid), source })
         const ctx = control?.hookSpecificOutput?.additionalContext
-        if (!ctx) return
+        if (typeof ctx !== "string" || !ctx) return // a foreign binary on PATH can emit any shape; only a string may become a part
         output.parts.unshift({
           id: "prt_director" + Math.random().toString(36).slice(2, 14),
           sessionID: sid,
@@ -259,13 +294,13 @@ export const DirectorPlugin = async ({ directory, client }) => {
     "tool.execute.after": async (input, output) => {
       try {
         const sid = input.sessionID
-        if (!sid || (await isChild(sid))) return
+        if (!sid || (await classify(sid)) !== "top") return
         const control = await runHook("posttooluse", {
           ...basePayload("PostToolUse", sid),
           tool_name: input.tool,
         })
         const ctx = control?.hookSpecificOutput?.additionalContext
-        if (!ctx) return
+        if (typeof ctx !== "string" || !ctx) return
         output.output = (output.output ?? "") + "\n\n" + ctx
       } catch {}
     },

--- a/internal/install/opencode/director.js
+++ b/internal/install/opencode/director.js
@@ -1,0 +1,213 @@
+// Director OpenCode plugin (_managedBy: director — do not edit; managed by `director install --opencode`).
+//
+// This file IS the OpenCode shim: where Claude Code and Codex run bash shims
+// that pipe hook stdin JSON to `director _hook <event>`, OpenCode hooks are
+// in-process function calls — so this plugin fabricates the same CC-shaped
+// payloads and applies the verb's control output to each hook's mutable output.
+// The Go core is agent-agnostic and unchanged; everything OpenCode-specific
+// lives here.
+//
+// Event mapping (one line each):
+//   chat.message        → SessionStart  (once per session; digest injected as a
+//                         synthetic text part prepended to the first user message)
+//   tool.execute.after  → PostToolUse   (heartbeat + optional nudge appended to
+//                         the tool output)
+//   session.idle        → Stop          (end-of-turn fleet bookkeeping; the
+//                         emit-guard is inert here — no transcript — so any
+//                         control output is deliberately ignored)
+//   session.created     → subagent filter (a child session, parentID set, is
+//                         skipped everywhere: no injection, no fleet rows)
+//   session.compacted   → re-arm injection (next chat.message re-injects with
+//                         source=compact, mirroring CC's compact SessionStart)
+//
+// Cardinal rule, same as the Go adapter (§13 t5): a broken hook must NEVER
+// break a session. Every handler swallows every error; the worst outcome is
+// silently absent coordination, never a blocked turn.
+
+import { spawn } from "node:child_process"
+
+// FALLBACK_BIN is templated by `director install --opencode` to the install
+// symlink (<hooks root>/bin/director) — the same PATH-independent tier the bash
+// shims probe, for GUI/launchd processes whose PATH misses `director`.
+const FALLBACK_BIN = "__DIRECTOR_BIN_FALLBACK__"
+
+// hookTimeoutMs bounds one `director _hook` invocation so a wedged subprocess
+// can't stall the session's turn. The Go verbs are fast (ms-scale folds); ten
+// seconds is generous headroom, and on expiry the child is killed and the hook
+// degrades to a no-op.
+const hookTimeoutMs = 10_000
+
+// runHook pipes a CC-shaped payload to `director _hook <event>` and returns the
+// parsed control JSON from stdout, or null on any failure (missing binary,
+// timeout, non-JSON output). Resolution order mirrors the bash shims:
+// DIRECTOR_BIN → `director` on PATH → the templated install symlink.
+function runHook(event, payload) {
+  const candidates = process.env.DIRECTOR_BIN
+    ? [process.env.DIRECTOR_BIN]
+    : ["director", FALLBACK_BIN]
+  return tryCandidates(candidates, event, payload)
+}
+
+async function tryCandidates(candidates, event, payload) {
+  for (const bin of candidates) {
+    const result = await runOne(bin, event, payload)
+    if (result.spawned) return result.control
+  }
+  return null
+}
+
+function runOne(bin, event, payload) {
+  return new Promise((resolve) => {
+    let child
+    try {
+      child = spawn(bin, ["_hook", event], { stdio: ["pipe", "pipe", "ignore"] })
+    } catch {
+      resolve({ spawned: false, control: null })
+      return
+    }
+    let stdout = ""
+    let settled = false
+    const finish = (spawned, control) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve({ spawned, control })
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL")
+      } catch {}
+      // The process existed long enough to time out: report spawned so the
+      // caller does not retry the payload against the fallback binary.
+      finish(true, null)
+    }, hookTimeoutMs)
+    child.on("error", (err) => {
+      // ENOENT/EACCES mean "try the next candidate" — the bash shims' `command
+      // -v` tier only matches executables, so a missing or non-executable PATH
+      // entry falls through to the symlink there too. Anything else means the
+      // binary exists but failed — degrade, don't retry.
+      const code = err && err.code
+      finish(code === "ENOENT" || code === "EACCES" ? false : true, null)
+    })
+    // A child that dies before reading its stdin surfaces an async EPIPE on the
+    // stream — swallowed by Bun today, fatal under Node. The no-op listener
+    // makes the cardinal rule hold by construction, not by runtime lenience.
+    child.stdin.on("error", () => {})
+    // Decode as UTF-8 with a real StringDecoder so a multi-byte codepoint split
+    // across chunk boundaries can't become U+FFFD in the injected digest.
+    child.stdout.setEncoding("utf8")
+    child.stdout.on("data", (d) => {
+      stdout += d
+    })
+    child.on("close", () => {
+      let control = null
+      const line = stdout.trim()
+      if (line !== "") {
+        try {
+          control = JSON.parse(line)
+        } catch {}
+      }
+      finish(true, control)
+    })
+    try {
+      child.stdin.write(JSON.stringify(payload))
+      child.stdin.end()
+    } catch {}
+  })
+}
+
+export const DirectorPlugin = async ({ directory }) => {
+  // Per-server-instance state. injected: sessions already carrying the ground
+  // truth. children: subagent sessions (parentID set at creation) — excluded
+  // from injection and fleet everywhere, mirroring the CC throwaway filter.
+  // compacted: sessions whose next injection is a source=compact re-injection.
+  // A server restart clears all three; the worst case is a benign re-injection,
+  // the same thing CC does on session resume.
+  const injected = new Set()
+  const children = new Set()
+  const compacted = new Set()
+
+  // cwd is the server-level directory captured at init: OpenCode runs one
+  // server per project directory in practice, so it matches every session's
+  // root. If multi-root servers ever appear, session.created's info.directory
+  // is the per-session signal to switch to.
+  const basePayload = (event, sessionID) => ({
+    hook_event_name: event,
+    session_id: sessionID,
+    transcript_path: "",
+    cwd: directory,
+    agent: "opencode",
+  })
+
+  return {
+    event: async ({ event }) => {
+      try {
+        const sid = event?.properties?.sessionID ?? event?.properties?.info?.id
+        switch (event?.type) {
+          case "session.created":
+            if (event.properties?.info?.parentID) children.add(event.properties.info.id)
+            return
+          case "session.compacted":
+            if (sid && injected.has(sid)) {
+              injected.delete(sid)
+              compacted.add(sid)
+            }
+            return
+          case "session.deleted":
+            injected.delete(sid)
+            children.delete(sid)
+            compacted.delete(sid)
+            return
+          case "session.idle":
+            if (!sid || children.has(sid)) return
+            // End-of-turn Stop: fleet bookkeeping only. The emit-guard needs a
+            // transcript to ever block, and this payload carries none, so any
+            // control output is ignored by design — a block here would have
+            // nowhere to go anyway (OpenCode has no blockable stop).
+            await runHook("stop", { ...basePayload("Stop", sid), stop_hook_active: false })
+            return
+        }
+      } catch {}
+    },
+
+    "chat.message": async (input, output) => {
+      try {
+        const sid = input.sessionID
+        if (!sid || children.has(sid) || injected.has(sid)) return
+        // Marking BEFORE the await is the dedupe for concurrent fires — and it
+        // is deliberately not rolled back on a null control result: null can't
+        // distinguish "hook failed" from "nothing to inject" (a non-git dir),
+        // and retrying the latter would spawn a process on every message
+        // forever. The cost is that a genuinely broken setup stays uninjected
+        // until the server restarts — the same silent-degrade the shims choose.
+        injected.add(sid)
+        const source = compacted.delete(sid) ? "compact" : "startup"
+        const control = await runHook("sessionstart", { ...basePayload("SessionStart", sid), source })
+        const ctx = control?.hookSpecificOutput?.additionalContext
+        if (!ctx) return
+        output.parts.unshift({
+          id: "prt_director" + Math.random().toString(36).slice(2, 14),
+          sessionID: sid,
+          messageID: output.message.id,
+          type: "text",
+          synthetic: true,
+          text: ctx,
+        })
+      } catch {}
+    },
+
+    "tool.execute.after": async (input, output) => {
+      try {
+        const sid = input.sessionID
+        if (!sid || children.has(sid)) return
+        const control = await runHook("posttooluse", {
+          ...basePayload("PostToolUse", sid),
+          tool_name: input.tool,
+        })
+        const ctx = control?.hookSpecificOutput?.additionalContext
+        if (!ctx) return
+        output.output = (output.output ?? "") + "\n\n" + ctx
+      } catch {}
+    },
+  }
+}

--- a/internal/install/opencode/director.js
+++ b/internal/install/opencode/director.js
@@ -16,9 +16,15 @@
 //                         emit-guard is inert here — no transcript — so any
 //                         control output is deliberately ignored)
 //   session.created     → subagent filter (a child session, parentID set, is
-//                         skipped everywhere: no injection, no fleet rows)
-//   session.compacted   → re-arm injection (next chat.message re-injects with
-//                         source=compact, mirroring CC's compact SessionStart)
+//                         skipped everywhere: no injection, no fleet rows;
+//                         unknown ids — a resumed session after a server
+//                         restart — are classified via client.session.get)
+//   session.compacted   → immediate re-grounding: the resumed auto-continue
+//                         turn does NOT pass through chat.message (OpenCode
+//                         synthesizes it directly), so a compacted session
+//                         gets the ground truth appended to its system prompt
+//                         per request until the next real user message, where
+//                         chat.message re-injects it durably (source=compact)
 //
 // Cardinal rule, same as the Go adapter (§13 t5): a broken hook must NEVER
 // break a session. Every handler swallows every error; the worst outcome is
@@ -28,8 +34,12 @@ import { spawn } from "node:child_process"
 
 // FALLBACK_BIN is templated by `director install --opencode` to the install
 // symlink (<hooks root>/bin/director) — the same PATH-independent tier the bash
-// shims probe, for GUI/launchd processes whose PATH misses `director`.
-const FALLBACK_BIN = "__DIRECTOR_BIN_FALLBACK__"
+// shims probe, for GUI/launchd processes whose PATH misses `director`. The
+// placeholder is an UNQUOTED identifier and install substitutes a complete
+// JSON-encoded string literal, so no path character can escape the literal; an
+// untemplated copy throws a ReferenceError inside runHook, which the handlers'
+// catch-all turns into the standard silent degrade.
+const FALLBACK_BIN = __DIRECTOR_BIN_FALLBACK__
 
 // hookTimeoutMs bounds one `director _hook` invocation so a wedged subprocess
 // can't stall the session's turn. The Go verbs are fast (ms-scale folds); ten
@@ -116,16 +126,41 @@ function runOne(bin, event, payload) {
   })
 }
 
-export const DirectorPlugin = async ({ directory }) => {
+export const DirectorPlugin = async ({ directory, client }) => {
   // Per-server-instance state. injected: sessions already carrying the ground
-  // truth. children: subagent sessions (parentID set at creation) — excluded
-  // from injection and fleet everywhere, mirroring the CC throwaway filter.
-  // compacted: sessions whose next injection is a source=compact re-injection.
-  // A server restart clears all three; the worst case is a benign re-injection,
-  // the same thing CC does on session resume.
+  // truth. children/tops: subagent classification (children are excluded from
+  // injection and fleet everywhere, mirroring the CC throwaway filter).
+  // compacted: sessions in the post-compaction window, with compactCtx caching
+  // their re-grounding text so the per-request system-prompt bridge doesn't
+  // spawn a hook per LLM call. A server restart clears all of this; injected/
+  // compacted degrade to a benign re-injection (what CC does on resume), and
+  // the child classification is RECOVERED, not guessed: an unknown session id
+  // is looked up via client.session.get (see isChild) so a resumed child
+  // doesn't come back as a top-level session with a fleet row.
   const injected = new Set()
   const children = new Set()
+  const tops = new Set()
   const compacted = new Set()
+  const compactCtx = new Map()
+
+  // isChild classifies a session, surviving server restarts: the created-event
+  // cache first, then one client.session.get lookup for an unknown id (cached
+  // on success). On lookup failure it reports top-level WITHOUT caching — the
+  // pre-recovery behavior, retried on the next call — because permanently
+  // mis-caching on a transient error would be worse than a redundant lookup.
+  const isChild = async (sid) => {
+    if (children.has(sid)) return true
+    if (tops.has(sid)) return false
+    try {
+      const res = await client.session.get({ path: { id: sid } })
+      const info = res?.data ?? res
+      if (info && typeof info === "object" && "id" in info) {
+        ;(info.parentID ? children : tops).add(sid)
+        return !!info.parentID
+      }
+    } catch {}
+    return false
+  }
 
   // cwd is the server-level directory captured at init: OpenCode runs one
   // server per project directory in practice, so it matches every session's
@@ -145,21 +180,24 @@ export const DirectorPlugin = async ({ directory }) => {
         const sid = event?.properties?.sessionID ?? event?.properties?.info?.id
         switch (event?.type) {
           case "session.created":
-            if (event.properties?.info?.parentID) children.add(event.properties.info.id)
+            ;(event.properties?.info?.parentID ? children : tops).add(event.properties.info.id)
             return
           case "session.compacted":
-            if (sid && injected.has(sid)) {
+            if (sid && !(await isChild(sid))) {
               injected.delete(sid)
               compacted.add(sid)
+              compactCtx.delete(sid)
             }
             return
           case "session.deleted":
             injected.delete(sid)
             children.delete(sid)
+            tops.delete(sid)
             compacted.delete(sid)
+            compactCtx.delete(sid)
             return
           case "session.idle":
-            if (!sid || children.has(sid)) return
+            if (!sid || (await isChild(sid))) return
             // End-of-turn Stop: fleet bookkeeping only. The emit-guard needs a
             // transcript to ever block, and this payload carries none, so any
             // control output is ignored by design — a block here would have
@@ -170,10 +208,31 @@ export const DirectorPlugin = async ({ directory }) => {
       } catch {}
     },
 
+    // The post-compaction bridge: OpenCode's automatic compaction synthesizes
+    // the continuation user message directly (it never passes through
+    // chat.message), so the FIRST resumed model turn would otherwise run on
+    // the compaction summary alone. While a session sits in the compacted
+    // window, append its re-grounding text to the system prompt of every LLM
+    // request; the next real user message hands over to chat.message's durable
+    // part injection (which clears the window before this hook runs again).
+    "experimental.chat.system.transform": async (input, output) => {
+      try {
+        const sid = input.sessionID
+        if (!sid || !compacted.has(sid)) return
+        let ctx = compactCtx.get(sid)
+        if (ctx === undefined) {
+          const control = await runHook("sessionstart", { ...basePayload("SessionStart", sid), source: "compact" })
+          ctx = control?.hookSpecificOutput?.additionalContext ?? ""
+          compactCtx.set(sid, ctx) // cache "" too — a failed/empty fetch must not re-spawn per request
+        }
+        if (ctx) output.system.push(ctx)
+      } catch {}
+    },
+
     "chat.message": async (input, output) => {
       try {
         const sid = input.sessionID
-        if (!sid || children.has(sid) || injected.has(sid)) return
+        if (!sid || injected.has(sid) || (await isChild(sid))) return
         // Marking BEFORE the await is the dedupe for concurrent fires — and it
         // is deliberately not rolled back on a null control result: null can't
         // distinguish "hook failed" from "nothing to inject" (a non-git dir),
@@ -182,6 +241,7 @@ export const DirectorPlugin = async ({ directory }) => {
         // until the server restarts — the same silent-degrade the shims choose.
         injected.add(sid)
         const source = compacted.delete(sid) ? "compact" : "startup"
+        compactCtx.delete(sid) // hand-over: the durable part injection replaces the system-prompt bridge
         const control = await runHook("sessionstart", { ...basePayload("SessionStart", sid), source })
         const ctx = control?.hookSpecificOutput?.additionalContext
         if (!ctx) return
@@ -199,7 +259,7 @@ export const DirectorPlugin = async ({ directory }) => {
     "tool.execute.after": async (input, output) => {
       try {
         const sid = input.sessionID
-        if (!sid || children.has(sid)) return
+        if (!sid || (await isChild(sid))) return
         const control = await runHook("posttooluse", {
           ...basePayload("PostToolUse", sid),
           tool_name: input.tool,

--- a/internal/install/opencode_test.go
+++ b/internal/install/opencode_test.go
@@ -53,8 +53,13 @@ func TestInstallOpenCodeWritesTemplatedPlugin(t *testing.T) {
 	if strings.Contains(string(b), opencodeBinPlaceholder) {
 		t.Errorf("plugin still carries the untemplated placeholder %s", opencodeBinPlaceholder)
 	}
-	wantBin := filepath.Join(filepath.Dir(hooksDir), "bin", "director")
-	if !strings.Contains(string(b), wantBin) {
+	// Compare against the JSON-encoded literal, not the raw path: on Windows
+	// the encoder escapes the backslashes, so the raw form never appears.
+	wantBin, err := json.Marshal(filepath.Join(filepath.Dir(hooksDir), "bin", "director"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), string(wantBin)) {
 		t.Errorf("plugin fallback path not templated to %s:\n%.400s", wantBin, b)
 	}
 
@@ -170,6 +175,9 @@ func TestInstallOpenCodeRefusesForeignPlugin(t *testing.T) {
 // preflight cannot READ is neither absent nor provably ours — refuse with the
 // inspect error (distinct from the unmarked refusal), never write through it.
 func TestInstallOpenCodeRefusesUnreadablePlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("0o000 does not make a file unreadable on windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("root ignores file modes")
 	}
@@ -195,6 +203,9 @@ func TestInstallOpenCodeRefusesUnreadablePlugin(t *testing.T) {
 // the fallback path is substituted as a complete JSON-encoded string literal,
 // never spliced raw into quotes.
 func TestInstallOpenCodeTemplatesHostilePathSafely(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip(`" is not a legal path character on windows; the hostile-path scenario is unix-only`)
+	}
 	pluginPath, _, _ := setupOpenCode(t)
 	hostile := filepath.Join(t.TempDir(), `bad"root\dir`, "hooks")
 	t.Setenv(hooksDirEnv, hostile)

--- a/internal/install/opencode_test.go
+++ b/internal/install/opencode_test.go
@@ -1,0 +1,253 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// opencode_test.go exercises the OpenCode delivery target: the pure file drop
+// (templated plugin + director-*.md commands, no config merge anywhere), the
+// managed-marker discipline on uninstall, and the three-way bin-symlink reclaim
+// (the plugin's fallback tier shares the symlink with the CC/Codex shims but
+// not the shims themselves).
+
+// setupOpenCode isolates every default the OpenCode install/uninstall paths
+// resolve — its own plugin/commands targets plus the shared hooks dir and the
+// CC/Codex probes (which UninstallOpenCode consults for the symlink reclaim) —
+// so no test ever reads or writes the developer's real config.
+func setupOpenCode(t *testing.T) (pluginPath, commandsDir, hooksDir string) {
+	t.Helper()
+	hooksDir = filepath.Join(t.TempDir(), "hooks")
+	t.Setenv(hooksDirEnv, hooksDir)
+	t.Setenv(settingsPathEnv, filepath.Join(t.TempDir(), "settings.json"))
+	t.Setenv(commandsDirEnv, filepath.Join(t.TempDir(), "commands"))
+	t.Setenv(codexHooksPathEnv, filepath.Join(t.TempDir(), "codex-hooks.json"))
+	t.Setenv(codexSkillsDirEnv, filepath.Join(t.TempDir(), "skills"))
+	pluginPath = filepath.Join(t.TempDir(), "plugin", "director.js")
+	t.Setenv(opencodePluginPathEnv, pluginPath)
+	commandsDir = filepath.Join(t.TempDir(), "oc-command")
+	t.Setenv(opencodeCommandsDirEnv, commandsDir)
+	return pluginPath, commandsDir, hooksDir
+}
+
+// TestInstallOpenCodeWritesTemplatedPlugin: the plugin materializes with the
+// managed marker intact and the fallback-binary placeholder templated to this
+// install's symlink path, and re-install is byte-idempotent.
+func TestInstallOpenCodeWritesTemplatedPlugin(t *testing.T) {
+	pluginPath, _, hooksDir := setupOpenCode(t)
+
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode: %v", err)
+	}
+	b, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("plugin not materialized: %v", err)
+	}
+	if !strings.Contains(string(b), opencodeManagedMarker) {
+		t.Errorf("plugin lost the managed marker %q", opencodeManagedMarker)
+	}
+	if strings.Contains(string(b), opencodeBinPlaceholder) {
+		t.Errorf("plugin still carries the untemplated placeholder %s", opencodeBinPlaceholder)
+	}
+	wantBin := filepath.Join(filepath.Dir(hooksDir), "bin", "director")
+	if !strings.Contains(string(b), wantBin) {
+		t.Errorf("plugin fallback path not templated to %s:\n%.400s", wantBin, b)
+	}
+
+	before := string(b)
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("re-InstallOpenCode: %v", err)
+	}
+	after, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before != string(after) {
+		t.Errorf("re-install is not idempotent")
+	}
+}
+
+// TestInstallOpenCodeWritesCommands: the boundary commands land flat as
+// director-<name>.md with every CC-namespaced cross-reference rewritten to
+// OpenCode's /director-<name> form (the filename IS the command name there, so
+// no name: frontmatter transform is needed).
+func TestInstallOpenCodeWritesCommands(t *testing.T) {
+	pluginPath, commandsDir, _ := setupOpenCode(t)
+
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode: %v", err)
+	}
+	for _, name := range []string{"director-adopt.md", "director-complete.md", "director-handoff.md"} {
+		b, err := os.ReadFile(filepath.Join(commandsDir, name))
+		if err != nil {
+			t.Fatalf("command %s not materialized: %v", name, err)
+		}
+		if strings.Contains(string(b), "/director:") {
+			t.Errorf("%s still carries a CC-namespaced /director: reference", name)
+		}
+	}
+	// complete's advice to use the handoff command must now be the flat form.
+	b, err := os.ReadFile(filepath.Join(commandsDir, "director-complete.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "/director-handoff") {
+		t.Errorf("director-complete.md should cross-reference /director-handoff:\n%.400s", b)
+	}
+}
+
+// TestUninstallOpenCodeRemovesOnlyItsOwn: uninstall removes the managed plugin
+// and the director-*.md commands but never a foreign command in the shared dir.
+// This is an opencode-only machine, so the bin symlink is reclaimed too.
+func TestUninstallOpenCodeRemovesOnlyItsOwn(t *testing.T) {
+	pluginPath, commandsDir, hooksDir := setupOpenCode(t)
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode: %v", err)
+	}
+	foreign := filepath.Join(commandsDir, "my-command.md")
+	if err := os.WriteFile(foreign, []byte("mine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UninstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("UninstallOpenCode: %v", err)
+	}
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Errorf("managed plugin survived uninstall (err=%v)", err)
+	}
+	for _, name := range []string{"director-adopt.md", "director-complete.md", "director-handoff.md"} {
+		if _, err := os.Stat(filepath.Join(commandsDir, name)); !os.IsNotExist(err) {
+			t.Errorf("command %s survived uninstall (err=%v)", name, err)
+		}
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Errorf("foreign command removed by uninstall: %v", err)
+	}
+	if runtime.GOOS != "windows" { // the bin symlink is unix-only (writeBinSymlink no-ops on windows)
+		if _, err := os.Lstat(filepath.Join(filepath.Dir(hooksDir), "bin", "director")); !os.IsNotExist(err) {
+			t.Errorf("opencode-only machine: uninstall must reclaim the bin symlink (err=%v)", err)
+		}
+	}
+}
+
+// TestUninstallOpenCodeRefusesForeignPlugin: a director.js without the managed
+// marker is someone else's file — refuse rather than delete it, the file-drop
+// analog of the merge's refuse-on-foreign-shape stance.
+func TestUninstallOpenCodeRefusesForeignPlugin(t *testing.T) {
+	pluginPath, _, _ := setupOpenCode(t)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("export const Mine = async () => ({})"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UninstallOpenCode(pluginPath); err == nil {
+		t.Fatal("UninstallOpenCode on an unmarked plugin should refuse, got nil")
+	}
+	if _, err := os.Stat(pluginPath); err != nil {
+		t.Errorf("foreign plugin was removed despite the refusal: %v", err)
+	}
+}
+
+// TestUninstallOpenCodeMissingFileNoop: an absent plugin means no OpenCode
+// install to undo — total no-op, commands included, mirroring the CC/Codex
+// missing-file stance.
+func TestUninstallOpenCodeMissingFileNoop(t *testing.T) {
+	pluginPath, commandsDir, _ := setupOpenCode(t)
+	if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(commandsDir, "director-complete.md")
+	if err := os.WriteFile(stale, []byte("stale copy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UninstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("UninstallOpenCode on missing plugin errored: %v", err)
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Errorf("UninstallOpenCode on missing plugin must not remove commands: %v", err)
+	}
+}
+
+// TestUninstallOpenCodeSparesSymlinkWhenCCPresent: while the default CC
+// settings.json still carries Director-managed entries, the opencode uninstall
+// leaves the shared bin symlink — the CC shims' fallback tier probes it.
+func TestUninstallOpenCodeSparesSymlinkWhenCCPresent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bin symlink is unix-only")
+	}
+	pluginPath, _, hooksDir := setupOpenCode(t)
+	if err := Install(os.Getenv(settingsPathEnv)); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode: %v", err)
+	}
+
+	if err := UninstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("UninstallOpenCode: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(hooksDir), "bin", "director")); err != nil {
+		t.Errorf("opencode uninstall removed the bin symlink a CC install still references: %v", err)
+	}
+}
+
+// TestUninstallCodexSparesSymlinkWhenOpenCodePresent: a Codex uninstall on a
+// machine where only an OpenCode install remains must reclaim the shims
+// (nothing left uses them) but spare the bin symlink the plugin's fallback
+// tier probes — the Codex twin of the CC-side test below.
+func TestUninstallCodexSparesSymlinkWhenOpenCodePresent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bin symlink is unix-only")
+	}
+	pluginPath, _, hooksDir := setupOpenCode(t)
+	codexHooks := os.Getenv(codexHooksPathEnv)
+	if err := InstallCodex(codexHooks); err != nil {
+		t.Fatalf("InstallCodex: %v", err)
+	}
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode: %v", err)
+	}
+
+	if err := UninstallCodex(codexHooks); err != nil {
+		t.Fatalf("UninstallCodex: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hooksDir, "sessionstart.sh")); !os.IsNotExist(err) {
+		t.Errorf("codex uninstall must reclaim the shims — OpenCode does not use them (err=%v)", err)
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(hooksDir), "bin", "director")); err != nil {
+		t.Errorf("codex uninstall removed the bin symlink the OpenCode plugin still probes: %v", err)
+	}
+}
+
+// TestUninstallSparesSymlinkWhenOpenCodePresent is the mirror: a CC uninstall
+// on a machine whose OpenCode install remains must reclaim the shims (nothing
+// else uses them) but spare the bin symlink the plugin's fallback tier probes.
+func TestUninstallSparesSymlinkWhenOpenCodePresent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bin symlink is unix-only")
+	}
+	pluginPath, _, hooksDir := setupOpenCode(t)
+	settings := os.Getenv(settingsPathEnv)
+	if err := Install(settings); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode: %v", err)
+	}
+
+	if err := Uninstall(settings); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hooksDir, "sessionstart.sh")); !os.IsNotExist(err) {
+		t.Errorf("CC uninstall must reclaim the shims — OpenCode does not use them (err=%v)", err)
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(hooksDir), "bin", "director")); err != nil {
+		t.Errorf("CC uninstall removed the bin symlink the OpenCode plugin still probes: %v", err)
+	}
+}

--- a/internal/install/opencode_test.go
+++ b/internal/install/opencode_test.go
@@ -166,6 +166,30 @@ func TestInstallOpenCodeRefusesForeignPlugin(t *testing.T) {
 	}
 }
 
+// TestInstallOpenCodeRefusesUnreadablePlugin: an existing plugin file the
+// preflight cannot READ is neither absent nor provably ours — refuse with the
+// inspect error (distinct from the unmarked refusal), never write through it.
+func TestInstallOpenCodeRefusesUnreadablePlugin(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores file modes")
+	}
+	pluginPath, _, _ := setupOpenCode(t)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("unreadable"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+
+	err := InstallOpenCode(pluginPath)
+	if err == nil {
+		t.Fatal("InstallOpenCode over an unreadable plugin should refuse, got nil")
+	}
+	if !strings.Contains(err.Error(), "inspect plugin path") {
+		t.Errorf("unreadable plugin should get the inspect refusal, got: %v", err)
+	}
+}
+
 // TestInstallOpenCodeTemplatesHostilePathSafely: a hooks-dir override carrying
 // quote/backslash characters must still produce a syntactically valid plugin —
 // the fallback path is substituted as a complete JSON-encoded string literal,
@@ -189,7 +213,7 @@ func TestInstallOpenCodeTemplatesHostilePathSafely(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(b), "const FALLBACK_BIN = "+string(wantLiteral)+"\n") {
+	if !strings.Contains(string(b), "return "+string(wantLiteral)+"\n") {
 		t.Errorf("fallback path not substituted as a JSON string literal; want %s in:\n%.400s", wantLiteral, b)
 	}
 }

--- a/internal/install/opencode_test.go
+++ b/internal/install/opencode_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -130,6 +131,66 @@ func TestUninstallOpenCodeRemovesOnlyItsOwn(t *testing.T) {
 		if _, err := os.Lstat(filepath.Join(filepath.Dir(hooksDir), "bin", "director")); !os.IsNotExist(err) {
 			t.Errorf("opencode-only machine: uninstall must reclaim the bin symlink (err=%v)", err)
 		}
+	}
+}
+
+// TestInstallOpenCodeRefusesForeignPlugin: an existing director.js without the
+// managed marker is someone else's file — install must refuse BEFORE writing
+// any artifact (preflight-first ordering), preserving the foreign bytes and
+// leaving no commands or symlink behind.
+func TestInstallOpenCodeRefusesForeignPlugin(t *testing.T) {
+	pluginPath, commandsDir, hooksDir := setupOpenCode(t)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := []byte("export const Mine = async () => ({})")
+	if err := os.WriteFile(pluginPath, foreign, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallOpenCode(pluginPath); err == nil {
+		t.Fatal("InstallOpenCode over an unmarked plugin should refuse, got nil")
+	}
+	b, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != string(foreign) {
+		t.Errorf("foreign plugin bytes were changed by the refused install:\n%s", b)
+	}
+	if _, err := os.Stat(filepath.Join(commandsDir, "director-complete.md")); !os.IsNotExist(err) {
+		t.Errorf("refused install still wrote command files (err=%v)", err)
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(hooksDir), "bin", "director")); !os.IsNotExist(err) {
+		t.Errorf("refused install still wrote the bin symlink (err=%v)", err)
+	}
+}
+
+// TestInstallOpenCodeTemplatesHostilePathSafely: a hooks-dir override carrying
+// quote/backslash characters must still produce a syntactically valid plugin —
+// the fallback path is substituted as a complete JSON-encoded string literal,
+// never spliced raw into quotes.
+func TestInstallOpenCodeTemplatesHostilePathSafely(t *testing.T) {
+	pluginPath, _, _ := setupOpenCode(t)
+	hostile := filepath.Join(t.TempDir(), `bad"root\dir`, "hooks")
+	t.Setenv(hooksDirEnv, hostile)
+
+	if err := InstallOpenCode(pluginPath); err != nil {
+		t.Fatalf("InstallOpenCode: %v", err)
+	}
+	b, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), opencodeBinPlaceholder) {
+		t.Errorf("plugin still carries the untemplated placeholder")
+	}
+	wantLiteral, err := json.Marshal(filepath.Join(binDirFor(hostile), "director"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "const FALLBACK_BIN = "+string(wantLiteral)+"\n") {
+		t.Errorf("fallback path not substituted as a JSON string literal; want %s in:\n%.400s", wantLiteral, b)
 	}
 }
 


### PR DESCRIPTION
## OpenCode adapter: `director install --opencode`

Third delivery target, following the Claude Code and Codex adapters. Design and spike history in the LOG (decisions 01KXQ0AKQH, 01KXRDKM2N, 01KXRDY28E; spike note 01KXR1MPK0).

### How it works

OpenCode hooks are in-process plugin function calls, not command hooks, so the bash shims do not port. Instead the adapter ships **one embedded zero-dependency JS plugin** that acts as the shim: it fabricates CC-shaped stdin payloads for the existing agent-agnostic `director _hook` verbs and applies the control output to each hook's mutable output. The Go hook core is unchanged except for one generalization (below).

| Director need | OpenCode surface |
|---|---|
| SessionStart injection | `chat.message` part-prepend, once per session (per-session seen-set), re-armed on `session.compacted` with `source=compact` |
| PostToolUse heartbeat + nudge | `tool.execute.after` output append |
| Stop fleet bookkeeping | `session.idle` (a turn-end signal, so liveness matches CC) |
| Subagent filter | `session.created` `parentID` |
| Boundary commands | `/director-adopt`, `/director-complete`, `/director-handoff` as custom commands |

The emit-guard stays safely inert on this path (no CC transcript), same as on Codex.

### Install is a pure file drop

OpenCode loads plugin-dir files with no registration (verified live), so `--opencode` merges **no config file at all**: it drops the managed plugin at `~/.config/opencode/plugin/director.js` (tagged `_managedBy: director`; uninstall refuses an unmarked file) and the command markdowns. The plugin's binary fallback tier probes the same install symlink the shims do, so the symlink reclaim becomes a three-way gate across the CC/Codex/OpenCode uninstalls (both new directions test-pinned).

### Hook core generalization

`Input` gains an adapter-supplied `agent` field and the codex bool becomes a flavor (`claude|codex|opencode`): the authored protocol/nudge blocks now carry `/director-*` names on OpenCode, and the handoff-nudge text routes through the same rewrite. The digest stays byte-for-byte the render output.

### Verification

- `go test ./... -race` green; new tests for install/uninstall/marker/reclaim/doctor/flavor.
- Live against opencode 1.18.3: acknowledgment banner relayed verbatim, `/director-*` names correct, sibling-session detection and idle-stop bookkeeping observed in `health/`.
- ce:review pass applied: `stdin` error listener (EPIPE is Bun-lenient, Node-fatal), UTF-8 stream decoding, EACCES treated like ENOENT for shim parity, the no-retry injection tradeoff documented, target-aware Windows refusal message, and the two missing test pins added.

### Noted for follow-up (not in this PR)

- The curl installer (`--codex`/`--both`) does not know `--opencode` yet.
- Live testing resurfaced the shadowed-binary gap (01KWZ5NH): a stale `director` on PATH shadows the fallback symlink for the plugin exactly as it does for the shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
