### PR TITLE
feat(install.sh): OpenCode wire flag (--opencode, --all); drop --both

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ One command downloads the right prebuilt binary for your platform (checksum-veri
 curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
 ```
 
-Wire Codex instead with `… | sh -s -- --codex` (or `--both`); install the binary only with `… | sh -s -- --no-wire`.
+Wire Codex instead with `… | sh -s -- --codex`, OpenCode with `--opencode`, all three agents with `--all` (wire flags combine: `--codex --opencode` wires exactly those two); install the binary only with `… | sh -s -- --no-wire`.
 
 > **On Windows?** Run the one-liner inside [WSL](https://learn.microsoft.com/windows/wsl/) with the Linux binary: everything works there, hooks included. Native Windows is CLI-only for now: the binary is built and CI-tested, and every manual verb (`emit`, `render`, `status`, `brief`, `show`, `resolve`, …) works from PowerShell, but the hook shims are bash, so the ambient layer (session-start injection, heartbeats, boundary nudges) is not yet wired natively.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 By now everyone agrees on the cure for context rot: don't push a degraded session, reset it, and carry distilled state forward, not the transcript. The advice is right; the cost is why nobody follows it. A fresh session starts blank on the state of the work (what was decided and why, which loops you left open on purpose, where the last block stopped), so every reset means re-explaining, and every week away means ten minutes of archaeology before real work starts. Most people pay that down by hand (a CLAUDE.md, a notes file, a "write a handoff for the next one" before they stop), and that instinct is right. But a hand-kept record rides on you remembering, has no open-vs-closed lifecycle, and doesn't survive two sessions at once. **The session boundary is where the state leaks**: one repo or many, whether it's a reset, a compaction, a session ending, a week away, or a parallel worktree.
 
-Director makes the reset free, and you don't operate it: it wires into Claude Code and Codex through hooks, the session emits as it works, and that state is injected into the next one as ground truth. It moves you out of the **message bus** seat: the ledger carries the state between sessions, and you go back to **directing the work**. Built around a shared, durable, **append-only event log** per repo:
+Director makes the reset free, and you don't operate it: it wires into Claude Code, Codex, and OpenCode through hooks, the session emits as it works, and that state is injected into the next one as ground truth. It moves you out of the **message bus** seat: the ledger carries the state between sessions, and you go back to **directing the work**. Built around a shared, durable, **append-only event log** per repo:
 
 - Sessions **`emit`** typed events as they work (`decision` · `open-item` · `handoff` · `note`) and **`resolve`** open loops when they truly close.
 - The log collapses deterministically into **`render`** (the machine digest), **`brief`** (the human re-orientation view), and **`status`** (the one-line-per-workstream cockpit).
@@ -18,7 +18,7 @@ Director makes the reset free, and you don't operate it: it wires into Claude Co
 
 Memory tools answer *"what does the agent know?"* Director answers *"what is the state of the work?"*: what was decided and why, which loops were deliberately deferred, and what still needs *you*. Facts accumulate; loops open and close, and nothing in a memory store ever *closes*. That lifecycle is the difference, and so is the delivery: pushed at session start, not recalled by similarity. Run both: they don't overlap.
 
-The LOG (plus the deliberately-edited living docs) is the only system of record; sessions and every rendered view are disposable caches reconstructible from it. Director wires natively into **Claude Code and OpenAI Codex**: same hooks, same log, same boundary commands, either agent alone or both side by side. A single static binary, stdlib-first, one vetted build-time dependency (`github.com/oklog/ulid/v2`). No daemon, no database, no cloud, no telemetry: the binary never opens a network connection, and the log is plain NDJSON.
+The LOG (plus the deliberately-edited living docs) is the only system of record; sessions and every rendered view are disposable caches reconstructible from it. Director wires natively into **Claude Code, OpenAI Codex, and OpenCode**: same log, same boundary commands, any of them alone or side by side. A single static binary, stdlib-first, one vetted build-time dependency (`github.com/oklog/ulid/v2`). No daemon, no database, no cloud, no telemetry: the binary never opens a network connection, and the log is plain NDJSON.
 
 ```text
 $ claude
@@ -93,7 +93,7 @@ go build -o bin/director ./cmd/director
 sudo install bin/director /usr/local/bin/director   # or copy it anywhere on PATH
 ```
 
-Then wire it into your agent. The one-liner already wired Claude Code; the sections below spell out what that does, and how to add Codex.
+Then wire it into your agent. The one-liner already wired Claude Code; the sections below spell out what that does, and how to add Codex and OpenCode.
 
 ### Wire into Claude Code
 
@@ -109,7 +109,7 @@ director install
 
 The installed hook commands point at the **shims**, not the binary directly, so rebuilding or relocating `director` never requires rewriting `settings.json` (re-run `install` to refresh the shims to the current binary). If `~/.claude/settings.json` already has a malformed (non-object) `hooks` value, `install` refuses rather than overwrite it.
 
-Confirm the wiring will actually fire with `director doctor`. The shims fail safe (a missing binary exits 0 and coordination silently no-ops), so a broken install is otherwise invisible; `doctor` walks the same binary-resolution ladder the shims walk and reports each link (binary, Claude Code hooks, Codex hooks if present, hub). It exits non-zero when the install is broken, and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss:
+Confirm the wiring will actually fire with `director doctor`. The shims fail safe (a missing binary exits 0 and coordination silently no-ops), so a broken install is otherwise invisible; `doctor` walks the same binary-resolution ladder the shims walk and reports each link (binary, Claude Code hooks, Codex and OpenCode hooks if present, hub). It exits non-zero when the install is broken, and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss:
 
 ```bash
 director doctor
@@ -123,7 +123,7 @@ director install --codex
 
 Codex's hook contract mirrors Claude Code's, so the **same shims serve both agents**, and neither install needs the other: `--codex` works standalone on a machine that has never run Claude Code. It merges the three hooks into `~/.codex/hooks.json` (never your `config.toml`) and installs the boundary commands as agent skills under `~/.agents/skills`, invoked as `$director-adopt`, `$director-complete`, `$director-handoff`. Codex asks you to **trust** the three hooks at your next session start (if you dismiss that prompt, run `/hooks` in the session). Details, including what degrades on Codex, in [`docs/getting-started.md`](docs/getting-started.md).
 
-Everything below uses the Claude Code command names (`/director:adopt` etc.); on Codex, read each as its `$director-*` skill twin: same command, same behavior.
+Everything below uses the Claude Code command names (`/director:adopt` etc.); on Codex, read each as its `$director-*` skill twin, and on OpenCode as its flat `/director-*` custom command (`/director-adopt`): same command, same behavior.
 
 ### Wire into OpenCode
 
@@ -154,19 +154,19 @@ Install paths and runtime knobs, common to both agents unless a default says oth
 
 ## Adopt an existing repo
 
-A director's projects already exist, so adoption of existing repos is on the critical path. It has two layers: **`director adopt` registers; `/director:adopt` understands** (on Codex: `$director-adopt`, same command, delivered as a skill). From inside (or pointing at) a repo:
+A director's projects already exist, so adoption of existing repos is on the critical path. It has two layers: **`director adopt` registers; `/director:adopt` understands** (on Codex: `$director-adopt`; on OpenCode: `/director-adopt` — same command, different delivery). From inside (or pointing at) a repo:
 
 ```bash
 director adopt [<dir>]        # defaults to the current directory
 ```
 
-Working in an agent session, you can skip straight to `/director:adopt` (Claude Code) or `$director-adopt` (Codex): the command runs this registration itself as its first step. The bare CLI verb is what you use outside a session (scripts, a quick shell registration).
+Working in an agent session, you can skip straight to `/director:adopt` (Claude Code), `$director-adopt` (Codex), or `/director-adopt` (OpenCode): the command runs this registration itself as its first step. The bare CLI verb is what you use outside a session (scripts, a quick shell registration).
 
 Adoption **requires a git repository**: workstream identity and liveness are derived from git. On a non-git directory `adopt` fails fast and tells you to `git init` first (an empty init is enough).
 
 `adopt` (the register layer) derives the repo's **stable workstream identity** (handling worktrees, remotes, and forks; see [Identity](#identity)), creates `projects/<repo-key>/` in the hub, scaffolds a ~3-line **CHARTER stub** there, and registers the workstream in the fleet. Re-adopting never clobbers an edited CHARTER. That is all the CLI does: deterministic, done in seconds.
 
-The understand layer is **`/director:adopt`** (Claude Code; `$director-adopt` on Codex), installed by the matching `director install` form and run inside an agent session. It starts with the same `director adopt`, then fans out read-only agents over the repo (docs and planning files, code TODOs read *in context*, git state, the repo's self-descriptions) and brings back two things for your confirmation:
+The understand layer is **`/director:adopt`** (Claude Code; `$director-adopt` on Codex; `/director-adopt` on OpenCode), installed by the matching `director install` form and run inside an agent session. It starts with the same `director adopt`, then fans out read-only agents over the repo (docs and planning files, code TODOs read *in context*, git state, the repo's self-descriptions) and brings back two things for your confirmation:
 
 - a **CHARTER proposal** (goal, non-goals, risk line): every claim cited, inferences marked `(inferred)`, plus the short list of questions only you can answer. Approved, it replaces the stub; adoption starts from an informed draft instead of a blank template.
 - the repo's open loops, **triaged** into four buckets: genuinely **in-flight** work (imported as `open-item` events after your confirm; git state must corroborate the prose, which keeps this bucket naturally small), **backlog** (stays in the repo's own tracker and planning docs; Director is not the tracker), **doc-stamps** (facts wearing a TODO costume; they feed the CHARTER), and **fossils**. Every bucket's count is reported; nothing is imported silently.
@@ -282,7 +282,7 @@ A workstream's id is `<repo>-<branch>-<shortid>`, derived deterministically from
 
 ## Status & scope
 
-**In v1:** the hook-first coordination core (CLI write path, identity, event store, fleet/liveness, `render`/`brief`/`status`, hooks + the `_managedBy` installer, the injected coordination protocol), **informed adoption** (`adopt` registers; `/director:adopt` drafts the CHARTER proposal and runs the triaged open-loop import; see [Adopt an existing repo](#adopt-an-existing-repo)), and a **Codex adapter**: `director install --codex` wires the same hooks into Codex's `hooks.json` (Codex asks you to trust them at the next session start; if you dismiss that prompt, run `/hooks` in the session) and installs the boundary commands as agent skills: `$director-adopt`, `$director-complete`, `$director-handoff`. Ground truth injection, liveness, and close-out work identically on both agents; the emit-guard and the context-fill handoff nudge are Claude Code-only for now (they read CC's transcript format and stay safely inert on Codex). Single-machine.
+**In v1:** the hook-first coordination core (CLI write path, identity, event store, fleet/liveness, `render`/`brief`/`status`, hooks + the `_managedBy` installer, the injected coordination protocol), **informed adoption** (`adopt` registers; `/director:adopt` drafts the CHARTER proposal and runs the triaged open-loop import; see [Adopt an existing repo](#adopt-an-existing-repo)), and a **Codex adapter**: `director install --codex` wires the same hooks into Codex's `hooks.json` (Codex asks you to trust them at the next session start; if you dismiss that prompt, run `/hooks` in the session) and installs the boundary commands as agent skills: `$director-adopt`, `$director-complete`, `$director-handoff`. Ground truth injection, liveness, and close-out work identically on both agents; the emit-guard and the context-fill handoff nudge are Claude Code-only for now (they read CC's transcript format and stay safely inert on Codex). Single-machine. **Since v1** (v1.9.0): an **OpenCode adapter**, `director install --opencode` — a managed plugin plus the boundary commands as `/director-*` custom commands; injection, liveness, and close-out work as on Claude Code, and the CC-only nudges stay safely inert there too.
 
 **Deferred:** deeper brownfield analysis beyond the informed-adopt pass (doc living/record/rot reconciliation, an arc42 overview draft, back-dated decision records). `brief --synthesize` (model-narrated prose) is deferred: v1 ships the deterministic brief. A background monitor/reaper, notifications, and a freshness sweep come later.
 
@@ -323,7 +323,8 @@ In each adopted worktree: `.director/workstream-id` (and `.director/repo-key`), 
 go build -o bin/director ./cmd/director
 sudo install bin/director /usr/local/bin/director
 director install              # Claude Code
-director install --codex      # OpenAI Codex — either, or both
+director install --codex      # OpenAI Codex — any combination
+director install --opencode   # OpenCode
 director doctor               # confirm the wiring will actually fire
 
 # 2. Register an existing repo in the fleet
@@ -331,7 +332,8 @@ cd ~/dev/src/some-project
 director adopt
 
 # 3. Open an agent session in that repo and run /director:adopt (Codex:
-#    $director-adopt) — it drafts the CHARTER from the repo's docs and triages
+#    $director-adopt; OpenCode: /director-adopt) — it drafts the CHARTER from
+#    the repo's docs and triages
 #    its real open loops for import, everything confirmed by you (or skip it
 #    and fill in the CHARTER stub by hand). From here on, every session start
 #    injects CHARTER + digest as Ground Truth.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,8 @@ curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/insta
 
 One command downloads the right prebuilt binary for your platform (checksum-verified), installs it to
 `~/.local/bin`, and runs `director install` to wire Claude Code (wire Codex instead with
-`… | sh -s -- --codex`, or `--both`; install the binary only with `… | sh -s -- --no-wire`).
+`… | sh -s -- --codex`, OpenCode with `--opencode`, all three with `--all`; wire flags combine,
+and `… | sh -s -- --no-wire` installs the binary only).
 **Already ran it?** The binary is in place: run `director doctor` to confirm the wiring, then skip
 to section 2.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,8 +9,8 @@ archaeology, so re-entering a project you haven't touched in weeks picks up exac
 block left off. You don't operate it: you read the projections (`status`, `brief`) and step in only
 where a human is actually needed.
 
-This guide walks the first run end to end, written in Claude Code terms with the Codex differences
-called out where they exist (see "Using OpenAI Codex?" in section 1). Go is only needed for the
+This guide walks the first run end to end, written in Claude Code terms with the Codex and OpenCode
+differences called out where they exist (see "Using OpenAI Codex?" and "Using OpenCode?" in section 1). Go is only needed for the
 `go install` and build-from-source paths. For the full command/flag reference see
 [`../README.md`](../README.md).
 
@@ -109,7 +109,7 @@ installed Director hooks into /Users/you/.claude/settings.json (set DIRECTOR_SET
   merged workstream). More on the boundary pair in section 5.
 
 Verify it took. `director doctor` is the thorough check: it walks the same binary-resolution ladder
-the hooks walk and reports each link (binary, Claude Code hooks, Codex hooks if present, hub), so a
+the hooks walk and reports each link (binary, Claude Code hooks, Codex and OpenCode hooks if present, hub), so a
 broken install becomes loud instead of a silent no-op. It exits non-zero when the install is broken,
 and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss.
 
@@ -181,7 +181,8 @@ Codex-specific notes:
   `done --workstream <id>` is unaffected.
 
 The rest of this guide uses the Claude Code command names (`/director:adopt` etc.); on Codex, read each
-as its `$director-*` skill twin: same command, same behavior.
+as its `$director-*` skill twin, and on OpenCode as its flat `/director-*` custom command: same command,
+same behavior.
 
 `director uninstall --codex` removes only the tagged entries and the three skill directories. The hook
 shims are shared between the two agents: either uninstall form leaves them in place while the other
@@ -273,7 +274,7 @@ this is where you steer the fleet.
 
 ## 3. Open an agent session
 
-Just start Claude Code (or Codex) in the adopted repo as usual. Director's `SessionStart` hook fires automatically and:
+Just start Claude Code (or Codex, or OpenCode) in the adopted repo as usual. Director's `SessionStart` hook fires automatically and:
 
 - registers/refreshes the workstream's liveness row, and
 - injects the **CHARTER + a deterministic digest** of the LOG as the session's *authoritative current
@@ -382,8 +383,8 @@ what `brief` shows and what the next session starts from.
 
 ## 6. Troubleshooting
 
-Start with **`director doctor`**: it checks the whole install chain (binary resolution, Claude Code and
-Codex hooks, shims present, hub writable) and names the broken link, exiting non-zero when coordination
+Start with **`director doctor`**: it checks the whole install chain (binary resolution, Claude Code,
+Codex, and OpenCode hooks, shims present, hub writable) and names the broken link, exiting non-zero when coordination
 would not fire. The table covers the specifics.
 
 | Symptom | Cause & fix |

--- a/docs/why-director.md
+++ b/docs/why-director.md
@@ -16,7 +16,7 @@ Director exists to take the message-bus job off you. The ledger relays the state
 
 ## What Director is
 
-You don't operate Director; your agents do. It installs into Claude Code and Codex as hooks, so the writing happens as sessions work and the state is there waiting when the next one starts. What it maintains is a shared, durable, **append-only event log** per repo (one static Go binary: no daemon, no database, no cloud, no telemetry), plus **deterministic projections** over it:
+You don't operate Director; your agents do. It installs into Claude Code, Codex, and OpenCode as hooks, so the writing happens as sessions work and the state is there waiting when the next one starts. What it maintains is a shared, durable, **append-only event log** per repo (one static Go binary: no daemon, no database, no cloud, no telemetry), plus **deterministic projections** over it:
 
 - Sessions **emit** typed events as they work, using exactly four kinds (`decision`, `open-item`, `handoff`, `note`), and **resolve** open-items when they are truly closed.
 - The log collapses deterministically (no LLM in the loop) into three views: `render` (the machine digest), `brief` (the human re-orientation view), and `status` (the one-line-per-workstream cockpit with a *Needs-you* band).

--- a/install.sh
+++ b/install.sh
@@ -8,12 +8,18 @@
 #   curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
 #
 # Options (pass through sh: `... | sh -s -- <opt>`), `--opt value` or `--opt=value`:
-#   --codex        wire OpenAI Codex instead of Claude Code
-#   --both         wire both agents
+#   --claude       wire Claude Code (the default when no wire flag is given)
+#   --codex        wire OpenAI Codex
+#   --opencode     wire OpenCode
+#   --all          wire all three agents
 #   --no-wire      install the binary only, wire nothing
 #   --version T    install release tag T (default: latest)
 #   --dir D        install the binary into D (default: ~/.local/bin)
 #   --help         print this and exit
+#
+# Wire flags are additive: naming any of them replaces the Claude Code default
+# with exactly the named set (`--codex --opencode` wires those two, not Claude).
+# `--both` (the pre-OpenCode "Claude + Codex") was removed in favor of --all.
 #
 # Environment overrides (flags win over these):
 #   DIRECTOR_VERSION       release tag to install (default: latest)
@@ -30,7 +36,13 @@
 set -eu
 
 REPO="colinsurprenant/director"
-WIRE="claude" # claude | codex | both | none
+# Wire targets. Claude Code is the default until an explicit wire flag speaks;
+# the first one clears the default, later ones add (see add_wire).
+WIRE_CLAUDE=1
+WIRE_CODEX=0
+WIRE_OPENCODE=0
+WIRE_EXPLICIT=0
+WIRE_NONE=0
 VERSION="${DIRECTOR_VERSION:-}"
 # The ~/.local/bin default is applied AFTER arg parsing so that --dir /
 # DIRECTOR_INSTALL_DIR work even when HOME is unset (stripped envs, cron, sudo).
@@ -55,8 +67,11 @@ Install Director (a coordination ledger for your coding-agent work).
   curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
 
 Options (via `... | sh -s -- <opt>`):
-  --codex        wire OpenAI Codex instead of Claude Code
-  --both         wire both agents
+  --claude       wire Claude Code (the default when no wire flag is given)
+  --codex        wire OpenAI Codex
+  --opencode     wire OpenCode
+  --all          wire all three agents (wire flags are additive: combine
+                 --claude/--codex/--opencode to wire exactly that set)
   --no-wire      install the binary only
   --version T    install release tag T (default: latest)
   --dir D        install into D (default: ~/.local/bin)
@@ -64,12 +79,33 @@ Options (via `... | sh -s -- <opt>`):
 EOF
 }
 
+# First explicit wire flag replaces the Claude Code default; later ones add.
+add_wire() {
+	if [ "$WIRE_EXPLICIT" -eq 0 ]; then
+		WIRE_CLAUDE=0
+		WIRE_EXPLICIT=1
+	fi
+	case "$1" in
+	claude) WIRE_CLAUDE=1 ;;
+	codex) WIRE_CODEX=1 ;;
+	opencode) WIRE_OPENCODE=1 ;;
+	*) die "add_wire: unknown target $1" ;; # unreachable; guards future call sites
+	esac
+}
+
 # --- args ----------------------------------------------------------------
 while [ $# -gt 0 ]; do
 	case "$1" in
-	--codex) WIRE=codex ;;
-	--both) WIRE=both ;;
-	--no-wire) WIRE=none ;;
+	--claude) add_wire claude ;;
+	--codex) add_wire codex ;;
+	--opencode) add_wire opencode ;;
+	--all)
+		add_wire claude
+		add_wire codex
+		add_wire opencode
+		;;
+	--both | --both=*) die "--both was removed now that there are three wire targets — use --all, or combine --claude/--codex/--opencode" ;;
+	--no-wire) WIRE_NONE=1 ;;
 	--version)
 		[ $# -ge 2 ] || die "--version needs a value"
 		VERSION="$2"
@@ -90,6 +126,12 @@ while [ $# -gt 0 ]; do
 	esac
 	shift
 done
+
+# Checked after the loop so the conflict is caught in either flag order.
+if [ "$WIRE_NONE" -eq 1 ]; then
+	[ "$WIRE_EXPLICIT" -eq 0 ] || die "--no-wire contradicts --claude/--codex/--opencode/--all"
+	WIRE_CLAUDE=0
+fi
 
 # Apply the default install dir now that flags/env have spoken. Only here is HOME
 # needed, and only when no explicit dir was given — so --dir rescues a HOME-less
@@ -223,15 +265,10 @@ run_wire() { # DESCRIPTION ARGS...
 		wire_failed=1
 	}
 }
-case "$WIRE" in
-claude) run_wire "Wiring Claude Code…" install ;;
-codex) run_wire "Wiring Codex…" install --codex ;;
-both)
-	run_wire "Wiring Claude Code…" install
-	run_wire "Wiring Codex…" install --codex
-	;;
-none) info "Skipping agent wiring (--no-wire)." ;;
-esac
+if [ "$WIRE_CLAUDE" -eq 1 ]; then run_wire "Wiring Claude Code…" install; fi
+if [ "$WIRE_CODEX" -eq 1 ]; then run_wire "Wiring Codex…" install --codex; fi
+if [ "$WIRE_OPENCODE" -eq 1 ]; then run_wire "Wiring OpenCode…" install --opencode; fi
+if [ "$WIRE_NONE" -eq 1 ]; then info "Skipping agent wiring (--no-wire)."; fi
 
 # --- PATH guidance + next steps -----------------------------------------
 on_path=0
@@ -243,7 +280,11 @@ if [ "$on_path" -eq 0 ]; then
 	info "NOTE: $INSTALL_DIR is not on your PATH. To run 'director' directly, add:"
 	info "    export PATH=\"$INSTALL_DIR:\$PATH\""
 	info "  to your ~/.profile, ~/.bashrc, or ~/.zshrc."
-	info "  (Director's Claude Code hooks already work without this — 'install' dropped a PATH-independent fallback.)"
+	# Every wire form drops the PATH-independent bin symlink; with --no-wire
+	# nothing was wired, so there is no fallback to reassure about.
+	if [ "$WIRE_NONE" -eq 0 ]; then
+		info "  (Director's hooks already work without this — 'install' dropped a PATH-independent fallback.)"
+	fi
 fi
 
 # Point at the binary the way the user can actually invoke it right now.

--- a/site/index.html
+++ b/site/index.html
@@ -272,7 +272,7 @@
       <a class="btn" href="https://github.com/colinsurprenant/director/blob/main/docs/getting-started.md">Getting started</a>
     </nav>
   </div>
-  <p class="also reveal d4">downloads a verified binary and wires Claude Code (pass <code>--codex</code> for Codex) · macOS, Linux, WSL · <code>go install</code> and <a href="https://github.com/colinsurprenant/director/releases">prebuilt binaries</a> also available</p>
+  <p class="also reveal d4">downloads a verified binary and wires Claude Code (pass <code>--codex</code> for Codex, <code>--opencode</code> for OpenCode) · macOS, Linux, WSL · <code>go install</code> and <a href="https://github.com/colinsurprenant/director/releases">prebuilt binaries</a> also available</p>
 </header>
 
 <main>

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Director: a coordination ledger for coding agents</title>
-<meta name="description" content="The cure for context rot is a fresh session; the cost is re-explaining everything. Director makes the reset free: a coordination ledger your agent writes as it works, injected into the next session as ground truth. For Claude Code and OpenAI Codex.">
+<meta name="description" content="The cure for context rot is a fresh session; the cost is re-explaining everything. Director makes the reset free: a coordination ledger your agent writes as it works, injected into the next session as ground truth. For Claude Code, OpenAI Codex, and OpenCode.">
 <meta property="og:title" content="Director: a coordination ledger for coding agents">
 <meta property="og:description" content="Sessions are disposable. The state of the work isn't. Director is a ledger your agent writes as it works, injected into every new session as ground truth.">
 <meta property="og:type" content="website">


### PR DESCRIPTION
## What

Extends the curl|sh installer's wire flags to cover the OpenCode adapter (PR #42), closing the wire-flag gap tracked as open-item `01KXRF6AP9`.

- **`--opencode`** wires OpenCode; **`--claude`** names the default explicitly.
- **Wire flags are additive**: the first explicit flag replaces the Claude Code default, later ones add. `--codex --opencode` wires exactly those two.
- **`--all`** wires all three agents (implemented as three `add_wire` calls, so it can never drift from individual-flag behavior).
- The off-PATH guidance note is now target-neutral and printed only when an agent was actually wired (every wire form drops the PATH-independent bin symlink; `--no-wire` drops none, so it gets no reassurance line).

Docs updated: `README.md`, `docs/getting-started.md`, `site/index.html`.

## Breaking changes (for the v1.9.0 release notes)

1. **`--both` is removed** with a hard error pointing at `--all` (decision `01KXW5YTQK`, ratified 2026-07-18): with three targets the name stopped matching what it does, and silently repointing it would change the behavior of already-published command lines. `--both=x` gets the same migration message.
2. **`--no-wire` now hard-errors when combined with any wire flag**, in either order. Previously the parser was last-flag-wins (`--no-wire --codex` silently wired Codex).

## Verification

- `shellcheck -s sh` and `dash -n` pass (the CI gates).
- All arg paths that exit before download smoke-tested: `--both`, `--both=x`, `--no-wire` conflicts in both orders, `--help` content, unknown flag, `--no-wire` fallback-note omission.
- Full end-to-end run against the real v1.8.0 release with `--no-wire --dir` (download + checksum + atomic install path untouched).
- Three independent reviews, all approving: `ce:code-reviewer` (16 flag permutations under dash), an OpenCode + Kimi K3 session (17-combo parse matrix + sandboxed zero-network E2E of the wire dispatch), and Codex adversarial. All actionable findings folded in.

## ⚠ Merge sequencing: tag first, then merge

**Tag v1.9.0 from current main (which already contains PR #42) before merging this.** The script downloads the latest *release* binary, and v1.8.0 rejects `install --opencode` — merging first would open a window where `--opencode` first-runs fail at the wire step (and `--all` wires Claude + Codex, then stops). Tagging first closes that window entirely; this PR's script changes don't need to be in the release binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
