### PR TITLE
docs+site: promote the multi-harness use case to a top-level story

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **[The two-minute tour: colinsurprenant.github.io/director](https://colinsurprenant.github.io/director/)**
 
-By now everyone agrees on the cure for context rot: don't push a degraded session, reset it, and carry distilled state forward, not the transcript. The advice is right; the cost is why nobody follows it. A fresh session starts blank on the state of the work (what was decided and why, which loops you left open on purpose, where the last block stopped), so every reset means re-explaining, and every week away means ten minutes of archaeology before real work starts. Most people pay that down by hand (a CLAUDE.md, a notes file, a "write a handoff for the next one" before they stop), and that instinct is right. But a hand-kept record rides on you remembering, has no open-vs-closed lifecycle, and doesn't survive two sessions at once. **The session boundary is where the state leaks**: one repo or many, whether it's a reset, a compaction, a session ending, a week away, or a parallel worktree.
+By now everyone agrees on the cure for context rot: don't push a degraded session, reset it, and carry distilled state forward, not the transcript. The advice is right; the cost is why nobody follows it. A fresh session starts blank on the state of the work (what was decided and why, which loops you left open on purpose, where the last block stopped), so every reset means re-explaining, and every return to a parked repo means archaeology before real work starts. Most people pay that down by hand (a CLAUDE.md, a notes file, a "write a handoff for the next one" before they stop), and that instinct is right. But a hand-kept record rides on you remembering, has no open-vs-closed lifecycle, and doesn't survive two sessions at once. **The session boundary is where the state leaks**: one repo or many, whether it's a reset, a compaction, a session ending, a week away, or a parallel worktree.
 
 Director makes the reset free, and you don't operate it: it wires into Claude Code, Codex, and OpenCode through hooks, the session emits as it works, and that state is injected into the next one as ground truth. It moves you out of the **message bus** seat: the ledger carries the state between sessions, and you go back to **directing the work**. Built around a shared, durable, **append-only event log** per repo:
 
@@ -57,9 +57,21 @@ docs-site-main-9d2e5b71 · dormant · 13d ago · ok
 
 *One human, many workstreams: which are live, which are parked between blocks, and the one line that needs you.*
 
+And the same log carries the state across **tools**, not just across time: Claude Code, OpenAI Codex, and OpenCode all read and write one ledger (see [One ledger, three harnesses](#one-ledger-three-harnesses)).
+
 > **Scope:** single-machine for now, single-human by design; multi-machine sync is on the roadmap (see [Status & scope](#status--scope)).
 >
 > **New here?** [`docs/getting-started.md`](docs/getting-started.md) is the task-oriented first-run guide (install → adopt → first session → cockpit), plus how the model uses Director and a troubleshooting section. This README is the reference.
+
+## One ledger, three harnesses
+
+Multi-harness is not a compatibility checkbox; it is a workflow. Without a shared ledger, running more than one coding agent on a repo puts *you* in the message-bus seat between them: paste the diff context here, re-explain the decision there, carry the verdict back. With one log that every harness reads and writes, that job disappears:
+
+- **Build in one, review from the others.** The setup Director itself is developed with: main work in Claude Code, with Codex and OpenCode (the latter running a non-Anthropic model) as standing reviewers on the same repo. A review session opens on the same injected ground truth the build session wrote (the decisions with their why, the open loops, where the work stopped), and its verdict lands back in the log as a `note` for the next session to pick up. Different vendors, different models, one state of the work.
+- **Hit a usage limit mid-task? Switch harnesses, not context.** Open another wired agent on the same repo and it starts from the same digest: what was decided, what is open, where you stopped. The wall costs you the tool, not the thread.
+- **The ledger is neutral ground.** The state of the work lives in a plain NDJSON log on your machine, not in any one vendor's session format. Adding, dropping, or mixing agents never strands it.
+
+Wiring is symmetric: `director install --all` (or any combination of `--codex` / `--opencode` with the bare Claude Code default) gives every harness the same boundary commands and the same ground-truth injection at the top of every session. Details per agent are under [Install](#install).
 
 ## Why Director
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,8 +5,8 @@ on that state: what was decided, which loops are open, where the last one stoppe
 boundary is where the state leaks**, whether it's a reset, a compaction, or weeks away. Director makes
 the reset free: sessions write durable coordination state (decisions, open loops, handoffs) to a shared
 append-only LOG as they work, and every new session starts from that record instead of from git
-archaeology, so re-entering a project you haven't touched in weeks picks up exactly where the last
-block left off. You don't operate it: you read the projections (`status`, `brief`) and step in only
+archaeology, so re-entering a parked project picks up exactly where the last block left off. You
+don't operate it: you read the projections (`status`, `brief`) and step in only
 where a human is actually needed.
 
 This guide walks the first run end to end, written in Claude Code terms with the Codex and OpenCode

--- a/site/index.html
+++ b/site/index.html
@@ -335,6 +335,29 @@
 </section>
 
 <section class="wrap">
+  <p class="kicker">across harnesses</p>
+  <h2>One ledger, three harnesses. Zero copy-paste.</h2>
+  <div class="grid">
+    <div class="cell">
+      <h3>the standing review panel</h3>
+      <p>Build in Claude Code with Codex and OpenCode reviewing the same repo. Every harness opens on the same injected ground truth, and a review verdict lands back in the log for the next session to pick up.</p>
+    </div>
+    <div class="cell">
+      <h3>the limit wall</h3>
+      <p>Hit a usage limit mid-task? Open another harness on the same repo: it starts from the same digest. The wall costs you the tool, not the thread.</p>
+    </div>
+    <div class="cell">
+      <h3>neutral ground</h3>
+      <p>The state of the work lives in a plain NDJSON log on your machine, not in any vendor&rsquo;s session format. Different vendors, different models, one state of the work.</p>
+    </div>
+    <div class="cell">
+      <h3><span class="p">$</span> director install --all</h3>
+      <p>Same boundary commands, same ground-truth injection at the top of every session, on all three. Wire one agent or all of them; they read and write the same log, live.</p>
+    </div>
+  </div>
+</section>
+
+<section class="wrap">
   <p class="kicker">where it fits</p>
   <h2>Keep your tools. This is a different layer.</h2>
   <dl class="vs">


### PR DESCRIPTION
Promotes the multi-harness use case from a compatibility statement to a top-level story, on both reader surfaces:

- **README**: new `## One ledger, three harnesses` section (after the hero examples, before Why Director) with three beats: the standing review panel (build in Claude Code, review from Codex/OpenCode), the usage-limit wall (switch harnesses, not context), and the neutral-ground argument (plain NDJSON, no vendor session format owns the state). Plus a one-line pointer from the hero and a closing note on symmetric wiring.
- **Tour site**: matching "across harnesses" section between how-it-works and where-it-fits, four cells in the existing grid pattern. Visually verified against the site design (local serve + screenshot).
- **Phrasing residue** (parked docs item): README opening now reads "every return to a parked repo means archaeology" (explicit week counts dropped), getting-started reads "re-entering a parked project".

Review pass applied: injection timing phrased neutrally ("at the top of every session") so the copy stays consistent with the documented OpenCode first-message injection mechanism.

Docs and static site only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
