### PR TITLE
site+readme: make multi-harness support visible above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **Save the work, not the chat.**
 
+One shared log across **Claude Code · Codex · OpenCode**: build in one, resume or review in another.
+
 [![A Claude Code session records decisions, open items, and handoffs to an append-only log; a Codex session a day later starts with them injected and appends to the same log.](site/hero.svg)](https://colinsurprenant.github.io/director/)
 
 **[The two-minute tour: colinsurprenant.github.io/director](https://colinsurprenant.github.io/director/)**
@@ -24,7 +26,7 @@ $ claude
 
 ──────────── session ends ────────────
 
-$ claude
+$ codex
 > where were we?
 ▸ Director: acme-api-main-7c21e9d4 · 1 open-item(s), 1 need-you
 
@@ -58,11 +60,13 @@ Under the hood, deliberately boring:
 - one concurrency-safe static binary
 - a plain NDJSON log file
 
-Install is one line (macOS / Linux / WSL):
+Install is one line (macOS / Linux / WSL); it wires Claude Code:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/colinsurprenant/director/main/install.sh | sh
 ```
+
+Wire Codex instead with `… | sh -s -- --codex`, OpenCode with `--opencode`, all three with `--all` (flags combine; see [Install](#install)).
 
 > **Scope:** single-machine for now, single-human by design; multi-machine sync is on the roadmap (see [Status & scope](#status--scope)).
 >

--- a/site/index.html
+++ b/site/index.html
@@ -84,6 +84,14 @@
     color: var(--ink-dim);
     font-style: italic;
   }
+  .harnesses {
+    margin-top: .8rem;
+    font-family: var(--mono);
+    font-size: .7rem;
+    color: var(--ink-faint);
+    letter-spacing: .02em;
+  }
+  .harnesses strong { color: var(--ink-dim); font-weight: 400; }
   .lede {
     margin-top: 1.6rem;
     max-width: 40rem;
@@ -269,6 +277,7 @@
   <p class="ack reveal d1">▸ Director: director-main-aaa5961e · <span class="meta">3 open-item(s), 1 need-you</span><span class="caret" aria-hidden="true"></span></p>
   <h1 class="reveal d2">Sessions are disposable. The state of the work isn&rsquo;t.</h1>
   <p class="sub reveal d2">Save the work, not the chat: a small local log your agent writes as it works (decisions, open loops, handoffs), loaded into every new session as ground truth.</p>
+  <p class="harnesses reveal d2">one shared log across <strong>Claude Code · Codex · OpenCode</strong>: build in one, resume or review in another</p>
   <div class="qa reveal d3">
     <p><span class="q-label">Memory tools answer</span> <span class="q-dim">“what does the agent <em>know</em>?”</span></p>
     <p><span class="q-label">Director answers</span> <span class="q-hot">“what is the state of the <em>work</em>?”</span></p>
@@ -301,7 +310,7 @@
     <div class="term">
       <div class="term-bar" aria-hidden="true">
         <span class="dots"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span></span>
-        <span class="term-title">claude</span>
+        <span class="term-title">acme-api</span>
         <span></span>
       </div>
       <pre><code><span class="cm">$</span> claude
@@ -314,7 +323,7 @@
 
 <span class="cm">──────────── session ends ────────────</span>
 
-<span class="cm">$</span> claude
+<span class="cm">$</span> codex
 <span class="cm">&gt;</span> <span class="hd">where were we?</span>
 <span class="ok">▸ Director: acme-api-main-7c21e9d4 · 1 open-item(s), 1 need-you</span>
 


### PR DESCRIPTION
Prompted by a real user asking "does it work in Codex". It does — but nothing a skimmer reads above the fold says so: both demo sessions were `$ claude`, the first text mention of Codex/OpenCode was buried mid-sentence, and the install one-liner didn't say what it wires.

Three changes, README and site kept in mirror:

- **The demo now shows it instead of asserting it**: session 2 of the terminal demo is `$ codex`, resuming from the log a Claude Code session wrote. This also aligns the demo with the hero diagram beside it, whose session 2 was already Codex. The site terminal's title bar becomes the neutral `acme-api`.
- **A harness line directly under the tagline**: one shared log across Claude Code · Codex · OpenCode: build in one, resume or review in another.
- **The README install one-liner names the wiring**: Claude Code by default; `--codex`, `--opencode`, or `--all` for the others.

Deliberately not done: "more harnesses coming" language — held until a fourth adapter actually lands.

Site header verified in headless Chrome (harness line sits on one line at desktop width; demo renders correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
