### PR TITLE
install: survive tag-stripping, heal duplicates, grant the hub sandbox write

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,15 +145,16 @@ Then wire it into your agent. The one-liner already wired Claude Code; the secti
 director install
 ```
 
-`director install` does three things, all idempotent and self-contained:
+`director install` does four things, all idempotent and self-contained:
 
 1. **Writes the hook shims.** The shims are embedded in the binary, so `install` materializes them (executable) into the hooks dir. There is **no manual copy step**.
-2. **Merges the hooks into `~/.claude/settings.json`.** Every entry it writes carries a `"_managedBy":"director"` tag, so Director's hooks run **alongside** GSD's and any hand-rolled hooks without clobbering them. Re-running adds nothing; `director uninstall` removes only Director's tagged entries **and** the shims and command files it wrote. Pass `--settings <path>` to target a project or test settings file.
+2. **Merges the hooks into `~/.claude/settings.json`.** Every entry it writes carries a `"_managedBy":"director"` tag, so Director's hooks run **alongside** GSD's and any hand-rolled hooks without clobbering them. Re-running adds nothing; `director uninstall` removes only Director's own entries (tagged, or untagged at its shim paths) **and** the shims and command files it wrote. Pass `--settings <path>` to target a project or test settings file.
 3. **Materializes the slash commands.** The `/director:adopt`, `/director:complete`, and `/director:handoff` commands (also embedded) are written under `~/.claude/commands/director/`, namespaced so they never clobber a user's own commands.
+4. **Grants the hub sandbox write access.** A sandboxed session can write only its working directory and session tmp by default, so the first coordination write would stop on a permission prompt. `install` adds the hub (`~/.director`, or your `DIRECTOR_HUB`) to `sandbox.filesystem.allowWrite` in `settings.json`, leaving any entries you added there untouched.
 
 The installed hook commands point at the **shims**, not the binary directly, so rebuilding or relocating `director` never requires rewriting `settings.json` (re-run `install` to refresh the shims to the current binary). If `~/.claude/settings.json` already has a malformed (non-object) `hooks` value, `install` refuses rather than overwrite it.
 
-Confirm the wiring will actually fire with `director doctor`. The shims fail safe (a missing binary exits 0 and coordination silently no-ops), so a broken install is otherwise invisible; `doctor` walks the same binary-resolution ladder the shims walk and reports each link (binary, Claude Code hooks, Codex and OpenCode hooks if present, hub). It exits non-zero when the install is broken, and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss:
+Confirm the wiring will actually fire with `director doctor`. The shims fail safe (a missing binary exits 0 and coordination silently no-ops), so a broken install is otherwise invisible; `doctor` walks the same binary-resolution ladder the shims walk and reports each link (binary, Claude Code hooks, Codex and OpenCode hooks if present, the hub's sandbox write grant, hub). It exits non-zero when the install is broken, and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss:
 
 ```bash
 director doctor

--- a/cmd/director/context.go
+++ b/cmd/director/context.go
@@ -3,24 +3,21 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/colinsurprenant/director/internal/identity"
+	"github.com/colinsurprenant/director/internal/install"
 )
 
 // hubRoot resolves the central hub directory — where cross-worktree coordination
 // state (projects/, fleet/) lives (§5.1). DIRECTOR_HUB overrides; otherwise it
 // defaults to ~/.director. (Dogfooding the Director repo as its own hub sets
 // DIRECTOR_HUB to the repo root.)
+//
+// The resolution itself lives in internal/install, which needs the same answer to
+// grant the hub Claude Code sandbox write access at install time. One resolver
+// means an install can never authorize a directory the CLI does not write to.
 func hubRoot() (string, error) {
-	if h := os.Getenv("DIRECTOR_HUB"); h != "" {
-		return h, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve hub: %w", err)
-	}
-	return filepath.Join(home, ".director"), nil
+	return install.DefaultHubRoot()
 }
 
 // resolveContext gathers what every working command needs: the hub root and the

--- a/cmd/director/doctorcmd.go
+++ b/cmd/director/doctorcmd.go
@@ -74,6 +74,7 @@ type doctorInputs struct {
 	codexHooks              string                // ~/.codex/hooks.json
 	opencodePlugin          string                // ~/.config/opencode/plugin/director.js
 	hub                     string                // the coordination hub root
+	hubAllowWrite           string                // the hub form install grants in sandbox.filesystem.allowWrite
 }
 
 // runDoctor is the CLI wrapper: resolve the environment, diagnose, print, and
@@ -165,6 +166,7 @@ func doctorInputsFromEnv() (doctorInputs, error) {
 		codexHooks:              codexHooks,
 		opencodePlugin:          opencodePlugin,
 		hub:                     hub,
+		hubAllowWrite:           install.HubAllowWriteValue(),
 	}, nil
 }
 
@@ -182,7 +184,8 @@ func diagnose(in doctorInputs) doctorReport {
 	// standalone) would deterministically exit unhealthy.
 	codexCheck, codexPresent := codexHooksCheck(in)
 	opencodeCheck, opencodePresent := opencodeHooksCheck(in)
-	claudeAbsent := !install.ManagedEntriesPresent(in.settingsPath) && install.SettingsParseError(in.settingsPath) == nil
+	claudePresent := install.ManagedEntriesPresent(in.settingsPath, in.hooksDir)
+	claudeAbsent := !claudePresent && install.SettingsParseError(in.settingsPath) == nil
 	if !claudeAbsent || (!codexPresent && !opencodePresent) {
 		r.checks = append(r.checks, claudeHooksCheck(in))
 	}
@@ -191,6 +194,13 @@ func diagnose(in doctorInputs) doctorReport {
 	}
 	if opencodePresent {
 		r.checks = append(r.checks, opencodeCheck)
+	}
+	// The sandbox grant is a Claude Code setting, so it is only assessable where a
+	// CC install actually exists: on an absent or malformed settings.json the
+	// claude check above already carries the remedy, and a second warning about
+	// the same file would just double-report it.
+	if claudePresent {
+		r.checks = append(r.checks, sandboxWriteCheck(in))
 	}
 	r.checks = append(r.checks, hubCheck(in.hub))
 
@@ -246,10 +256,10 @@ func binaryResolutionCheck(in doctorInputs) check {
 	}
 }
 
-// claudeHooksCheck verifies the Claude Code side is wired: the FULL set of tagged
+// claudeHooksCheck verifies the Claude Code side is wired: the FULL set of
 // entries is in settings.json AND the shims those entries point at actually exist.
 func claudeHooksCheck(in doctorInputs) check {
-	if !install.ManagedEntriesPresent(in.settingsPath) {
+	if !install.ManagedEntriesPresent(in.settingsPath, in.hooksDir) {
 		// ManagedEntriesPresent collapses a read/parse failure to the same false as
 		// "no managed entries", but the remedies differ: a malformed settings.json
 		// needs fixing (install would refuse to overwrite it), not a re-run. Split
@@ -272,14 +282,40 @@ func claudeHooksCheck(in doctorInputs) check {
 		return check{"claude code hooks", levelFail, fmt.Sprintf(
 			"settings.json references Director hooks, but shims are missing from %s (%s) — re-run `director install`.", in.hooksDir, strings.Join(missing, ", "))}
 	}
+	// Wired but untagged: Claude Code sometimes rewrites settings.json without
+	// unknown fields, taking `"_managedBy":"director"` with it. The hooks still
+	// fire (the shim path is what CC runs) and install/uninstall still recognize
+	// them by that path, so this is a warning, not a failure — but it is worth
+	// surfacing, because a re-install is what puts the tag back.
+	if untagged := install.UntaggedManagedEntries(in.settingsPath, in.hooksDir); len(untagged) > 0 {
+		return check{"claude code hooks", levelWarn, fmt.Sprintf(
+			"Director hooks in %s have lost their \"_managedBy\" tag (%s) — Claude Code rewrites settings.json without unknown fields. They still fire, and Director still recognizes them by their shim path; re-run `director install` to re-tag them.",
+			in.settingsPath, strings.Join(untagged, ", "))}
+	}
 	return check{"claude code hooks", levelOK, fmt.Sprintf("wired in %s; shims present in %s", in.settingsPath, in.hooksDir)}
+}
+
+// sandboxWriteCheck verifies the hub is listed in settings.json's
+// sandbox.filesystem.allowWrite. A sandboxed Claude Code session may write only
+// its cwd and session tmp by default, so without the grant the first coordination
+// write into the hub stops on a permission prompt — and from a hook, a blocked
+// write reads as Director quietly doing nothing. Warning-grade: an unsandboxed
+// session is unaffected, and the remedy is one re-install.
+func sandboxWriteCheck(in doctorInputs) check {
+	if install.SettingsAllowsHubWrite(in.settingsPath, in.hubAllowWrite) {
+		return check{"sandbox write access", levelOK, fmt.Sprintf(
+			"%s grants write access to the hub (%s)", in.settingsPath, in.hubAllowWrite)}
+	}
+	return check{"sandbox write access", levelWarn, fmt.Sprintf(
+		"%s does not list the hub (%s) in sandbox.filesystem.allowWrite — in a sandboxed session, coordination writes will hit a permission prompt. Re-run `director install`.",
+		in.settingsPath, in.hubAllowWrite)}
 }
 
 // codexHooksCheck reports the Codex side only when a Codex install is present, so
 // it never nags a Claude-Code-only user. The bool is false when there is nothing
 // to report.
 func codexHooksCheck(in doctorInputs) (check, bool) {
-	if !install.ManagedEntriesPresent(in.codexHooks) {
+	if !install.ManagedEntriesPresent(in.codexHooks, in.hooksDir) {
 		return check{}, false
 	}
 	if missing := missingShims(in.hooksDir, install.CodexShims()); len(missing) > 0 {

--- a/cmd/director/doctorcmd_test.go
+++ b/cmd/director/doctorcmd_test.go
@@ -37,6 +37,9 @@ func installedFixture(t *testing.T) doctorInputs {
 	hooksDir := filepath.Join(root, "hooks")
 	t.Setenv("DIRECTOR_HOOKS_DIR", hooksDir)
 	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
+	// Pin the hub form install grants (and the check reads) to the default,
+	// independent of the developer's exported DIRECTOR_HUB.
+	t.Setenv("DIRECTOR_HUB", "")
 	settings := filepath.Join(root, "settings.json")
 	if err := install.Install(settings); err != nil {
 		t.Fatalf("install fixture: %v", err)
@@ -46,13 +49,14 @@ func installedFixture(t *testing.T) doctorInputs {
 		t.Fatalf("resolve bin path: %v", err)
 	}
 	return doctorInputs{
-		directorBin:  "",
-		lookDirector: func() (string, bool) { return "", false }, // rely on the symlink tier
-		settingsPath: settings,
-		hooksDir:     hooksDir,
-		binPath:      binPath,
-		codexHooks:   filepath.Join(root, "no-codex.json"),
-		hub:          root, // a writable directory
+		directorBin:   "",
+		lookDirector:  func() (string, bool) { return "", false }, // rely on the symlink tier
+		settingsPath:  settings,
+		hooksDir:      hooksDir,
+		binPath:       binPath,
+		codexHooks:    filepath.Join(root, "no-codex.json"),
+		hub:           root, // a writable directory
+		hubAllowWrite: install.HubAllowWriteValue(),
 	}
 }
 
@@ -81,11 +85,17 @@ func TestDoctorHealthy(t *testing.T) {
 	if !rep.healthy {
 		t.Fatalf("want healthy, got %+v", rep.checks)
 	}
+	if rep.hasWarn() {
+		t.Errorf("a fresh install must report no warnings at all, got %+v", rep.checks)
+	}
 	if lv := levelOf(t, rep, "binary"); lv != levelOK {
 		t.Errorf("binary check: got %v, want OK", lv)
 	}
 	if lv := levelOf(t, rep, "claude code hooks"); lv != levelOK {
 		t.Errorf("hooks check: got %v, want OK", lv)
+	}
+	if lv := levelOf(t, rep, "sandbox write access"); lv != levelOK {
+		t.Errorf("sandbox check: got %v, want OK", lv)
 	}
 	if hasCheck(rep, "codex hooks") {
 		t.Errorf("codex check must be absent without a Codex install")
@@ -659,6 +669,199 @@ func TestDoctorHubUnwritableAncestorFails(t *testing.T) {
 	in.hub = filepath.Join(locked, "hub") // missing; nearest ancestor is unwritable
 	if levelOf(t, diagnose(in), "hub") != levelFail {
 		t.Fatal("a missing hub under an unwritable parent must FAIL")
+	}
+}
+
+// TestDoctorUntaggedEntriesWarn: Claude Code sometimes rewrites settings.json
+// without unknown fields, stripping `"_managedBy":"director"` from hooks that
+// still fire. doctor must SAY so — naming the events and the re-tag remedy — but
+// as a warning: the entries work, and Director still recognizes them by their shim
+// path. A failure here would tell users their working install is broken.
+func TestDoctorUntaggedEntriesWarn(t *testing.T) {
+	in := installedFixture(t)
+	stripManagedTags(t, in.settingsPath)
+
+	rep := diagnose(in)
+	if lv := levelOf(t, rep, "claude code hooks"); lv != levelWarn {
+		t.Fatalf("tag-stripped install: claude check = %v, want a warning (%+v)", lv, rep.checks)
+	}
+	if !rep.healthy {
+		t.Fatal("stripped tags must not sink the report — the hooks still fire")
+	}
+	for _, c := range rep.checks {
+		if c.title != "claude code hooks" {
+			continue
+		}
+		for _, event := range []string{"SessionStart", "PostToolUse", "Stop", "SessionEnd"} {
+			if !strings.Contains(c.detail, event) {
+				t.Errorf("warning should name the affected event %s, got: %s", event, c.detail)
+			}
+		}
+		if !strings.Contains(c.detail, "director install") {
+			t.Errorf("warning should name the remedy, got: %s", c.detail)
+		}
+	}
+}
+
+// TestRunDoctorUntaggedEntriesExitsZero drives the same state through the CLI
+// wrapper: a warning is not a failure, so the exit code stays 0 and a re-install
+// clears it.
+func TestRunDoctorUntaggedEntriesExitsZero(t *testing.T) {
+	skipUnixOnlyDoctor(t)
+	root := t.TempDir()
+	settings := filepath.Join(root, "settings.json")
+	t.Setenv("DIRECTOR_HOOKS_DIR", filepath.Join(root, "hooks"))
+	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
+	t.Setenv("DIRECTOR_SETTINGS_PATH", settings)
+	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", filepath.Join(root, "no-codex.json"))
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", filepath.Join(root, "no-plugin.js"))
+	t.Setenv("DIRECTOR_HUB", root)
+	t.Setenv("DIRECTOR_BIN", "")
+	if err := install.Install(settings); err != nil {
+		t.Fatal(err)
+	}
+	stripManagedTags(t, settings)
+
+	if code := runDoctor(nil); code != 0 {
+		t.Fatalf("a tag-stripped install must warn, not fail: runDoctor exit = %d, want 0", code)
+	}
+	if err := install.Install(settings); err != nil {
+		t.Fatal(err)
+	}
+	if code := runDoctor(nil); code != 0 {
+		t.Fatalf("after the re-install: runDoctor exit = %d, want 0", code)
+	}
+}
+
+// TestDoctorSandboxGrantMissingWarns: an install predating the sandbox grant (or
+// a settings.json a user edited) leaves the hub unwritable from a sandboxed
+// session — a permission prompt on the first coordination write, which from a
+// hook looks like Director doing nothing. Warning-grade: unsandboxed sessions are
+// unaffected, and the remedy is one re-install.
+func TestDoctorSandboxGrantMissingWarns(t *testing.T) {
+	in := installedFixture(t)
+	dropSandboxBlock(t, in.settingsPath)
+
+	rep := diagnose(in)
+	if lv := levelOf(t, rep, "sandbox write access"); lv != levelWarn {
+		t.Fatalf("missing hub grant: sandbox check = %v, want a warning (%+v)", lv, rep.checks)
+	}
+	if !rep.healthy {
+		t.Fatal("a missing sandbox grant must not sink the report")
+	}
+	for _, c := range rep.checks {
+		if c.title == "sandbox write access" && !strings.Contains(c.detail, "director install") {
+			t.Errorf("warning should name the remedy, got: %s", c.detail)
+		}
+	}
+}
+
+// TestDoctorSandboxCheckAbsentWithoutClaudeInstall: the grant is a Claude Code
+// setting, so with no CC install there is nothing to assess — the claude check
+// already carries the "run director install" remedy, and a second line about the
+// same file would just double-report it.
+func TestDoctorSandboxCheckAbsentWithoutClaudeInstall(t *testing.T) {
+	in := installedFixture(t)
+	in.settingsPath = filepath.Join(t.TempDir(), "no-settings.json")
+	if hasCheck(diagnose(in), "sandbox write access") {
+		t.Error("sandbox check must stand down when no Claude Code install is present")
+	}
+}
+
+// TestDoctorSandboxCheckHonorsHubOverride: with DIRECTOR_HUB set, install grants
+// that exact path and doctor must look for the same one. A check keyed on the
+// default `~/.director` would warn forever on an overridden hub.
+func TestDoctorSandboxCheckHonorsHubOverride(t *testing.T) {
+	skipUnixOnlyDoctor(t)
+	root := t.TempDir()
+	hub := filepath.Join(root, "custom-hub")
+	settings := filepath.Join(root, "settings.json")
+	t.Setenv("DIRECTOR_HOOKS_DIR", filepath.Join(root, "hooks"))
+	t.Setenv("DIRECTOR_COMMANDS_DIR", filepath.Join(root, "commands"))
+	t.Setenv("DIRECTOR_SETTINGS_PATH", settings)
+	t.Setenv("DIRECTOR_CODEX_HOOKS_PATH", filepath.Join(root, "no-codex.json"))
+	t.Setenv("DIRECTOR_OPENCODE_PLUGIN_PATH", filepath.Join(root, "no-plugin.js"))
+	t.Setenv("DIRECTOR_HUB", hub)
+	t.Setenv("DIRECTOR_BIN", "")
+	if err := install.Install(settings); err != nil {
+		t.Fatal(err)
+	}
+
+	in, err := doctorInputsFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in.lookDirector = func() (string, bool) { return "", false } // rely on the symlink tier
+	if in.hub != hub {
+		t.Errorf("hubRoot did not honor DIRECTOR_HUB: got %q, want %q", in.hub, hub)
+	}
+	if in.hubAllowWrite != hub {
+		t.Errorf("granted hub value = %q, want the override %q verbatim", in.hubAllowWrite, hub)
+	}
+	rep := diagnose(in)
+	if lv := levelOf(t, rep, "sandbox write access"); lv != levelOK {
+		t.Errorf("overridden hub: sandbox check = %v, want OK (%+v)", lv, rep.checks)
+	}
+	if code := runDoctor(nil); code != 0 {
+		t.Fatalf("overridden hub: runDoctor exit = %d, want 0", code)
+	}
+}
+
+// stripManagedTags removes the `_managedBy` tag from every command object in a
+// settings.json, reproducing a Claude Code rewrite that drops unknown fields. The
+// commands themselves are left alone: the hooks still fire.
+func stripManagedTags(t *testing.T, path string) {
+	t.Helper()
+	root := readSettingsTree(t, path)
+	hooks, _ := root["hooks"].(map[string]any)
+	for _, groups := range hooks {
+		gs, _ := groups.([]any)
+		for _, g := range gs {
+			gm, _ := g.(map[string]any)
+			cmds, _ := gm["hooks"].([]any)
+			for _, c := range cmds {
+				if cm, _ := c.(map[string]any); cm != nil {
+					delete(cm, "_managedBy")
+				}
+			}
+		}
+	}
+	writeSettingsTree(t, path, root)
+}
+
+// dropSandboxBlock removes the whole sandbox block, rolling a settings.json back
+// to what an install predating the hub grant wrote.
+func dropSandboxBlock(t *testing.T, path string) {
+	t.Helper()
+	root := readSettingsTree(t, path)
+	if _, ok := root["sandbox"]; !ok {
+		t.Fatalf("setup: %s carries no sandbox block to drop", path)
+	}
+	delete(root, "sandbox")
+	writeSettingsTree(t, path, root)
+}
+
+func readSettingsTree(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func writeSettingsTree(t *testing.T, path string, root map[string]any) {
+	t.Helper()
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/director/installcmd.go
+++ b/cmd/director/installcmd.go
@@ -110,6 +110,7 @@ func installOne(target, path string) int {
 		return 0
 	}
 	fmt.Printf("  commands written to %s (/director:adopt, /director:complete, /director:handoff; set DIRECTOR_COMMANDS_DIR to override)\n", commandsDir)
+	fmt.Printf("  hub %s granted write access in settings.json (sandbox.filesystem.allowWrite, so sandboxed sessions can record coordination state; set DIRECTOR_HUB to override)\n", install.HubAllowWriteValue())
 	printBinLine()
 	return 0
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,6 +99,7 @@ Bare `install` wires Claude Code. The target flags mirror the one-liner's wire f
 installed Director hooks into /Users/you/.claude/settings.json (set DIRECTOR_SETTINGS_PATH to override)
   shims written to /Users/you/.claude/director/hooks (set DIRECTOR_HOOKS_DIR to override)
   commands written to /Users/you/.claude/commands/director (/director:adopt, /director:complete, /director:handoff; set DIRECTOR_COMMANDS_DIR to override)
+  hub ~/.director granted write access in settings.json (sandbox.filesystem.allowWrite, so sandboxed sessions can record coordination state; set DIRECTOR_HUB to override)
   binary symlinked at /Users/you/.claude/director/bin/director (hook fallback when director is not on PATH, e.g. desktop app launches)
 ```
 
@@ -111,10 +112,14 @@ installed Director hooks into /Users/you/.claude/settings.json (set DIRECTOR_SET
 - It materializes the three slash commands: `/director:adopt` (informed adoption, see section 3),
   `/director:handoff` (pause a workstream, record the resume point) and `/director:complete` (close out a finished,
   merged workstream). More on the boundary pair in section 5.
+- It grants the hub write access in `sandbox.filesystem.allowWrite`. A sandboxed session may write only its
+  working directory and session tmp, so without this the first write into `~/.director` (or your `DIRECTOR_HUB`)
+  stops on a permission prompt: from a hook, that reads as Director silently doing nothing. Your own
+  `allowWrite` entries are preserved, and `director uninstall` takes back only Director's.
 
 Verify it took. `director doctor` is the thorough check: it walks the same binary-resolution ladder
-the hooks walk and reports each link (binary, Claude Code hooks, Codex and OpenCode hooks if present, hub), so a
-broken install becomes loud instead of a silent no-op. It exits non-zero when the install is broken,
+the hooks walk and reports each link (binary, Claude Code hooks, Codex and OpenCode hooks if present, the hub's
+sandbox write grant, hub), so a broken install becomes loud instead of a silent no-op. It exits non-zero when the install is broken,
 and warns (without failing) on a partial one, such as a terminal-only install the desktop app would miss.
 
 ```bash
@@ -124,6 +129,7 @@ director doctor
 ```text
 ✓ binary: director resolves on your PATH (/usr/local/bin/director), and the install symlink ~/.claude/director/bin/director backs desktop-app (Dock/Launchpad) launches — both launch contexts covered
 ✓ claude code hooks: wired in ~/.claude/settings.json; shims present in ~/.claude/director/hooks
+✓ sandbox write access: ~/.claude/settings.json grants write access to the hub (~/.director)
 ✓ hub: ~/.director does not exist yet — it is created on first write
 
 ✓ Director is healthy: the hooks will fire and coordination is live.
@@ -193,7 +199,7 @@ The rest of this guide uses the Claude Code command names (`/director:adopt` etc
 as its `$director-*` skill twin, and on OpenCode as its flat `/director-*` custom command: same command,
 same behavior.
 
-`director uninstall --codex` removes only the tagged entries and the three skill directories. The hook
+`director uninstall --codex` removes only Director's own entries (tagged, or untagged at its shim paths) and the three skill directories. The hook
 shims are shared between the two agents: either uninstall form leaves them in place while the other
 agent's install still references them, and reclaims them once neither does, so uninstalling one agent
 never silently breaks the other, and uninstalling the last one leaves no shim files behind.
@@ -398,7 +404,7 @@ what `brief` shows and what the next session starts from.
 ## 6. Troubleshooting
 
 Start with **`director doctor`**: it checks the whole install chain (binary resolution, Claude Code,
-Codex, and OpenCode hooks, shims present, hub writable) and names the broken link, exiting non-zero when coordination
+Codex, and OpenCode hooks, shims present, the hub's sandbox write grant, hub writable) and names the broken link, exiting non-zero when coordination
 would not fire. The table covers the specifics.
 
 | Symptom | Cause & fix |

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -101,8 +101,9 @@ func InstallCodex(hooksPath string) error {
 	return mergeManagedEntries(hooksPath, codexEntries, hooksDir)
 }
 
-// UninstallCodex removes Director's tagged entries from hooksPath and the
-// Director-owned skill directories. A missing hooks file means no Codex install
+// UninstallCodex removes Director's entries from hooksPath (tagged, or untagged
+// at one of our shim paths) and the Director-owned skill directories. A missing
+// hooks file means no Codex install
 // to undo — touch nothing, mirroring the CC Uninstall. The shared shims (and
 // the bin symlink that travels with them) are spared while EITHER default
 // install still references them: the default CC settings.json carrying
@@ -118,20 +119,22 @@ func UninstallCodex(hooksPath string) error {
 	if _, err := os.Stat(hooksPath); os.IsNotExist(err) {
 		return nil
 	}
-	if err := removeManagedEntries(hooksPath); err != nil {
+	// Resolved before the removal, not just for the reclaim: the shim paths under
+	// it are what identify an entry of ours whose `_managedBy` tag was stripped.
+	// A failure (no HOME) degrades to tag-only removal, mirroring Uninstall.
+	hooksDir, hooksErr := DefaultHooksDir()
+	if err := removeManagedEntries(hooksPath, hooksDir); err != nil {
 		return err
 	}
 	if skillsDir, err := DefaultCodexSkillsDir(); err == nil {
 		removeCodexSkills(skillsDir)
 	}
-	if !claudeInstallPresent() && !codexInstallPresent() {
-		if hooksDir, err := DefaultHooksDir(); err == nil {
-			removeShims(hooksDir)
-			// The bin symlink outlives the shims when an OpenCode install remains:
-			// its plugin probes the same fallback path without using the shims.
-			if !opencodeInstallPresent() {
-				removeBinSymlink(hooksDir)
-			}
+	if !claudeInstallPresent() && !codexInstallPresent() && hooksErr == nil {
+		removeShims(hooksDir)
+		// The bin symlink outlives the shims when an OpenCode install remains:
+		// its plugin probes the same fallback path without using the shims.
+		if !opencodeInstallPresent() {
+			removeBinSymlink(hooksDir)
 		}
 	}
 	return nil
@@ -157,7 +160,11 @@ func codexInstallPresent() bool {
 	if err != nil {
 		return false
 	}
-	return ManagedEntriesPresent(hooksPath)
+	hooksDir, err := DefaultHooksDir()
+	if err != nil {
+		hooksDir = "" // degrade to the tag-only reading, as claudeInstallPresent does
+	}
+	return ManagedEntriesPresent(hooksPath, hooksDir)
 }
 
 // codexSkillName maps an embedded command filename to its skill name:

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -105,6 +105,39 @@ func TestInstallCodexMergesAndPreservesForeign(t *testing.T) {
 	}
 }
 
+// TestInstallCodexCollapsesDuplicateEntries pins the duplicate collapse on the
+// SHARED merge core: Codex's hooks.json is tagged by the same mechanism, so a
+// stripped tag followed by a pre-fix install doubles its entries the same way, and
+// InstallCodex must heal it to one tagged copy per event just as Install does.
+func TestInstallCodexCollapsesDuplicateEntries(t *testing.T) {
+	hooksPath, hooksDir, _ := setupCodex(t, codexFixture)
+	if err := InstallCodex(hooksPath); err != nil {
+		t.Fatalf("InstallCodex: %v", err)
+	}
+	stripDirectorTags(t, hooksPath, true)
+	duplicateDirectorCommands(t, hooksPath, hooksDir, true)
+	if got := directorCommandCount(t, loadTree(t, hooksPath), "Stop", hooksDir); got != 2 {
+		t.Fatalf("fixture setup: hooks.Stop carries %d Director commands, want 2", got)
+	}
+
+	if err := InstallCodex(hooksPath); err != nil {
+		t.Fatalf("re-InstallCodex: %v", err)
+	}
+	root := loadTree(t, hooksPath)
+	for _, event := range []string{"SessionStart", "PostToolUse", "Stop"} {
+		if got := directorCommandCount(t, root, event, hooksDir); got != 1 {
+			t.Errorf("hooks.%s carries %d Director commands after install, want 1 (%v)",
+				event, got, commands(t, root, event))
+		}
+		if got := managedCount(t, root, event); got != 1 {
+			t.Errorf("hooks.%s survivors tagged = %d, want 1", event, got)
+		}
+	}
+	if !contains(commands(t, root, "PreToolUse"), "my-own-guard.sh") {
+		t.Errorf("user's own PreToolUse hook was lost in the collapse")
+	}
+}
+
 // TestInstallCodexWritesSkills: the boundary commands materialize as agent
 // skills — one <skillsDir>/<director-name>/SKILL.md each, carrying the required
 // name: frontmatter and with every CC-namespaced cross-reference rewritten to

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -4,13 +4,24 @@
 // object Director owns carries a `"_managedBy":"director"` tag (an unknown field
 // CC ignores), so Director's hooks run ALONGSIDE hand-rolled and other-plugin
 // (GSD's) hooks without clobbering them. Re-install is a no-op on already-present
-// entries; Uninstall removes ONLY tagged objects and prunes now-empty groups,
+// entries; Uninstall removes ONLY Director's objects and prunes now-empty groups,
 // leaving everything else intact.
+//
+// Ownership has a SECOND proof, and it is load-bearing: Claude Code has been
+// observed rewriting settings.json in a way that drops unknown fields, taking
+// `_managedBy` with them. Keyed on the tag alone, every layer then misreads the
+// file — install appends duplicate hooks, uninstall removes nothing, doctor
+// reports healthy, and (worst) a Codex uninstall reclaims the shared shims out
+// from under live CC hooks. So a command object whose "command" is one of the
+// shim paths under Director's OWN hooks dir counts as ours by construction, tag
+// or no tag; install re-tags what it finds AND collapses the duplicate copies a
+// pre-fix install already appended, which makes the whole install self-healing
+// after such a rewrite.
 //
 // The merge is structure-preserving: the settings file is decoded into generic
 // maps so foreign top-level keys (permissions, env, other hook events) and
 // foreign hook entries round-trip untouched — Director only ever adds or removes
-// its own tagged objects.
+// its own objects.
 package install
 
 import (
@@ -66,6 +77,13 @@ const commandsDirEnv = "DIRECTOR_COMMANDS_DIR"
 // already overrides the install/uninstall target; this env var additionally
 // redirects the cross-target claudeInstallPresent probe.
 const settingsPathEnv = "DIRECTOR_SETTINGS_PATH"
+
+// hubRootEnv redirects the coordination hub — the directory every write verb
+// records state in. It is the CLI's own override (cmd/director's hubRoot
+// delegates to DefaultHubRoot so the two can never disagree), and install needs
+// it for a second reason: the hub is the path it grants Claude Code sandbox
+// write access to.
+const hubRootEnv = "DIRECTOR_HUB"
 
 // managedEntry describes one hook Director installs: which CC event it attaches
 // to, the matcher (empty = all), and the shim filename under the hooks dir.
@@ -161,11 +179,45 @@ func DefaultCommandsDir() (string, error) {
 	return filepath.Join(home, ".claude", "commands", "director"), nil
 }
 
+// DefaultHubRoot resolves the coordination hub root, ~/.director — where the
+// per-project logs and fleet rows live. DIRECTOR_HUB overrides the location.
+// cmd/director's hubRoot delegates here so the path install grants sandbox write
+// access to is, by construction, the path the CLI and hooks actually write to.
+func DefaultHubRoot() (string, error) {
+	if h := os.Getenv(hubRootEnv); h != "" {
+		return h, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("install: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".director"), nil
+}
+
+// defaultHubAllowWrite is the hub entry install grants on a default hub. It is
+// the HOME-RELATIVE literal on purpose: that is the form Claude Code documents
+// for sandbox.filesystem.allowWrite, and it stays correct across machines with
+// different home paths (a settings.json is a routinely synced file).
+const defaultHubAllowWrite = "~/.director"
+
+// HubAllowWriteValue returns the exact string install ensures in Claude Code's
+// sandbox.filesystem.allowWrite: `~/.director` for the default hub, or the
+// DIRECTOR_HUB override verbatim (an override is already an absolute, deliberate
+// path — rewriting it to a ~-form would be guesswork). No error: the default form
+// needs no home lookup, so this answer exists even where DefaultHubRoot fails.
+func HubAllowWriteValue() string {
+	if h := os.Getenv(hubRootEnv); h != "" {
+		return h
+	}
+	return defaultHubAllowWrite
+}
+
 // Install merges Director's tagged hook entries into the settings file at
-// settingsPath. It is idempotent: an identical tagged entry already present is
-// left as-is, so re-running adds nothing (entry-count-stable). Untagged and
-// other-plugin entries are never touched. A missing settings file is created
-// with just Director's entries.
+// settingsPath and grants the hub sandbox write access there. It is idempotent:
+// an identical entry already present is left as-is, so re-running adds nothing
+// (entry-count-stable), and an entry of ours whose tag was stripped is re-tagged
+// rather than duplicated. Other-plugin entries are never touched. A missing
+// settings file is created with just Director's entries.
 func Install(settingsPath string) error {
 	hooksDir, err := DefaultHooksDir()
 	if err != nil {
@@ -191,20 +243,58 @@ func Install(settingsPath string) error {
 	if err := writeCommands(commandsDir); err != nil {
 		return err
 	}
-	return mergeManagedEntries(settingsPath, directorEntries, hooksDir)
+	return mergeClaudeSettings(settingsPath, hooksDir)
+}
+
+// mergeClaudeSettings is the Claude-Code-only settings merge: the shared
+// tagged-entry merge PLUS the sandbox write grant for the hub, in ONE
+// read-modify-write so a refusal at either step leaves the file byte-for-byte
+// untouched. The sandbox key is a Claude Code concept and would be foreign data
+// in Codex's hooks.json, which is why it lives here and not in the shared core.
+func mergeClaudeSettings(path, hooksDir string) error {
+	root, err := loadSettings(path)
+	if err != nil {
+		return err
+	}
+	if err := applyManagedEntries(root, path, directorEntries, hooksDir); err != nil {
+		return err
+	}
+	if err := applyHubAllowWrite(root, path, HubAllowWriteValue()); err != nil {
+		return err
+	}
+	return writeSettings(path, root)
 }
 
 // mergeManagedEntries performs the `_managedBy`-tagged merge of entries into the
 // hooks file at path. It is the shared core behind Install (CC settings.json) and
 // InstallCodex (Codex hooks.json) — both files carry the same top-level
 // {"hooks": {Event: [{matcher, hooks: [...]}]}} structure, so one merge serves
-// both. Idempotent: an identical tagged entry already present is left as-is.
+// both. Idempotent: an entry already present is left as-is.
 func mergeManagedEntries(path string, entries []managedEntry, hooksDir string) error {
 	root, err := loadSettings(path)
 	if err != nil {
 		return err
 	}
+	if err := applyManagedEntries(root, path, entries, hooksDir); err != nil {
+		return err
+	}
+	return writeSettings(path, root)
+}
 
+// applyManagedEntries merges entries into the decoded hooks tree in place. It is
+// split from the file I/O so the CC path can add its sandbox grant to the SAME
+// tree and write once; path is carried only to name the file in refusal errors.
+//
+// EVERY group whose effective matcher equals the entry's is in scope, not just the
+// first one found. The Claude Code rewrite that strips `_managedBy` has been
+// observed stripping `matcher` keys too, and a group with no matcher reads as
+// matcher "" — so one logical catch-all can arrive here split across several
+// groups. Keyed on the first group alone, an entry sitting in a LATER one is
+// invisible and install appends a fresh copy beside it, re-creating exactly the
+// double-firing the collapse exists to remove. So presence, adoption, and collapse
+// all run across the whole same-matcher set: one canonical copy survives overall,
+// in the group where it was found first, and the redundant copies go.
+func applyManagedEntries(root map[string]any, path string, entries []managedEntry, hooksDir string) error {
 	hooks, ok := typedMap(root, "hooks")
 	if !ok {
 		return fmt.Errorf("install: refusing to modify %s: \"hooks\" is present but not an object", path)
@@ -217,39 +307,196 @@ func mergeManagedEntries(path string, entries []managedEntry, hooksDir string) e
 		}
 		command := commandFor(hooksDir, e.shim)
 
-		gi := findMatcherGroup(groups, e.matcher)
-		if gi < 0 {
-			// No group for this matcher yet: add one carrying just our tagged
-			// command. Foreign groups for other matchers are left in place.
-			groups = append(groups, map[string]any{
-				"matcher": e.matcher,
-				"hooks":   []any{managedCommand(command)},
-			})
-			hooks[e.event] = groups
-			continue
+		var (
+			present    bool           // some same-matcher group already holds our command
+			survivor   bool           // the one canonical copy has been kept
+			firstGroup map[string]any // first same-matcher group: where a fresh copy lands
+			firstCmds  []any
+		)
+		kept := make([]any, 0, len(groups))
+		for gi, g := range groups {
+			if !groupMatches(g, e.matcher) {
+				kept = append(kept, g) // another matcher, or a shape we don't own
+				continue
+			}
+			group := asMap(g)
+			before, ok := typedArray(group, "hooks")
+			if !ok {
+				return fmt.Errorf("install: refusing to modify %s: hooks.%s[%d].hooks is present but not an array", path, e.event, gi)
+			}
+			// ensureManagedCommand both adopts (re-tags a stripped entry) and collapses
+			// (drops redundant copies a pre-fix install appended), so the list it hands
+			// back must be re-attached even when our entry was already present.
+			after, found, keptSurvivor := ensureManagedCommand(before, command, survivor)
+			present, survivor = present || found, keptSurvivor
+			if len(after) == 0 && len(before) > 0 {
+				// The collapse emptied this group: drop it rather than leave a hollow
+				// one behind, mirroring the uninstall pruning. A group that was
+				// ALREADY empty is somebody else's, and stays.
+				continue
+			}
+			group["hooks"] = after
+			if firstGroup == nil {
+				firstGroup, firstCmds = group, after
+			}
+			kept = append(kept, group)
 		}
-
-		group := asMap(groups[gi])
-		cmds, ok := typedArray(group, "hooks")
-		if !ok {
-			return fmt.Errorf("install: refusing to modify %s: hooks.%s[%d].hooks is present but not an array", path, e.event, gi)
+		if !present {
+			if firstGroup == nil {
+				// No group for this matcher yet: add one carrying just our tagged
+				// command. Foreign groups for other matchers are left in place.
+				kept = append(kept, map[string]any{
+					"matcher": e.matcher,
+					"hooks":   []any{managedCommand(command)},
+				})
+			} else {
+				// firstGroup is already in kept, so mutating it is enough.
+				firstGroup["hooks"] = append(firstCmds, managedCommand(command))
+			}
 		}
-		if hasManagedCommand(cmds, command) {
-			continue // already installed — idempotent no-op
-		}
-		group["hooks"] = append(cmds, managedCommand(command))
-		groups[gi] = group
-		hooks[e.event] = groups
+		hooks[e.event] = kept
 	}
 
 	root["hooks"] = hooks
-	return writeSettings(path, root)
+	return nil
 }
 
-// Uninstall removes ONLY Director's `_managedBy:"director"` command objects from
-// the settings file, then prunes any hook group and event list left empty as a
-// result. Untagged commands, foreign groups, and non-hook settings are preserved
-// exactly. A missing settings file is a no-op.
+// applyHubAllowWrite ensures value is listed in sandbox.filesystem.allowWrite,
+// creating whatever levels are missing. Claude Code sandboxes a session to its
+// cwd and session tmp by default, so without this grant a fresh user's FIRST
+// coordination write (`director emit` into ~/.director) stops on a permission
+// prompt — from a hook, that reads as Director silently not working. Idempotent,
+// and additive: a user's own allowWrite entries are preserved. Every level goes
+// through the typed accessors, so a present-but-wrong-typed key anywhere on the
+// path refuses the whole install rather than clobbering data we don't understand.
+func applyHubAllowWrite(root map[string]any, path, value string) error {
+	sandbox, ok := typedMap(root, "sandbox")
+	if !ok {
+		return fmt.Errorf("install: refusing to modify %s: \"sandbox\" is present but not an object", path)
+	}
+	filesystem, ok := typedMap(sandbox, "filesystem")
+	if !ok {
+		return fmt.Errorf("install: refusing to modify %s: sandbox.filesystem is present but not an object", path)
+	}
+	allow, ok := typedArray(filesystem, "allowWrite")
+	if !ok {
+		return fmt.Errorf("install: refusing to modify %s: sandbox.filesystem.allowWrite is present but not an array", path)
+	}
+	if !containsString(allow, value) {
+		allow = append(allow, value)
+	}
+	// Re-attach unconditionally: typedMap/typedArray hand back a FRESH container
+	// for an absent key, so the levels this install created only reach the tree here.
+	filesystem["allowWrite"] = allow
+	sandbox["filesystem"] = filesystem
+	root["sandbox"] = sandbox
+	return nil
+}
+
+// removeHubAllowWrite drops exactly the value applyHubAllowWrite adds, then
+// prunes each level THIS removal left empty (allowWrite → filesystem → sandbox),
+// so an uninstall leaves no hollow scaffolding behind. A user's other allowWrite
+// entries — and any other sandbox setting — keep their level alive and are never
+// touched.
+//
+// The pruning is gated on having actually removed the grant, not merely on the
+// level ending up empty: a user's own pre-existing `sandbox.filesystem.allowWrite:
+// []` is scaffolding Director never wrote, and deleting it would be an uninstall
+// mutating a file it has nothing to remove from. A no-op removal leaves the tree
+// exactly as it found it.
+//
+// Nothing here refuses. A wrong-typed level provably holds nothing of ours —
+// applyHubAllowWrite refuses to write through one — so on the uninstall path it
+// reads as "no grant to take back" and the hook removal proceeds. Refusing instead
+// would leave a user whose settings.json carries an unrelated `"sandbox": "off"`
+// unable to remove Director's hooks at all.
+func removeHubAllowWrite(root map[string]any, value string) {
+	sandbox, ok := typedMap(root, "sandbox")
+	if !ok {
+		return
+	}
+	filesystem, ok := typedMap(sandbox, "filesystem")
+	if !ok {
+		return
+	}
+	allow, ok := typedArray(filesystem, "allowWrite")
+	if !ok {
+		return
+	}
+	kept := make([]any, 0, len(allow))
+	removed := false
+	for _, v := range allow {
+		if s, isStr := v.(string); isStr && s == value {
+			removed = true
+			continue
+		}
+		kept = append(kept, v)
+	}
+	if !removed {
+		return
+	}
+	// Each level is deleted only when EMPTY, and a delete of an absent key is a
+	// no-op — so a settings file that never carried a sandbox block comes through
+	// this unchanged rather than gaining empty objects.
+	if len(kept) == 0 {
+		delete(filesystem, "allowWrite")
+	} else {
+		filesystem["allowWrite"] = kept
+	}
+	if len(filesystem) == 0 {
+		delete(sandbox, "filesystem")
+	} else {
+		sandbox["filesystem"] = filesystem
+	}
+	if len(sandbox) == 0 {
+		delete(root, "sandbox")
+	} else {
+		root["sandbox"] = sandbox
+	}
+}
+
+// SettingsAllowsHubWrite reports whether value is listed in the settings file's
+// sandbox.filesystem.allowWrite — the read-only half of applyHubAllowWrite, used
+// by `director doctor`. A missing/unreadable file or any foreign shape on the
+// path reads as "not granted": the remedy doctor prints (re-run install) is the
+// same either way, and a malformed settings.json already has its own check.
+func SettingsAllowsHubWrite(path, value string) bool {
+	root, err := loadSettings(path)
+	if err != nil {
+		return false
+	}
+	sandbox, ok := typedMap(root, "sandbox")
+	if !ok {
+		return false
+	}
+	filesystem, ok := typedMap(sandbox, "filesystem")
+	if !ok {
+		return false
+	}
+	allow, ok := typedArray(filesystem, "allowWrite")
+	if !ok {
+		return false
+	}
+	return containsString(allow, value)
+}
+
+// containsString reports whether the decoded array carries the exact string
+// value, skipping non-string elements (allowWrite is documented as strings, but
+// the tree is generic and a foreign element must not panic the scan).
+func containsString(values []any, value string) bool {
+	for _, v := range values {
+		if s, ok := v.(string); ok && s == value {
+			return true
+		}
+	}
+	return false
+}
+
+// Uninstall removes ONLY Director's command objects from the settings file
+// (tagged, or untagged at one of our shim paths — see the package doc), drops the
+// hub's sandbox write grant, then prunes any hook group, event list, and sandbox
+// level left empty as a result. Foreign commands, foreign groups, and non-hook
+// settings are preserved exactly. A missing settings file is a no-op.
 func Uninstall(settingsPath string) error {
 	// A missing settings file means no CC install to undo: touch NOTHING — not
 	// the shims (a Codex install may be the only one referencing them), not the
@@ -259,7 +506,12 @@ func Uninstall(settingsPath string) error {
 	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
 		return nil
 	}
-	if err := removeManagedEntries(settingsPath); err != nil {
+	// The hooks dir is what proves ownership of an entry whose tag was stripped,
+	// so it has to be resolved BEFORE the removal, not just for the shim reclaim
+	// below. A failure here (no HOME) degrades to tag-only removal — the same
+	// best-effort stance the reclaim takes — rather than refusing to uninstall.
+	hooksDir, hooksErr := DefaultHooksDir()
+	if err := removeClaudeSettings(settingsPath, hooksDir); err != nil {
 		return err
 	}
 	// Remove the Director-owned shims too — the inverse of Install's writeShims
@@ -269,12 +521,10 @@ func Uninstall(settingsPath string) error {
 	// mirror of UninstallCodex leaving them for CC). The bin symlink is wider
 	// than the shims: the OpenCode plugin's fallback tier probes it too (no
 	// shims involved), so its reclaim additionally gates on that install.
-	if !codexInstallPresent() {
-		if hooksDir, err := DefaultHooksDir(); err == nil {
-			removeShims(hooksDir)
-			if !opencodeInstallPresent() {
-				removeBinSymlink(hooksDir)
-			}
+	if !codexInstallPresent() && hooksErr == nil {
+		removeShims(hooksDir)
+		if !opencodeInstallPresent() {
+			removeBinSymlink(hooksDir)
 		}
 	}
 	// And the Director-owned slash commands — the inverse of writeCommands, same
@@ -285,12 +535,14 @@ func Uninstall(settingsPath string) error {
 	return nil
 }
 
-// removeManagedEntries strips Director's tagged command objects from the hooks
-// file at path — the shared removal core behind Uninstall (CC) and
-// UninstallCodex. Callers gate on the file's existence themselves (both
-// uninstalls treat a missing file as "nothing installed, touch nothing"); the
-// stat here is only a belt against a caller that didn't.
-func removeManagedEntries(path string) error {
+// removeClaudeSettings is the Claude-Code-only removal: Director's command
+// objects AND the hub's sandbox write grant, in one read-modify-write so a
+// refusal by the hooks step leaves the file untouched. The mirror of
+// mergeClaudeSettings, and for the same reason: `sandbox` never exists in the
+// Codex hooks file, so its removal cannot live in the shared core. The sandbox
+// step never refuses (see removeHubAllowWrite): a shape it cannot read holds
+// nothing of ours, and must not cost the user the hook removal.
+func removeClaudeSettings(path, hooksDir string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil
 	}
@@ -298,6 +550,40 @@ func removeManagedEntries(path string) error {
 	if err != nil {
 		return err
 	}
+	if err := stripManagedEntries(root, path, directorCommands(hooksDir)); err != nil {
+		return err
+	}
+	removeHubAllowWrite(root, HubAllowWriteValue())
+	return writeSettings(path, root)
+}
+
+// removeManagedEntries strips Director's command objects from the hooks file at
+// path — the shared removal core behind UninstallCodex (Uninstall goes through
+// removeClaudeSettings, which adds the CC-only sandbox step). Callers gate on the
+// file's existence themselves (both uninstalls treat a missing file as "nothing
+// installed, touch nothing"); the stat here is only a belt against a caller that
+// didn't.
+func removeManagedEntries(path, hooksDir string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	root, err := loadSettings(path)
+	if err != nil {
+		return err
+	}
+	if err := stripManagedEntries(root, path, directorCommands(hooksDir)); err != nil {
+		return err
+	}
+	return writeSettings(path, root)
+}
+
+// stripManagedEntries removes Director's command objects from the decoded hooks
+// tree in place. Ownership is the tag OR an exact match against commands (the
+// shim paths under our own hooks dir): removing only tagged objects would leave
+// an entry stranded and firing forever once Claude Code rewrites settings.json
+// without the unknown `_managedBy` field. An empty commands set (an unresolvable
+// hooks dir) degrades to tag-only — never to matching on a bare relative name.
+func stripManagedEntries(root map[string]any, path string, commands []string) error {
 	hooks, ok := typedMap(root, "hooks")
 	if !ok {
 		// No package prefix on the uninstall-path errors: the CLI wraps them with
@@ -327,7 +613,7 @@ func removeManagedEntries(path string) error {
 			}
 			survivors := make([]any, 0, len(cmds))
 			for _, c := range cmds {
-				if !isManaged(c) {
+				if !directorOwned(c, commands) {
 					survivors = append(survivors, c)
 				}
 			}
@@ -350,7 +636,7 @@ func removeManagedEntries(path string) error {
 	} else {
 		root["hooks"] = hooks
 	}
-	return writeSettings(path, root)
+	return nil
 }
 
 // claudeInstallPresent reports whether the default CC settings file still
@@ -367,16 +653,26 @@ func claudeInstallPresent() bool {
 	if err != nil {
 		return false
 	}
-	return ManagedEntriesPresent(settingsPath)
+	hooksDir, err := DefaultHooksDir()
+	if err != nil {
+		// Degrade to the tag-only reading rather than skipping the probe: the
+		// answer this feeds (spare the shared shims) must stay fail-open, and a
+		// tagged install is still recognizable without the path proof.
+		hooksDir = ""
+	}
+	return ManagedEntriesPresent(settingsPath, hooksDir)
 }
 
 // ManagedEntriesPresent reports whether the hooks file at path carries any
-// Director-managed command object — the shared scan behind codexInstallPresent,
-// claudeInstallPresent, and `director doctor`. Read errors and foreign shapes
-// read as "not present": the uninstall callers want the fail-open direction (see
-// codexInstallPresent for why fail-safe would make shim removal permanently leaky),
-// and doctor treats an unreadable/absent hooks file the same as "not wired".
-func ManagedEntriesPresent(path string) bool {
+// Director command object — tagged, or untagged at one of the shim paths under
+// hooksDir (see the package doc: a stripped tag must not read as "no install",
+// or a Codex uninstall would reclaim the shims out from under live CC hooks).
+// It is the shared scan behind codexInstallPresent, claudeInstallPresent, and
+// `director doctor`. Read errors and foreign shapes read as "not present": the
+// uninstall callers want the fail-open direction (see codexInstallPresent for why
+// fail-safe would make shim removal permanently leaky), and doctor treats an
+// unreadable/absent hooks file the same as "not wired".
+func ManagedEntriesPresent(path, hooksDir string) bool {
 	root, err := loadSettings(path)
 	if err != nil {
 		return false
@@ -385,6 +681,7 @@ func ManagedEntriesPresent(path string) bool {
 	if !ok {
 		return false
 	}
+	commands := directorCommands(hooksDir)
 	for event := range hooks {
 		groups, ok := typedArray(hooks, event)
 		if !ok {
@@ -400,7 +697,7 @@ func ManagedEntriesPresent(path string) bool {
 				continue
 			}
 			for _, c := range cmds {
-				if isManaged(c) {
+				if directorOwned(c, commands) {
 					return true
 				}
 			}
@@ -409,11 +706,69 @@ func ManagedEntriesPresent(path string) bool {
 	return false
 }
 
+// UntaggedManagedEntries reports which of Director's hook events carry a command
+// object of ours whose `_managedBy` tag is GONE — the fingerprint of Claude Code
+// rewriting settings.json without unknown fields. Those entries still fire (the
+// command path is what CC runs) and install/uninstall still recognize them by
+// path, so this is a warning-grade observation, not a failure: doctor names the
+// events and prescribes a re-install, which re-tags them.
+//
+// Events come back deduplicated in directorEntries order — a stable, meaningful
+// order for a user-facing message, unlike a Go map's iteration. Read errors and
+// foreign shapes report nothing, the same fail-open direction as its neighbors.
+func UntaggedManagedEntries(path, hooksDir string) []string {
+	root, err := loadSettings(path)
+	if err != nil {
+		return nil
+	}
+	hooks, ok := typedMap(root, "hooks")
+	if !ok {
+		return nil
+	}
+	commands := directorCommands(hooksDir)
+	var seen, events []string
+	for _, e := range directorEntries {
+		if containsName(seen, e.event) {
+			continue
+		}
+		seen = append(seen, e.event)
+		if eventHasUntaggedCommand(hooks, e.event, commands) {
+			events = append(events, e.event)
+		}
+	}
+	return events
+}
+
+// eventHasUntaggedCommand reports whether any group under hooks[event] holds a
+// command object at one of our shim paths that has lost its tag.
+func eventHasUntaggedCommand(hooks map[string]any, event string, commands []string) bool {
+	groups, ok := typedArray(hooks, event)
+	if !ok {
+		return false
+	}
+	for _, g := range groups {
+		cmds, ok := typedArray(asMap(g), "hooks")
+		if !ok {
+			continue
+		}
+		for _, c := range cmds {
+			m := asMap(c)
+			if m == nil || isManaged(m) {
+				continue
+			}
+			if containsName(commands, stringAt(m, "command")) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // MissingManagedEvents reports which of Director's Claude Code hook events are NOT
 // wired in the hooks file at path, deduplicated and in directorEntries order. An
-// entry counts as present under exactly the criteria mergeManagedEntries uses for
-// idempotency (matcher group + tagged command path under hooksDir), so an empty
-// result means "Install would add nothing".
+// entry counts as present under exactly the criteria applyManagedEntries uses for
+// idempotency (matcher group + our command path under hooksDir, tag or no tag), so
+// an empty result means "Install would add nothing".
 //
 // This is the question ManagedEntriesPresent cannot answer: it reports whether ANY
 // Director entry exists, which reads as wired on an install predating a hook event
@@ -442,23 +797,31 @@ func MissingManagedEvents(path, hooksDir string) []string {
 }
 
 // managedEntryPresent reports whether e is already wired in the decoded hooks map:
-// the read-only half of mergeManagedEntries' idempotency test, built from the same
-// primitives (findMatcherGroup, hasManagedCommand, commandFor) so the two can never
-// disagree about what "already installed" means.
+// the read-only half of applyManagedEntries' idempotency test, built from the same
+// primitives (groupMatches, hasDirectorCommand, commandFor) so the two can never
+// disagree about what "already installed" means — including the case where the tag
+// was stripped, which install adopts rather than duplicates, and the case where the
+// entry sits in a LATER same-matcher group, which install adopts in place. Hence
+// the scan over every same-matcher group rather than only the first.
 func managedEntryPresent(hooks map[string]any, e managedEntry, hooksDir string) bool {
 	groups, ok := typedArray(hooks, e.event)
 	if !ok {
 		return false
 	}
-	gi := findMatcherGroup(groups, e.matcher)
-	if gi < 0 {
-		return false
+	command := commandFor(hooksDir, e.shim)
+	for _, g := range groups {
+		if !groupMatches(g, e.matcher) {
+			continue
+		}
+		cmds, ok := typedArray(asMap(g), "hooks")
+		if !ok {
+			continue
+		}
+		if hasDirectorCommand(cmds, command) {
+			return true
+		}
 	}
-	cmds, ok := typedArray(asMap(groups[gi]), "hooks")
-	if !ok {
-		return false
-	}
-	return hasManagedCommand(cmds, commandFor(hooksDir, e.shim))
+	return false
 }
 
 // ClaudeShims and CodexShims return the shim basenames each target's entry set
@@ -778,20 +1141,118 @@ func managedCommand(command string) map[string]any {
 	}
 }
 
-// hasManagedCommand reports whether cmds already contains Director's tagged
-// command for the given command string — used to make Install idempotent without
-// duplicating an identical entry.
-func hasManagedCommand(cmds []any, command string) bool {
+// directorCommands returns the command paths Director's installs write into a
+// hooks file: one per EMBEDDED shim, under hooksDir. The full embedded set is
+// deliberate rather than one target's subset — removal and presence must
+// recognize every Director command in the file, including one written by the
+// other agent's install or by a binary whose entry set has since changed. An
+// empty hooksDir yields no paths, so an unresolvable hooks dir degrades to
+// tag-only ownership instead of matching a bare relative filename.
+func directorCommands(hooksDir string) []string {
+	if hooksDir == "" {
+		return nil
+	}
+	shims := ExpectedShims()
+	cmds := make([]string, 0, len(shims))
+	for _, s := range shims {
+		cmds = append(cmds, commandFor(hooksDir, s))
+	}
+	return cmds
+}
+
+// directorOwned reports whether a command object is Director's: it carries the
+// tag, or its "command" is one of our shim paths. The second proof is what
+// survives Claude Code rewriting settings.json without unknown fields.
+func directorOwned(c any, commands []string) bool {
+	if isManaged(c) {
+		return true
+	}
+	m := asMap(c)
+	if m == nil {
+		return false
+	}
+	return containsName(commands, stringAt(m, "command"))
+}
+
+// hasDirectorCommand reports whether cmds already carries Director's command
+// object for the given shim path. The tag is NOT required: the shims live under
+// Director's own hooks dir, so a command object at that exact path is ours by
+// construction — which is what keeps install idempotent (and doctor honest) after
+// a settings.json rewrite drops the tag.
+func hasDirectorCommand(cmds []any, command string) bool {
 	for _, c := range cmds {
-		m := asMap(c)
-		if m == nil {
-			continue
-		}
-		if isManaged(m) && stringAt(m, "command") == command {
+		if m := asMap(c); m != nil && stringAt(m, "command") == command {
 			return true
 		}
 	}
 	return false
+}
+
+// ensureManagedCommand is hasDirectorCommand with the two REPAIR side effects the
+// merge needs, applied to one matcher group's command list. It returns the list to
+// keep, whether any copy of our command was found IN THIS GROUP, and whether the
+// one canonical copy is now kept — that last value threads through the caller's
+// walk of every same-matcher group (pass false for the first), so "exactly one
+// survivor" holds across the whole set and not merely within one group:
+//
+//   - ADOPTION: an untagged command object at our exact path is re-tagged in place
+//     (nothing else about it is rewritten) and reported as present, so install adds
+//     no duplicate and the file comes out tagged again.
+//   - COLLAPSE: every FURTHER copy of that command in the same group is dropped, so
+//     exactly one survives. This heals the second casualty of a settings.json
+//     rewrite that drops unknown fields: with the tag gone, a pre-fix install
+//     appended a second copy of every hook into the same group, and the hook then
+//     fired twice per session. Adoption alone would tag both copies and make the
+//     double-firing permanent and invisible.
+//
+// Together they make `director install` the single healing verb for that damage —
+// no uninstall/reinstall ceremony.
+//
+// Only a collapsible copy (see collapsibleCommand) is ever dropped. One carrying a
+// field we do not write is somebody's deliberate edit, not a duplicate we can prove
+// redundant, so it survives untouched — never removing what we do not fully
+// understand outranks the heal. It still counts as present: appending a canonical
+// copy beside it would re-create the double-firing this is here to remove. Such a
+// copy also keeps doctor's untagged-entry warning lit through every re-install,
+// which is honest — the file does carry an entry at our path that install did not
+// write and will not rewrite.
+func ensureManagedCommand(cmds []any, command string, survivor bool) ([]any, bool, bool) {
+	kept := make([]any, 0, len(cmds))
+	var present bool
+	for _, c := range cmds {
+		m := asMap(c)
+		if m == nil || stringAt(m, "command") != command {
+			kept = append(kept, c) // not ours; position preserved
+			continue
+		}
+		present = true
+		if !collapsibleCommand(m) {
+			kept = append(kept, c)
+			continue
+		}
+		if survivor {
+			continue // a redundant copy of our own entry: collapse it away
+		}
+		survivor = true
+		if !isManaged(m) {
+			m[managedByKey] = managedByValue
+		}
+		kept = append(kept, m)
+	}
+	return kept, present, survivor
+}
+
+// collapsibleCommand reports whether a command object holds nothing beyond the
+// fields managedCommand writes. That subset is what makes a second copy provably
+// redundant: Director never writes anything else, and the Claude Code rewrite that
+// creates these duplicates only ever drops fields.
+func collapsibleCommand(m map[string]any) bool {
+	for k := range m {
+		if k != "type" && k != "command" && k != managedByKey {
+			return false
+		}
+	}
+	return true
 }
 
 // isManaged reports whether a command object carries Director's tag.
@@ -803,21 +1264,27 @@ func isManaged(c any) bool {
 	return stringAt(m, managedByKey) == managedByValue
 }
 
-// findMatcherGroup returns the index of the group whose matcher equals matcher,
-// or -1. A group with no "matcher" key is treated as matcher "" so Director's
-// empty-matcher entry lands beside an existing catch-all group rather than
-// spawning a duplicate.
-func findMatcherGroup(groups []any, matcher string) int {
-	for i, g := range groups {
-		group := asMap(g)
-		if group == nil {
-			continue
-		}
-		if stringAt(group, "matcher") == matcher {
-			return i
-		}
+// groupMatches reports whether a decoded hook group's effective matcher equals
+// matcher. It is the single definition of "this group is where our entry belongs",
+// shared by the merge and the presence probe so the two can never disagree.
+//
+// An ABSENT (or null) "matcher" key reads as "" — that is Claude Code's own
+// reading, and it makes Director's empty-matcher entry land beside an existing
+// catch-all group rather than spawning a duplicate. A PRESENT but non-string
+// matcher is a different case entirely: it is foreign data we cannot compare, so
+// it matches NOTHING. Coercing it to "" (which stringAt would) would hand install
+// a wrong-typed stranger's group to select and mutate.
+func groupMatches(g any, matcher string) bool {
+	group := asMap(g)
+	if group == nil {
+		return false
 	}
-	return -1
+	v, present := group["matcher"]
+	if !present || v == nil {
+		return matcher == ""
+	}
+	s, ok := v.(string)
+	return ok && s == matcher
 }
 
 // loadSettings reads and decodes the settings file into a generic map. A missing

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -753,7 +753,7 @@ func eventHasUntaggedCommand(hooks map[string]any, event string, commands []stri
 		}
 		for _, c := range cmds {
 			m := asMap(c)
-			if m == nil || isManaged(m) {
+			if m == nil || isManaged(m) || !commandTyped(m) {
 				continue
 			}
 			if containsName(commands, stringAt(m, "command")) {
@@ -1161,17 +1161,27 @@ func directorCommands(hooksDir string) []string {
 }
 
 // directorOwned reports whether a command object is Director's: it carries the
-// tag, or its "command" is one of our shim paths. The second proof is what
-// survives Claude Code rewriting settings.json without unknown fields.
+// tag, or it is a "command"-typed object whose "command" is one of our shim
+// paths. The second proof is what survives Claude Code rewriting settings.json
+// without unknown fields. The type gate keeps the proof honest: only actual
+// command hooks are ours by construction; some other object shape that happens
+// to reference a shim path is foreign data and must never be matched.
 func directorOwned(c any, commands []string) bool {
 	if isManaged(c) {
 		return true
 	}
 	m := asMap(c)
-	if m == nil {
+	if m == nil || !commandTyped(m) {
 		return false
 	}
 	return containsName(commands, stringAt(m, "command"))
+}
+
+// commandTyped reports whether the object is a Claude Code command hook — the
+// only shape Director ever writes (managedCommand), and a KNOWN field CC's
+// settings rewrite preserves, so an entry of ours always still carries it.
+func commandTyped(m map[string]any) bool {
+	return stringAt(m, "type") == "command"
 }
 
 // hasDirectorCommand reports whether cmds already carries Director's command
@@ -1181,7 +1191,7 @@ func directorOwned(c any, commands []string) bool {
 // a settings.json rewrite drops the tag.
 func hasDirectorCommand(cmds []any, command string) bool {
 	for _, c := range cmds {
-		if m := asMap(c); m != nil && stringAt(m, "command") == command {
+		if m := asMap(c); m != nil && commandTyped(m) && stringAt(m, "command") == command {
 			return true
 		}
 	}
@@ -1221,8 +1231,8 @@ func ensureManagedCommand(cmds []any, command string, survivor bool) ([]any, boo
 	var present bool
 	for _, c := range cmds {
 		m := asMap(c)
-		if m == nil || stringAt(m, "command") != command {
-			kept = append(kept, c) // not ours; position preserved
+		if m == nil || !commandTyped(m) || stringAt(m, "command") != command {
+			kept = append(kept, c) // not ours (wrong shape, type, or path); position preserved
 			continue
 		}
 		present = true

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -1483,6 +1484,53 @@ func TestInstallSkipsWrongTypedMatcherGroup(t *testing.T) {
 		t.Errorf("hooks.Stop tagged commands = %d, want 1", got)
 	}
 	assertInstallByteStable(t, path)
+}
+
+// TestForeignTypeAtShimPathIsNeverOurs: path ownership applies only to
+// "command"-typed objects. A foreign object of another type that happens to
+// reference one of our shim paths must never be adopted, collapsed, removed, or
+// counted as a Director install.
+func TestForeignTypeAtShimPathIsNeverOurs(t *testing.T) {
+	path, hooksDir := writeFixture(t, "")
+	stop := filepath.Join(hooksDir, "stop.sh")
+	fixture := fmt.Sprintf(`{"hooks": {"Stop": [{"matcher": "", "hooks": [
+		{"type": "tool", "command": %q, "note": "foreign"}
+	]}]}}`, stop)
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if present := ManagedEntriesPresent(path, hooksDir); present {
+		t.Errorf("ManagedEntriesPresent = true on a foreign-typed object at our path, want false")
+	}
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	// The foreign object survives verbatim beside our appended canonical command.
+	cmds := commands(t, root, "Stop")
+	if len(cmds) != 2 {
+		t.Fatalf("hooks.Stop carries %d commands, want 2 (foreign-typed + ours): %v", len(cmds), cmds)
+	}
+	if got := managedCount(t, root, "Stop"); got != 1 {
+		t.Errorf("hooks.Stop tagged commands = %d, want 1", got)
+	}
+	if untagged := UntaggedManagedEntries(path, hooksDir); len(untagged) != 0 {
+		t.Errorf("UntaggedManagedEntries = %v, want none (the foreign-typed object is not ours)", untagged)
+	}
+	assertInstallByteStable(t, path)
+
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+	root = loadTree(t, path)
+	cmds = commands(t, root, "Stop")
+	if len(cmds) != 1 || cmds[0] != stop {
+		t.Fatalf("after uninstall hooks.Stop = %v, want only the foreign-typed object at %s", cmds, stop)
+	}
+	if got := managedCount(t, root, "Stop"); got != 0 {
+		t.Errorf("after uninstall tagged commands = %d, want 0", got)
+	}
 }
 
 // TestUninstallRemovesUntaggedEntries: the removal half of the same failure. With

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -51,6 +51,11 @@ func writeFixture(t *testing.T, contents string) (path, hooksDir string) {
 	t.Setenv(codexSkillsDirEnv, filepath.Join(t.TempDir(), "skills"))
 	t.Setenv(opencodePluginPathEnv, filepath.Join(t.TempDir(), "director.js"))
 	t.Setenv(opencodeCommandsDirEnv, filepath.Join(t.TempDir(), "oc-command"))
+	// Clear DIRECTOR_HUB so the sandbox grant Install writes is the default
+	// `~/.director` literal regardless of the developer's shell (this repo
+	// dogfoods itself by exporting DIRECTOR_HUB, which would otherwise leak into
+	// the asserted value). Tests covering the override set it themselves.
+	t.Setenv(hubRootEnv, "")
 	dir := t.TempDir()
 	path = filepath.Join(dir, "settings.json")
 	// Point the default CC settings at the fixture itself, so UninstallCodex's
@@ -111,6 +116,21 @@ func managedCount(t *testing.T, root map[string]any, event string) int {
 			if isManaged(c) {
 				n++
 			}
+		}
+	}
+	return n
+}
+
+// directorCommandCount counts the command objects under hooks[event] whose command
+// is a shim path under hooksDir — Director's entries whether or not they still
+// carry the tag. managedCount answers "how many are tagged"; this answers "how many
+// will FIRE", which is the question a duplicate-collapse assertion needs.
+func directorCommandCount(t *testing.T, root map[string]any, event, hooksDir string) int {
+	t.Helper()
+	n := 0
+	for _, cmd := range commands(t, root, event) {
+		if strings.HasPrefix(cmd, hooksDir) {
+			n++
 		}
 	}
 	return n
@@ -847,7 +867,7 @@ func TestMissingManagedEventsDetectsStaleEntrySet(t *testing.T) {
 	delete(hooks, "SessionEnd") // exactly what the pre-SessionEnd install wrote
 	writeTree(t, path, root)
 
-	if !ManagedEntriesPresent(path) {
+	if !ManagedEntriesPresent(path, hooksDir) {
 		t.Fatal("setup: the stale set must still read as present — that collapse is the hole being closed")
 	}
 	got := MissingManagedEvents(path, hooksDir)
@@ -864,9 +884,10 @@ func TestMissingManagedEventsDetectsStaleEntrySet(t *testing.T) {
 }
 
 // TestMissingManagedEventsMatchesInstallCriteria: presence is judged exactly as the
-// merge judges it — the matcher group AND the tagged command path — so a dropped
-// matcher group (the `compact` SessionStart) reports its event, and an untagged
-// command at the right path does not count as Director's.
+// merge judges it — the matcher group AND our command path — so a dropped matcher
+// group (the `compact` SessionStart) reports its event, while an UNTAGGED command
+// at our path does not: the merge adopts that one instead of adding a second, so
+// calling it missing would tell doctor to demand a re-install that changes nothing.
 func TestMissingManagedEventsMatchesInstallCriteria(t *testing.T) {
 	path, hooksDir := writeFixture(t, gsdFixture)
 	if err := Install(path); err != nil {
@@ -884,7 +905,7 @@ func TestMissingManagedEventsMatchesInstallCriteria(t *testing.T) {
 		kept = append(kept, g)
 	}
 	hooks["SessionStart"] = kept
-	// Strip Director's tag from the Stop command: same path, no longer ours.
+	// Strip Director's tag from the Stop command: still at our shim path, so still ours.
 	stopGroups, _ := hooks["Stop"].([]any)
 	for _, g := range stopGroups {
 		gm, _ := g.(map[string]any)
@@ -898,9 +919,9 @@ func TestMissingManagedEventsMatchesInstallCriteria(t *testing.T) {
 	writeTree(t, path, root)
 
 	got := MissingManagedEvents(path, hooksDir)
-	want := map[string]bool{"SessionStart": true, "Stop": true}
+	want := map[string]bool{"SessionStart": true}
 	if len(got) != len(want) {
-		t.Fatalf("MissingManagedEvents = %v, want %v", got, want)
+		t.Fatalf("MissingManagedEvents = %v, want %v (Stop is untagged but at our path, so it is NOT missing)", got, want)
 	}
 	for _, e := range got {
 		if !want[e] {
@@ -976,6 +997,889 @@ func TestTargetShimSets(t *testing.T) {
 				t.Errorf("%s references %q, which install never writes", name, shim)
 			}
 		}
+	}
+}
+
+// stripDirectorTags removes the `_managedBy` tag from every command object in a
+// settings file — and, with dropMatchers, the empty `"matcher": ""` keys too —
+// reproducing what a Claude Code rewrite that drops unknown/empty fields leaves
+// behind. The commands themselves are untouched: the entries still fire, they are
+// just no longer self-identifying.
+func stripDirectorTags(t *testing.T, path string, dropMatchers bool) {
+	t.Helper()
+	root := loadTree(t, path)
+	hooks, _ := root["hooks"].(map[string]any)
+	for _, groups := range hooks {
+		gs, _ := groups.([]any)
+		for _, g := range gs {
+			gm, _ := g.(map[string]any)
+			if gm == nil {
+				continue
+			}
+			if dropMatchers && gm["matcher"] == "" {
+				delete(gm, "matcher")
+			}
+			cmds, _ := gm["hooks"].([]any)
+			for _, c := range cmds {
+				if cm, _ := c.(map[string]any); cm != nil {
+					delete(cm, managedByKey)
+				}
+			}
+		}
+	}
+	writeTree(t, path, root)
+}
+
+// duplicateDirectorCommands appends a SECOND copy of every Director command object
+// already in the file, reproducing the damage the tag-stripping incident actually
+// left on real settings files: with the tag gone, a pre-fix install could not
+// recognize its own entries and appended a fresh copy beside each one, so the same
+// shim sits twice in one matcher group and every hook fires twice per session.
+// tagged says whether the appended copy carries the tag (a pre-fix install wrote
+// tagged copies; a later CC rewrite would leave both copies bare).
+func duplicateDirectorCommands(t *testing.T, path, hooksDir string, tagged bool) {
+	t.Helper()
+	root := loadTree(t, path)
+	hooks, _ := root["hooks"].(map[string]any)
+	for _, groups := range hooks {
+		gs, _ := groups.([]any)
+		for _, g := range gs {
+			gm, _ := g.(map[string]any)
+			if gm == nil {
+				continue
+			}
+			cmds, _ := gm["hooks"].([]any)
+			// range holds the pre-append slice, so the copies are not re-copied.
+			for _, c := range cmds {
+				cm, _ := c.(map[string]any)
+				if cm == nil {
+					continue
+				}
+				s, _ := cm["command"].(string)
+				if !strings.HasPrefix(s, hooksDir) {
+					continue
+				}
+				dup := map[string]any{"type": "command", "command": s}
+				if tagged {
+					dup[managedByKey] = managedByValue
+				}
+				cmds = append(cmds, dup)
+			}
+			gm["hooks"] = cmds
+		}
+	}
+	writeTree(t, path, root)
+}
+
+// appendStopCommands appends raw command objects to the first group under
+// hooks.Stop — Director's single-group, single-entry event, so a test can build an
+// exact duplicate shape without disturbing the rest of the tree.
+func appendStopCommands(t *testing.T, path string, objs ...map[string]any) {
+	t.Helper()
+	root := loadTree(t, path)
+	hooks, _ := root["hooks"].(map[string]any)
+	groups, _ := hooks["Stop"].([]any)
+	if len(groups) == 0 {
+		t.Fatalf("fixture carries no hooks.Stop group to append to")
+	}
+	gm, _ := groups[0].(map[string]any)
+	cmds, _ := gm["hooks"].([]any)
+	for _, o := range objs {
+		cmds = append(cmds, o)
+	}
+	gm["hooks"] = cmds
+	writeTree(t, path, root)
+}
+
+// TestInstallAdoptsUntaggedEntries is the tag-loss gate. Claude Code has been
+// observed rewriting settings.json without unknown fields, which strips
+// `"_managedBy":"director"` from entries Director still owns. Keyed on the tag
+// alone, a re-install would append a SECOND copy of every hook; ownership by shim
+// path makes it adopt and re-tag them instead, so the file comes back to the
+// canonical state and a further re-install is byte-stable.
+func TestInstallAdoptsUntaggedEntries(t *testing.T) {
+	path, _ := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	before := map[string]int{}
+	for _, event := range []string{"SessionStart", "PostToolUse", "Stop", "SessionEnd"} {
+		before[event] = len(commands(t, loadTree(t, path), event))
+	}
+	stripDirectorTags(t, path, true) // tags AND the empty matcher keys
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	for _, event := range []string{"SessionStart", "PostToolUse", "Stop", "SessionEnd"} {
+		if got := len(commands(t, root, event)); got != before[event] {
+			t.Errorf("re-install over untagged entries duplicated hooks.%s: %d commands, want %d (%v)",
+				event, got, before[event], commands(t, root, event))
+		}
+	}
+	// Every adopted entry carries the tag again.
+	if got := managedCount(t, root, "SessionStart"); got != 2 {
+		t.Errorf("re-tagged SessionStart entries = %d, want 2", got)
+	}
+	for _, event := range []string{"PostToolUse", "Stop", "SessionEnd"} {
+		if got := managedCount(t, root, event); got != 1 {
+			t.Errorf("re-tagged %s entries = %d, want 1", event, got)
+		}
+	}
+	// GSD's untagged hook survives and is NOT adopted — adoption keys on our shim
+	// paths, and 3 managed SessionStart entries would mean we swallowed it.
+	if !contains(commands(t, root, "SessionStart"), "node /gsd/gsd-check-update.js") {
+		t.Errorf("GSD's hook was lost: %v", commands(t, root, "SessionStart"))
+	}
+	// A further re-install changes nothing at all.
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	third, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(second) != string(third) {
+		t.Errorf("re-install after adoption was not byte-stable:\n--- first ---\n%s\n--- second ---\n%s", second, third)
+	}
+}
+
+// managedEvents is the per-event count of Director commands a healthy CC install
+// carries: SessionStart twice (normal + compact matcher groups), everything else
+// once.
+var managedEvents = map[string]int{"SessionStart": 2, "PostToolUse": 1, "Stop": 1, "SessionEnd": 1}
+
+// TestInstallCollapsesDuplicateEntries is the damage-already-done gate. Adoption
+// stops NEW duplicates, but real settings files already carry the ones a pre-fix
+// install appended after Claude Code stripped the tags: an untagged copy and a
+// tagged copy of the same shim in one matcher group, firing every hook twice.
+// Install must collapse them to one, making it the single healing verb for the
+// whole incident — no uninstall/reinstall ceremony.
+func TestInstallCollapsesDuplicateEntries(t *testing.T) {
+	path, hooksDir := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	stripDirectorTags(t, path, true)                   // CC's rewrite drops the tags
+	duplicateDirectorCommands(t, path, hooksDir, true) // a pre-fix install appends tagged copies
+	// The fixture must really be broken, or the collapse proves nothing.
+	if got := directorCommandCount(t, loadTree(t, path), "Stop", hooksDir); got != 2 {
+		t.Fatalf("fixture setup: hooks.Stop carries %d Director commands, want the 2 the incident leaves", got)
+	}
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	for event, want := range managedEvents {
+		if got := directorCommandCount(t, root, event, hooksDir); got != want {
+			t.Errorf("hooks.%s carries %d Director commands after install, want %d (%v)",
+				event, got, want, commands(t, root, event))
+		}
+		if got := managedCount(t, root, event); got != want {
+			t.Errorf("hooks.%s survivors tagged = %d, want %d", event, got, want)
+		}
+	}
+	// The collapse keys on our shim paths, so GSD's hook is untouched.
+	if !contains(commands(t, root, "SessionStart"), "node /gsd/gsd-check-update.js") {
+		t.Errorf("GSD's hook was lost: %v", commands(t, root, "SessionStart"))
+	}
+
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("install after the collapse was not byte-stable:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// TestInstallCollapsesUntaggedDuplicates is the same heal on the shape a SECOND
+// Claude Code rewrite leaves: both copies bare, so neither is self-identifying and
+// only the shim path proves either is ours. One tagged survivor.
+func TestInstallCollapsesUntaggedDuplicates(t *testing.T) {
+	path, hooksDir := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	stripDirectorTags(t, path, true)
+	duplicateDirectorCommands(t, path, hooksDir, false)
+	if got := managedCount(t, loadTree(t, path), "Stop"); got != 0 {
+		t.Fatalf("fixture setup: hooks.Stop has %d tagged commands, want 0 (both copies bare)", got)
+	}
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	for event, want := range managedEvents {
+		if got := directorCommandCount(t, root, event, hooksDir); got != want {
+			t.Errorf("hooks.%s carries %d Director commands after install, want %d (%v)",
+				event, got, want, commands(t, root, event))
+		}
+		if got := managedCount(t, root, event); got != want {
+			t.Errorf("hooks.%s survivors tagged = %d, want %d", event, got, want)
+		}
+	}
+	if !contains(commands(t, root, "SessionStart"), "node /gsd/gsd-check-update.js") {
+		t.Errorf("GSD's hook was lost: %v", commands(t, root, "SessionStart"))
+	}
+}
+
+// TestInstallPreservesDuplicateWithForeignField is the limit of the heal. A copy of
+// our command carrying a field we never write (a hand-added "timeout") is somebody's
+// deliberate edit, not a duplicate we can prove redundant — collapsing it would
+// destroy an intent we cannot read. It survives untouched and unadopted beside the
+// one canonical copy, and install neither grows nor shrinks the group on re-runs.
+func TestInstallPreservesDuplicateWithForeignField(t *testing.T) {
+	path, hooksDir := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	stop := filepath.Join(hooksDir, "stop.sh")
+	appendStopCommands(t, path,
+		map[string]any{"type": "command", "command": stop},                 // collapsible: goes away
+		map[string]any{"type": "command", "command": stop, "timeout": 5.0}, // foreign field: stays
+	)
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	if got := directorCommandCount(t, root, "Stop", hooksDir); got != 2 {
+		t.Fatalf("hooks.Stop carries %d Director commands, want 2 (canonical + the foreign-fielded copy)", got)
+	}
+	if got := managedCount(t, root, "Stop"); got != 1 {
+		t.Errorf("hooks.Stop tagged commands = %d, want 1 (the copy we own; the edited one is not adopted)", got)
+	}
+	kept := stopCommandWithTimeout(t, root)
+	if kept == nil {
+		t.Fatalf("the copy carrying \"timeout\" was collapsed away: %v", root["hooks"])
+	}
+	if got := kept["timeout"]; got != 5.0 {
+		t.Errorf("the preserved copy's timeout = %v, want 5 (untouched)", got)
+	}
+	if _, tagged := kept[managedByKey]; tagged {
+		t.Errorf("the preserved copy was tagged; install must leave an edit it cannot read alone")
+	}
+
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("install over the foreign-fielded copy was not byte-stable:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// stopCommandWithTimeout returns the hooks.Stop command object carrying a "timeout"
+// field, or nil.
+func stopCommandWithTimeout(t *testing.T, root map[string]any) map[string]any {
+	t.Helper()
+	hooks, _ := root["hooks"].(map[string]any)
+	groups, _ := hooks["Stop"].([]any)
+	for _, g := range groups {
+		gm, _ := g.(map[string]any)
+		cmds, _ := gm["hooks"].([]any)
+		for _, c := range cmds {
+			cm, _ := c.(map[string]any)
+			if cm == nil {
+				continue
+			}
+			if _, ok := cm["timeout"]; ok {
+				return cm
+			}
+		}
+	}
+	return nil
+}
+
+// hookGroups returns the decoded group array under hooks[event].
+func hookGroups(t *testing.T, root map[string]any, event string) []any {
+	t.Helper()
+	hooks, _ := root["hooks"].(map[string]any)
+	groups, _ := hooks[event].([]any)
+	return groups
+}
+
+// groupCommands returns the command strings in hooks[event][i]. The per-group form
+// is what proves an entry was adopted WHERE IT SITS rather than re-added elsewhere —
+// a distinction the whole-event commands() helper cannot see.
+func groupCommands(t *testing.T, root map[string]any, event string, i int) []string {
+	t.Helper()
+	groups := hookGroups(t, root, event)
+	if i >= len(groups) {
+		t.Fatalf("hooks.%s has %d groups, wanted index %d", event, len(groups), i)
+	}
+	gm, _ := groups[i].(map[string]any)
+	cmds, _ := gm["hooks"].([]any)
+	out := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		cm, _ := c.(map[string]any)
+		if s, ok := cm["command"].(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// assertInstallByteStable runs one further Install and fails if it changed a byte —
+// the property that makes "install adds nothing" observable rather than asserted.
+func assertInstallByteStable(t *testing.T, path string) {
+	t.Helper()
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("re-install was not byte-stable:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// TestInstallAdoptsEntryInLaterMatcherGroup is the split-catch-all gate. The Claude
+// Code rewrite that drops `_managedBy` has been observed dropping `matcher` keys
+// too, and a group without one reads as matcher "" — so one logical catch-all can
+// arrive as TWO groups with Director's entry in the second. Keyed on the first
+// group alone, install appends a fresh copy there and the hook fires twice again;
+// it must find the entry where it is, re-tag it in place, and add nothing.
+func TestInstallAdoptsEntryInLaterMatcherGroup(t *testing.T) {
+	path, hooksDir := writeFixture(t, "")
+	stop := filepath.Join(hooksDir, "stop.sh")
+	writeTree(t, path, map[string]any{"hooks": map[string]any{"Stop": []any{
+		map[string]any{"matcher": "", "hooks": []any{
+			map[string]any{"type": "command", "command": "node /gsd/gsd-check-update.js"},
+		}},
+		// The rewrite took this group's matcher key with the tags: it reads as "" too.
+		map[string]any{"hooks": []any{
+			map[string]any{"type": "command", "command": stop},
+		}},
+	}}})
+
+	// The presence probe must agree with the merge BEFORE it runs, or doctor would
+	// report a wired event as missing and prescribe the install that duplicates it.
+	if contains(MissingManagedEvents(path, hooksDir), "Stop") {
+		t.Error("MissingManagedEvents reports Stop missing; its entry is in the second group")
+	}
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	if got := directorCommandCount(t, root, "Stop", hooksDir); got != 1 {
+		t.Fatalf("hooks.Stop carries %d Director commands, want 1: %v", got, commands(t, root, "Stop"))
+	}
+	if got := managedCount(t, root, "Stop"); got != 1 {
+		t.Errorf("hooks.Stop tagged commands = %d, want 1 (the entry re-tagged in place)", got)
+	}
+	// In place: the first group is untouched, the second still holds our entry.
+	if got := groupCommands(t, root, "Stop", 0); len(got) != 1 || got[0] != "node /gsd/gsd-check-update.js" {
+		t.Errorf("hooks.Stop[0] = %v, want only the foreign hook", got)
+	}
+	if got := groupCommands(t, root, "Stop", 1); len(got) != 1 || got[0] != stop {
+		t.Errorf("hooks.Stop[1] = %v, want [%s]", got, stop)
+	}
+	assertInstallByteStable(t, path)
+}
+
+// TestInstallCollapsesAcrossMatcherGroups: the heal has to span the split too. A
+// tagged copy in the first catch-all group and a bare copy in a second one is one
+// hook firing twice; collapsing only within a group leaves both. Exactly one
+// survivor overall — in the group it was found in first — and the group the
+// collapse empties is pruned rather than left hollow.
+func TestInstallCollapsesAcrossMatcherGroups(t *testing.T) {
+	path, hooksDir := writeFixture(t, "")
+	stop := filepath.Join(hooksDir, "stop.sh")
+	writeTree(t, path, map[string]any{"hooks": map[string]any{"Stop": []any{
+		map[string]any{"matcher": "", "hooks": []any{
+			map[string]any{"type": "command", "command": stop, managedByKey: managedByValue},
+		}},
+		map[string]any{"hooks": []any{
+			map[string]any{"type": "command", "command": stop},
+		}},
+	}}})
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	if got := directorCommandCount(t, root, "Stop", hooksDir); got != 1 {
+		t.Fatalf("hooks.Stop carries %d Director commands, want 1: %v", got, commands(t, root, "Stop"))
+	}
+	if got := managedCount(t, root, "Stop"); got != 1 {
+		t.Errorf("hooks.Stop tagged commands = %d, want 1", got)
+	}
+	if got := len(hookGroups(t, root, "Stop")); got != 1 {
+		t.Errorf("hooks.Stop has %d groups, want 1 (the emptied second group is pruned)", got)
+	}
+	if got := groupCommands(t, root, "Stop", 0); len(got) != 1 || got[0] != stop {
+		t.Errorf("hooks.Stop[0] = %v, want the one survivor [%s]", got, stop)
+	}
+	assertInstallByteStable(t, path)
+}
+
+// TestInstallSkipsWrongTypedMatcherGroup: a group whose "matcher" is PRESENT but
+// not a string is foreign data install cannot compare. Read through a coercion to
+// "" it would pass for our catch-all group and be mutated — a stranger's group
+// picked up on a type confusion. It must match nothing: our entry lands in its own
+// group and the stranger round-trips verbatim.
+func TestInstallSkipsWrongTypedMatcherGroup(t *testing.T) {
+	path, hooksDir := writeFixture(t, "")
+	foreign := map[string]any{
+		"matcher": 5,
+		"hooks":   []any{map[string]any{"type": "command", "command": "node /foreign.js"}},
+	}
+	writeTree(t, path, map[string]any{"hooks": map[string]any{"Stop": []any{foreign}}})
+	want, err := json.Marshal(foreign)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	groups := hookGroups(t, root, "Stop")
+	if len(groups) != 2 {
+		t.Fatalf("hooks.Stop has %d groups, want 2 (the stranger plus our own): %v", len(groups), groups)
+	}
+	got, err := json.Marshal(groups[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("the wrong-typed group was modified:\n got: %s\nwant: %s", got, want)
+	}
+	stop := filepath.Join(hooksDir, "stop.sh")
+	if cmds := groupCommands(t, root, "Stop", 1); len(cmds) != 1 || cmds[0] != stop {
+		t.Errorf("hooks.Stop[1] = %v, want our own group [%s]", cmds, stop)
+	}
+	if got := managedCount(t, root, "Stop"); got != 1 {
+		t.Errorf("hooks.Stop tagged commands = %d, want 1", got)
+	}
+	assertInstallByteStable(t, path)
+}
+
+// TestUninstallRemovesUntaggedEntries: the removal half of the same failure. With
+// tags stripped, a tag-only uninstall removes NOTHING and leaves live hooks
+// pointing at shims it deletes; ownership by shim path must reclaim them, while
+// the foreign GSD hook stays exactly where it is.
+func TestUninstallRemovesUntaggedEntries(t *testing.T) {
+	path, hooksDir := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	stripDirectorTags(t, path, true)
+
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	for _, event := range []string{"SessionStart", "PostToolUse", "Stop", "SessionEnd"} {
+		for _, cmd := range commands(t, root, event) {
+			if strings.HasPrefix(cmd, hooksDir) {
+				t.Errorf("hooks.%s still carries a Director command after uninstall: %s", event, cmd)
+			}
+		}
+	}
+	if !contains(commands(t, root, "SessionStart"), "node /gsd/gsd-check-update.js") {
+		t.Errorf("uninstall removed GSD's hook: %v", commands(t, root, "SessionStart"))
+	}
+	if _, ok := root["permissions"]; !ok {
+		t.Errorf("permissions setting lost")
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	for _, event := range []string{"PostToolUse", "Stop", "SessionEnd"} {
+		if _, ok := hooks[event]; ok {
+			t.Errorf("empty %s event was not pruned after uninstall", event)
+		}
+	}
+}
+
+// TestPresenceChecksSeeUntaggedEntries: the probes must agree with the merge. A
+// false "no CC install" here is the dangerous corollary of tag-stripping — it is
+// the signal UninstallCodex consults before reclaiming the SHARED shims, so a
+// Codex uninstall would have pulled them out from under live Claude Code hooks.
+func TestPresenceChecksSeeUntaggedEntries(t *testing.T) {
+	path, hooksDir := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	stripDirectorTags(t, path, true)
+
+	if !ManagedEntriesPresent(path, hooksDir) {
+		t.Error("untagged Director entries must still read as an install")
+	}
+	if got := MissingManagedEvents(path, hooksDir); len(got) != 0 {
+		t.Errorf("MissingManagedEvents = %v, want none (install would add nothing)", got)
+	}
+	// The tag-only reading (an unresolvable hooks dir) is the documented degrade.
+	if ManagedEntriesPresent(path, "") {
+		t.Error("with no hooks dir to prove ownership, untagged entries cannot read as present")
+	}
+	// A different hooks dir is somebody else's install, not ours.
+	if ManagedEntriesPresent(path, filepath.Join(hooksDir, "moved")) {
+		t.Error("entries under a different hooks dir must not read as our install")
+	}
+}
+
+// TestUntaggedManagedEntries is what doctor reports on: exactly the events whose
+// entries lost the tag, deduplicated, and nothing on a healthy or foreign file.
+func TestUntaggedManagedEntries(t *testing.T) {
+	path, hooksDir := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := UntaggedManagedEntries(path, hooksDir); len(got) != 0 {
+		t.Errorf("fresh install: got %v, want none", got)
+	}
+
+	// Strip the tag from the Stop entry only.
+	root := loadTree(t, path)
+	hooks, _ := root["hooks"].(map[string]any)
+	groups, _ := hooks["Stop"].([]any)
+	for _, g := range groups {
+		gm, _ := g.(map[string]any)
+		cmds, _ := gm["hooks"].([]any)
+		for _, c := range cmds {
+			if cm, _ := c.(map[string]any); cm != nil {
+				delete(cm, managedByKey)
+			}
+		}
+	}
+	writeTree(t, path, root)
+
+	got := UntaggedManagedEntries(path, hooksDir)
+	if len(got) != 1 || got[0] != "Stop" {
+		t.Fatalf("UntaggedManagedEntries = %v, want [Stop]", got)
+	}
+	// Both SessionStart groups losing their tag reports the event once, not twice.
+	stripDirectorTags(t, path, false)
+	got = UntaggedManagedEntries(path, hooksDir)
+	want := []string{"SessionStart", "PostToolUse", "Stop", "SessionEnd"}
+	if len(got) != len(want) {
+		t.Fatalf("all-stripped: got %v, want %v (deduplicated)", got, want)
+	}
+	for i, e := range want {
+		if got[i] != e {
+			t.Errorf("all-stripped: event %d = %q, want %q (directorEntries order)", i, got[i], e)
+		}
+	}
+	// And a re-install clears the report — the remedy doctor prints.
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := UntaggedManagedEntries(path, hooksDir); len(got) != 0 {
+		t.Errorf("after re-install: got %v, want none", got)
+	}
+}
+
+// allowWrite returns the decoded sandbox.filesystem.allowWrite array.
+func allowWrite(t *testing.T, root map[string]any) []string {
+	t.Helper()
+	sandbox, _ := root["sandbox"].(map[string]any)
+	filesystem, _ := sandbox["filesystem"].(map[string]any)
+	entries, _ := filesystem["allowWrite"].([]any)
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		s, _ := e.(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestInstallGrantsHubSandboxWrite: a sandboxed Claude Code session may write only
+// its cwd and session tmp, so a fresh user's first `director emit` into ~/.director
+// would stop on a permission prompt. Install grants the hub up front, in the
+// home-relative form CC documents, and adding it twice is not a thing.
+func TestInstallGrantsHubSandboxWrite(t *testing.T) {
+	path, _ := writeFixture(t, "")
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := allowWrite(t, loadTree(t, path)); len(got) != 1 || got[0] != "~/.director" {
+		t.Fatalf("allowWrite = %v, want [~/.director]", got)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("re-install changed the sandbox grant:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+	if !SettingsAllowsHubWrite(path, HubAllowWriteValue()) {
+		t.Error("SettingsAllowsHubWrite must see the grant install just wrote")
+	}
+}
+
+// TestInstallPreservesUserAllowWrite: the grant is additive. A user's own
+// allowWrite entries (and any other sandbox setting) survive install, and
+// uninstall takes back ONLY Director's own entry, pruning nothing that still
+// holds data.
+func TestInstallPreservesUserAllowWrite(t *testing.T) {
+	const fixture = `{
+  "sandbox": {
+    "enabled": true,
+    "filesystem": {"allowWrite": ["~/scratch", "/tmp/mine"]}
+  }
+}
+`
+	path, _ := writeFixture(t, fixture)
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	got := allowWrite(t, loadTree(t, path))
+	want := []string{"~/scratch", "/tmp/mine", "~/.director"}
+	if len(got) != len(want) {
+		t.Fatalf("allowWrite = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("allowWrite[%d] = %q, want %q (user entries keep their order)", i, got[i], want[i])
+		}
+	}
+
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	if got := allowWrite(t, root); len(got) != 2 || got[0] != "~/scratch" || got[1] != "/tmp/mine" {
+		t.Errorf("uninstall must remove only Director's entry, got %v", got)
+	}
+	sandbox, _ := root["sandbox"].(map[string]any)
+	if sandbox["enabled"] != true {
+		t.Errorf("uninstall dropped an unrelated sandbox setting: %v", sandbox)
+	}
+}
+
+// TestUninstallPrunesEmptySandbox: with nothing else in it, the whole scaffolding
+// install created (allowWrite → filesystem → sandbox) goes away, so an uninstall
+// leaves no trace — and a settings file that never had a sandbox block does not
+// grow an empty one.
+func TestUninstallPrunesEmptySandbox(t *testing.T) {
+	path, _ := writeFixture(t, gsdFixture)
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+	root := loadTree(t, path)
+	if _, ok := root["sandbox"]; ok {
+		t.Errorf("empty sandbox block was not pruned: %v", root["sandbox"])
+	}
+
+	// A file with no Director install at all: uninstall must not invent the block.
+	plain, _ := writeFixture(t, gsdFixture)
+	if err := Uninstall(plain); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadTree(t, plain)["sandbox"]; ok {
+		t.Error("uninstall created a sandbox block on a file that had none")
+	}
+}
+
+// TestInstallRefusesWrongTypedSandbox is H1 for the new key, at every level: a
+// present-but-wrong-typed sandbox / filesystem / allowWrite is foreign data, so
+// install refuses and — because the hooks merge and the grant share ONE
+// read-modify-write — the file is left byte-for-byte unchanged.
+func TestInstallRefusesWrongTypedSandbox(t *testing.T) {
+	cases := map[string]string{
+		"sandbox":    `{"sandbox":"off"}` + "\n",
+		"filesystem": `{"sandbox":{"filesystem":"all"}}` + "\n",
+		"allowWrite": `{"sandbox":{"filesystem":{"allowWrite":"~/everything"}}}` + "\n",
+	}
+	for name, fixture := range cases {
+		t.Run(name, func(t *testing.T) {
+			path, _ := writeFixture(t, fixture)
+			err := Install(path)
+			if err == nil {
+				t.Fatal("Install on a wrong-typed sandbox key = nil, want a refusal error")
+			}
+			if !strings.Contains(err.Error(), "refusing to modify") {
+				t.Errorf("error does not read as a refusal: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != fixture {
+				t.Errorf("Install mutated a file it refused:\n got: %q\nwant: %q", got, fixture)
+			}
+		})
+	}
+}
+
+// TestUninstallProceedsPastWrongTypedSandbox is the asymmetry the install side
+// earns. TestInstallRefusesWrongTypedSandbox is the proof that a wrong-typed
+// sandbox level holds nothing of Director's: install refuses to write through one.
+// So on the way out it is not foreign data to protect from a delete — there is
+// simply nothing to take back, and the hook removal must proceed. Refusing here
+// (which it once did) strands a user whose settings.json carries an unrelated
+// `"sandbox": "off"` with Director hooks they cannot uninstall at all.
+func TestUninstallProceedsPastWrongTypedSandbox(t *testing.T) {
+	cases := map[string]any{
+		"sandbox":    "off",
+		"filesystem": map[string]any{"filesystem": "all"},
+		"allowWrite": map[string]any{"filesystem": map[string]any{"allowWrite": "~/everything"}},
+	}
+	for name, sandbox := range cases {
+		t.Run(name, func(t *testing.T) {
+			path, hooksDir := writeFixture(t, gsdFixture)
+			if err := Install(path); err != nil {
+				t.Fatal(err)
+			}
+			// Replace the grant install just wrote with the shape uninstall cannot read.
+			root := loadTree(t, path)
+			root["sandbox"] = sandbox
+			writeTree(t, path, root)
+			want, err := json.Marshal(sandbox)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := Uninstall(path); err != nil {
+				t.Fatalf("Uninstall over a wrong-typed sandbox = %v, want nil (the hooks must still go)", err)
+			}
+			root = loadTree(t, path)
+			for _, event := range []string{"SessionStart", "PostToolUse", "Stop", "SessionEnd"} {
+				if got := directorCommandCount(t, root, event, hooksDir); got != 0 {
+					t.Errorf("hooks.%s still carries %d Director commands: %v", event, got, commands(t, root, event))
+				}
+			}
+			got, err := json.Marshal(root["sandbox"])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != string(want) {
+				t.Errorf("sandbox = %s, want %s (a value uninstall cannot read is left verbatim)", got, want)
+			}
+			if !contains(commands(t, root, "SessionStart"), "node /gsd/gsd-check-update.js") {
+				t.Errorf("uninstall removed GSD's hook: %v", commands(t, root, "SessionStart"))
+			}
+		})
+	}
+}
+
+// TestUninstallLeavesPreExistingEmptySandbox: the pruning is for scaffolding
+// DIRECTOR created. A user whose settings.json already carries an empty
+// sandbox.filesystem.allowWrite — and no grant of ours — has an uninstall with
+// nothing to take back there, so the file must come out byte-identical rather than
+// three levels lighter. Pruning on "ended up empty" instead of "we emptied it"
+// deletes a structure Director never touched.
+func TestUninstallLeavesPreExistingEmptySandbox(t *testing.T) {
+	// Spelled the way writeSettings renders it, so the byte comparison is an
+	// assertion about not rewriting rather than about formatting.
+	const fixture = `{
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": []
+    }
+  }
+}
+`
+	path, _ := writeFixture(t, fixture)
+
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != fixture {
+		t.Errorf("uninstall pruned scaffolding it never created:\n got: %q\nwant: %q", got, fixture)
+	}
+}
+
+// TestHubOverrideIsGrantedVerbatim: DIRECTOR_HUB is already an absolute,
+// deliberate path, so it is granted (and reclaimed) exactly as written — never
+// rewritten into a ~-form Claude Code would resolve somewhere else.
+func TestHubOverrideIsGrantedVerbatim(t *testing.T) {
+	path, _ := writeFixture(t, "")
+	hub := filepath.Join(t.TempDir(), "custom-hub")
+	t.Setenv(hubRootEnv, hub)
+
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := allowWrite(t, loadTree(t, path)); len(got) != 1 || got[0] != hub {
+		t.Fatalf("allowWrite = %v, want [%s]", got, hub)
+	}
+	if !SettingsAllowsHubWrite(path, hub) {
+		t.Error("SettingsAllowsHubWrite must honor the override")
+	}
+	if SettingsAllowsHubWrite(path, "~/.director") {
+		t.Error("the default form must NOT read as granted under an override")
+	}
+	if got, err := DefaultHubRoot(); err != nil || got != hub {
+		t.Errorf("DefaultHubRoot() = (%q, %v), want (%q, nil)", got, err, hub)
+	}
+
+	if err := Uninstall(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadTree(t, path)["sandbox"]; ok {
+		t.Error("uninstall left the overridden hub grant behind")
+	}
+}
+
+// TestCodexHooksNeverGainSandboxKey: `sandbox` is a Claude Code setting and would
+// be foreign data in Codex's hooks.json — the reason the grant lives in the CC-only
+// entry point instead of the shared merge core.
+func TestCodexHooksNeverGainSandboxKey(t *testing.T) {
+	path, _ := writeFixture(t, "")
+	codexHooksPath := os.Getenv(codexHooksPathEnv)
+
+	if err := InstallCodex(codexHooksPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadTree(t, codexHooksPath)["sandbox"]; ok {
+		t.Error("InstallCodex wrote a sandbox key into hooks.json")
+	}
+	// And the CC install beside it does not reach across into the Codex file.
+	if err := Install(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadTree(t, codexHooksPath)["sandbox"]; ok {
+		t.Error("a CC install added a sandbox key to the Codex hooks file")
+	}
+	if _, ok := loadTree(t, path)["sandbox"]; !ok {
+		t.Error("the CC settings file is missing its sandbox grant")
 	}
 }
 


### PR DESCRIPTION
Fixes the install-idempotency incident (log `01KYXGYT50`) and the fresh-install sandbox freeze (log `01KYXD8HKT`) in one pass over the installer, the project's stop-and-escalate surface.

## Tag-stripping resilience

Claude Code has been observed rewriting `~/.claude/settings.json` without unknown fields, dropping our `"_managedBy":"director"` tags (and some `matcher` keys). Keyed on the tag alone, every layer then misread the file: install appended duplicates (every hook firing twice per session), uninstall removed nothing, doctor reported healthy, and a Codex uninstall would have reclaimed the shared shims out from under live CC hooks.

Ownership now has a second proof: a command object at one of the shim paths under Director's own hooks dir is ours by construction. `director install` becomes the single healing verb for the whole incident state:

- adopts untagged entries at our exact path, re-tagging them in place;
- collapses the redundant copies a pre-fix install appended — only copies whose keys are a subset of `{type, command, _managedBy}`; a copy carrying a foreign field (someone's deliberate edit) survives untouched;
- scans every same-matcher group, so an entry stranded in a duplicate group is found, not duplicated again.

Uninstall and every presence check learned the same path ownership, and `doctor` warns on untagged-but-ours entries with a re-install remedy.

## Sandbox write grant

Sandboxed CC sessions may write only their cwd and session tmp by default, so a fresh user's first `director emit` into `~/.director` froze on a permission prompt (this stalled a demo recording for 15 minutes). `install` now grants the hub in `sandbox.filesystem.allowWrite` (Claude Code settings only — the shared merge core serving Codex's `hooks.json` never sees a sandbox key), `uninstall` takes back exactly that grant and prunes only levels its own removal emptied, and `doctor` gained a grant check.

## Hardening that fell out of review

- A present-but-non-string `matcher` never matches, so a wrong-typed foreign group is never mutated (pre-existing coercion, fixed here since this branch hardens exactly that surface).
- A wrong-typed `sandbox` level no longer blocks uninstall: install would have refused to write there, so it provably holds nothing of Director's.
- Pre-existing empty sandbox scaffolding survives uninstall byte-identically.

## Review trail

Built and fix-passed by Opus builders against a settled design; in-session criteria review; two independent external passes (Codex, Kimi K3 sandboxed) produced five accepted findings, all fixed and each mutation-checked (fix disabled → its test fails → restored). Rejected findings and reasons are in the session log. Full gate (`build · vet · gofmt · test -race`) green throughout, plus an end-to-end binary test reproducing the live incident file shape.

After merge: running `director install` on an affected machine re-tags and dedupes its settings.json in place and adds the sandbox grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
