### PR TITLE
docs(canary): runbook for when to run the harness

### DIFF
--- a/hack/canary/README.md
+++ b/hack/canary/README.md
@@ -143,7 +143,28 @@ fresh baseline lands.
 
 ## When to run it
 
-Re-run on a harness version change, not on every commit. This is a contract
-check against a moving upstream, so the trigger is "the harness updated", not
-CI-per-commit. Compare the new `findings.md` against the previous run in
-`findings/` to spot a contract regression.
+The canary is on-demand maintainer tooling, not CI: a run needs real
+per-harness auth, so it lives on the maintainer's machine and fires on one of
+two triggers.
+
+**A supported harness updated (regression check).** `director doctor` staying
+green does not prove the contract survived the update; that is what this
+verifies. There is no automatic detection: compare the installed version
+(`<cli> --version`) against the `version` recorded for that harness in
+`last-tested.json`, and re-run that module when they differ. The fresh run
+writes a new `findings/run-*` dir; diff its `findings.md` against the committed
+baseline (the run `last-tested.json` still points at) to spot a regression. A
+clean run becomes the new baseline: commit it and prune the previous one.
+
+**A new harness (adapter acceptance).** Build the canary module before the
+install adapter, not after. A green contract (hooks fire, injection lands,
+payload shape captured) is the go/no-go on whether the harness is integrable at
+all, and the probe becomes the adapter's acceptance test. The Cursor CLI module
+shipped this way, ahead of any Cursor adapter.
+
+**When a channel goes red.** A negative verdict is a finding, not a script
+error. Record it: open a tracking issue naming the harness version, the failing
+channel, an unpark condition (the release or upstream fix that would justify a
+re-test), and the exact command to reproduce. The Cursor IDE case (issue #50)
+is the worked example: injection broke upstream, so it is parked with a
+`--multikey` re-test recipe and unparks on the next IDE release.

--- a/hack/canary/README.md
+++ b/hack/canary/README.md
@@ -152,9 +152,11 @@ green does not prove the contract survived the update; that is what this
 verifies. There is no automatic detection: compare the installed version
 (`<cli> --version`) against the `version` recorded for that harness in
 `last-tested.json`, and re-run that module when they differ. The fresh run
-writes a new `findings/run-*` dir; diff its `findings.md` against the committed
-baseline (the run `last-tested.json` still points at) to spot a regression. A
-clean run becomes the new baseline: commit it and prune the previous one.
+writes a new `findings/run-*` dir and repoints `last-tested.json` at it, so
+`git diff hack/canary/last-tested.json` shows both the prior baseline path and
+the new one. Diff the new `findings.md` against that prior baseline to spot a
+regression. A clean run is already the new baseline: commit it and prune the
+prior dir.
 
 **A new harness (adapter acceptance).** Build the canary module before the
 install adapter, not after. A green contract (hooks fire, injection lands,


### PR DESCRIPTION
## What

Expands the canary README's `When to run it` section into a short runbook and fixes one stale instruction. Docs only; no code change.

The harness serves two distinct lifecycles that were never written down (they lived only in a merged LOG decision and issue #50):

- **Version bump (regression check)** — `director doctor` staying green does not prove the contract survived an upstream update. Detection is a manual `<cli> --version` vs `last-tested.json` check; diff the fresh run against the committed baseline.
- **New harness (adapter acceptance)** — build the canary module before the install adapter; a green contract is the go/no-go, and the probe becomes the adapter's acceptance test (as the Cursor CLI module shipped, ahead of any Cursor adapter). This is the lifecycle a new-adapter contributor needs.
- **Red response** — generalizes the issue #50 park-and-unpark pattern into a procedure: record the version, the failing channel, an unpark condition, and the repro command.

### Stale wording fixed

The old text said "compare the new `findings.md` against the previous run in `findings/`." After the retention policy landed (only the latest baseline per harness stays in the tree; superseded runs live in git history), that was misleading — there is no previous run in `findings/` at a committed state. The runbook now says to diff against the committed baseline `last-tested.json` points at.

### Deliberately omitted

No mention of automated version-detection or `doctor --live`; both stay deferred per the charter (frozen surface, single-machine maintainer tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
