### PR TITLE
emit: echo the routing target to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ director emit --type decision|open-item|handoff|note --area <subsystem> \
 
 `emit` prints the **new event's ULID to stdout**: note it; that is the id used to `--refs` or `resolve` the event later. (One `--refs` pairing is load-bearing: a `note` ref naming a **handoff** concludes it — see the kind table's lifecycle column below.)
 
+`emit` also echoes a routing line to **stderr** (`→ <repo-key> · <workstream-id>`) naming the project it wrote to. If that is not the project the session expects, its cwd drifted and the event landed in the wrong log.
+
 ### resolve: close an open-item
 
 ```bash

--- a/cmd/director/closeout_routing_test.go
+++ b/cmd/director/closeout_routing_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -98,34 +97,10 @@ func gitRun(t *testing.T, dir string, args ...string) {
 	}
 }
 
-// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
-// printed — the CLI verbs print with fmt.Print, so routing tests that assert on
-// output need the real fd swapped, not a passed writer.
+// captureStdout runs fn and returns what it printed to stdout (see
+// captureStreams in emit_test.go for why the real fd is swapped).
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	done := make(chan string)
-	go func() {
-		var b strings.Builder
-		buf := make([]byte, 4096)
-		for {
-			n, err := r.Read(buf)
-			b.Write(buf[:n])
-			if err != nil {
-				break
-			}
-		}
-		done <- b.String()
-	}()
-
-	fn()
-	w.Close()
-	return <-done
+	out, _ := captureStreams(t, fn)
+	return out
 }

--- a/cmd/director/emit.go
+++ b/cmd/director/emit.go
@@ -12,8 +12,9 @@ import (
 
 // runEmit is the model-facing write path: it derives the workstream, builds the
 // event from flags + body, and appends it (§5.3). It prints the new event's ULID
-// to stdout so the model can copy it into a later resolve (§15.6). This is the
-// only sanctioned way a semantic event reaches the log.
+// to stdout so the model can copy it into a later resolve (§15.6), and echoes the
+// resolved route to stderr. This is the only sanctioned way a semantic event
+// reaches the log.
 func runEmit(args []string) int {
 	fs := flag.NewFlagSet("emit", flag.ContinueOnError)
 	var typ, area, risk, to, refs string
@@ -55,7 +56,12 @@ func runEmit(args []string) int {
 		fmt.Fprintf(os.Stderr, "emit: %v\n", err)
 		return 1
 	}
+	// stdout stays the bare ULID and nothing else: callers capture it, sometimes
+	// through command substitution. The routing echo therefore goes to stderr,
+	// naming the project and workstream the event actually landed in so a session
+	// whose cwd drifted sees the misroute in its own transcript.
 	fmt.Println(ev.ID)
+	fmt.Fprintf(os.Stderr, "→ %s · %s\n", ws.RepoKey, ws.ID)
 	return 0
 }
 

--- a/cmd/director/emit_test.go
+++ b/cmd/director/emit_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/colinsurprenant/director/internal/id"
+	"github.com/colinsurprenant/director/internal/identity"
+)
+
+// TestRunEmitRoutingEcho locks emit's two-stream contract. stdout carries the
+// bare ULID and nothing else — callers capture it, sometimes through command
+// substitution — while stderr carries the routing echo naming the project and
+// workstream the event landed in, the line that makes a cwd-drift misroute
+// visible in the emitting session's transcript.
+func TestRunEmitRoutingEcho(t *testing.T) {
+	hub := t.TempDir()
+	t.Setenv("DIRECTOR_HUB", hub)
+	repo := filepath.Join(t.TempDir(), "proj")
+	gitInitRepo(t, repo)
+	t.Chdir(repo)
+
+	ws, err := identity.Resolve(repo)
+	if err != nil {
+		t.Fatalf("identity.Resolve: %v", err)
+	}
+
+	var code int
+	stdout, stderr := captureStreams(t, func() {
+		code = runEmit([]string{"--type", "note", "--area", "x", "routed somewhere"})
+	})
+	if code != 0 {
+		t.Fatalf("emit exit = %d, want 0\nstderr: %s", code, stderr)
+	}
+
+	if strings.Count(stdout, "\n") != 1 || !strings.HasSuffix(stdout, "\n") {
+		t.Fatalf("stdout = %q, want exactly one ULID line", stdout)
+	}
+	if _, err := id.Parse(strings.TrimSuffix(stdout, "\n")); err != nil {
+		t.Fatalf("stdout %q is not a bare ULID: %v", stdout, err)
+	}
+
+	if want := "→ " + ws.RepoKey + " · " + ws.ID + "\n"; stderr != want {
+		t.Fatalf("stderr = %q, want exactly %q", stderr, want)
+	}
+
+	// A rejected emit wrote nothing, so it echoes no route — only its error.
+	stdout, stderr = captureStreams(t, func() {
+		code = runEmit([]string{"--type", "note", "--refs", "not-a-ulid", "rejected"})
+	})
+	if code != 2 {
+		t.Fatalf("emit with bad --refs exit = %d, want 2", code)
+	}
+	if stdout != "" {
+		t.Errorf("rejected emit wrote to stdout: %q", stdout)
+	}
+	if strings.Contains(stderr, "→") {
+		t.Errorf("rejected emit echoed a route: %q", stderr)
+	}
+}
+
+// captureStreams runs fn with BOTH os.Stdout and os.Stderr redirected to pipes
+// and returns what each received. The CLI verbs print with fmt.Print/Fprint to
+// the real fds, so tests asserting on output need them swapped, not a passed
+// writer — and emit splits its output across the two, so both must be swapped at
+// once to see the split.
+func captureStreams(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	outR, outW := mustPipe(t)
+	errR, errW := mustPipe(t)
+	os.Stdout, os.Stderr = outW, errW
+	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
+
+	outDone, errDone := drainPipe(outR), drainPipe(errR)
+	fn()
+	outW.Close()
+	errW.Close()
+	return <-outDone, <-errDone
+}
+
+func mustPipe(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, w
+}
+
+// drainPipe reads r to EOF in the background so a writer that fills the pipe
+// buffer never blocks fn.
+func drainPipe(r *os.File) <-chan string {
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			b.Write(buf[:n])
+			if err != nil {
+				break
+			}
+		}
+		done <- b.String()
+	}()
+	return done
+}

--- a/cmd/director/emit_test.go
+++ b/cmd/director/emit_test.go
@@ -72,13 +72,17 @@ func captureStreams(t *testing.T, fn func()) (stdout, stderr string) {
 	outR, outW := mustPipe(t)
 	errR, errW := mustPipe(t)
 	os.Stdout, os.Stderr = outW, errW
-	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
-
 	outDone, errDone := drainPipe(outR), drainPipe(errR)
+	// Deferred so the fds are restored, the writers closed, and the drain
+	// goroutines collected even when fn panics mid-capture.
+	defer func() {
+		os.Stdout, os.Stderr = origOut, origErr
+		outW.Close()
+		errW.Close()
+		stdout, stderr = <-outDone, <-errDone
+	}()
 	fn()
-	outW.Close()
-	errW.Close()
-	return <-outDone, <-errDone
+	return
 }
 
 func mustPipe(t *testing.T) (*os.File, *os.File) {
@@ -104,6 +108,7 @@ func drainPipe(r *os.File) <-chan string {
 				break
 			}
 		}
+		r.Close()
 		done <- b.String()
 	}()
 	return done

--- a/skills/director/SKILL.md
+++ b/skills/director/SKILL.md
@@ -84,7 +84,9 @@ when it doesn't.
 ### emit returns the new event's ULID
 
 `director emit` prints the new event's **ULID to stdout**. Note it — that is the id others (and
-you) use to `--refs` or `resolve` it later.
+you) use to `--refs` or `resolve` it later. It also echoes a routing line to **stderr**
+(`→ <repo-key> · <workstream-id>`) naming the project it wrote to; if that is not the project you
+expect, your cwd drifted and the event landed in the wrong log.
 
 ## 3. Closing open-items — resolve discipline
 


### PR DESCRIPTION
Fixes the silent half of the CWD-routing dogfood incident (log `01KYXD85CR`): `director emit` resolves its target project from the shell CWD, and a session whose cwd drifted misfiled five events, including a handoff, into a different adopted project's log with no visible sign.

`emit` now echoes one routing line to **stderr** after a successful append:

```
→ <repo-key> · <workstream-id>
```

stdout stays exactly the bare ULID (sessions capture it, sometimes via command substitution), so nothing that reads emit's output changes. A misrouted write is now visible in the emitting session's own transcript, where the model can compare the echoed identity against the one injected at session start.

- `TestRunEmitRoutingEcho` locks the two-stream contract byte-exactly (success and rejected-emit paths); the existing `captureStdout` test helper now delegates to the new two-stream helper.
- README and the injected skill doc each gained a sentence documenting the echo.

Review: in-session criteria review, then two independent external passes (Codex, Kimi K3 sandboxed). Both confirmed the stream split and that no consumer of emit's stderr exists (shims and the OpenCode plugin invoke only `_hook`). Two low-severity notes (control chars in a malformed identity cache; test-helper goroutine lifetime on panic) were triaged as no-action: the ids are ASCII-slugged and printed verbatim on every other surface, and the helper is the standard idiom in a non-parallel test package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
