### PR TITLE
cli: failed durable writes cannot be silenced by stderr redirection

### DIFF
--- a/cmd/director/emit.go
+++ b/cmd/director/emit.go
@@ -29,19 +29,19 @@ func runEmit(args []string) int {
 	}
 	body := strings.TrimSpace(strings.Join(fs.Args(), " "))
 	if typ == "" || body == "" {
-		fmt.Fprintln(os.Stderr, "emit: --type and a body are required")
+		failf("emit: --type and a body are required\n")
 		return 2
 	}
 
 	refList, err := canonicalRefs(refs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "emit: %v\n", err)
+		failf("emit: %v\n", err)
 		return 2
 	}
 
 	hub, ws, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "emit: %v\n", err)
+		failf("emit: %v\n", err)
 		return 1
 	}
 	store := event.NewStore(hub, ws.RepoKey)
@@ -54,7 +54,7 @@ func runEmit(args []string) int {
 		Body:        body,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "emit: %v\n", err)
+		failf("emit: %v\n", err)
 		return 1
 	}
 	// stdout stays the bare ULID and nothing else: callers capture it, sometimes

--- a/cmd/director/fleetcmd.go
+++ b/cmd/director/fleetcmd.go
@@ -76,16 +76,16 @@ func runDone(args []string) int {
 		// cwd identity — it works from anywhere.
 		hub, err := hubRoot()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "done: %v\n", err)
+			failf("done: %v\n", err)
 			return 1
 		}
 		n, err := fleet.DoneWorkstream(hub, workstream, time.Now().UTC())
 		if err != nil {
 			if errors.Is(err, fleet.ErrRowNotFound) {
-				fmt.Fprintf(os.Stderr, "done: no live rows for workstream %q (already archived, a typo, or its rows are unreadable — see `director status`)\n", workstream)
+				failf("done: no live rows for workstream %q (already archived, a typo, or its rows are unreadable — see `director status`)\n", workstream)
 				return 2
 			}
-			fmt.Fprintf(os.Stderr, "done: %v\n", err)
+			failf("done: %v\n", err)
 			return 1
 		}
 		// A targeted done can archive several rows; say how many so the close-out
@@ -96,11 +96,11 @@ func runDone(args []string) int {
 
 	hub, ws, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "done: %v\n", err)
+		failf("done: %v\n", err)
 		return 1
 	}
 	if err := fleet.Done(hub, ws.ID, sessionUUID(), time.Now().UTC()); err != nil {
-		fmt.Fprintf(os.Stderr, "done: %v\n", err)
+		failf("done: %v\n", err)
 		return 1
 	}
 	return 0

--- a/cmd/director/promote.go
+++ b/cmd/director/promote.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/colinsurprenant/director/internal/event"
@@ -22,9 +21,9 @@ import (
 func runPromote(args []string) int {
 	usageErr := func(msg string) int {
 		if msg != "" {
-			fmt.Fprintf(os.Stderr, "promote: %s\n", msg)
+			failf("promote: %s\n", msg)
 		}
-		fmt.Fprintln(os.Stderr, "usage: director promote <ulid>... --to <doc>")
+		failf("usage: director promote <ulid>... --to <doc>\n")
 		return 2
 	}
 
@@ -35,13 +34,13 @@ func runPromote(args []string) int {
 
 	hub, ws, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "promote: %v\n", err)
+		failf("promote: %v\n", err)
 		return 1
 	}
 	store := event.NewStore(hub, ws.RepoKey)
 	marker, err := event.Promote(store, ws.ID, targets, doc)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "promote: %v\n", err)
+		failf("promote: %v\n", err)
 		// A rejected target or destination is the user's mistake (exit 2), not a
 		// system fault.
 		if errors.Is(err, event.ErrPromoteTargetNotFound) ||

--- a/cmd/director/resolve.go
+++ b/cmd/director/resolve.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/colinsurprenant/director/internal/event"
 )
@@ -19,20 +18,20 @@ func runResolve(args []string) int {
 		return 2
 	}
 	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "usage: director resolve <ulid>")
+		failf("usage: director resolve <ulid>\n")
 		return 2
 	}
 	target := fs.Arg(0)
 
 	hub, ws, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "resolve: %v\n", err)
+		failf("resolve: %v\n", err)
 		return 1
 	}
 	store := event.NewStore(hub, ws.RepoKey)
 	marker, err := event.Resolve(store, ws.ID, target)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "resolve: %v\n", err)
+		failf("resolve: %v\n", err)
 		// A rejected target is the user's mistake (exit 2), not a system fault.
 		if errors.Is(err, event.ErrTargetNotFound) || errors.Is(err, event.ErrAlreadyResolved) {
 			return 2

--- a/cmd/director/stderrguard.go
+++ b/cmd/director/stderrguard.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// stderrguard.go guards the model-driven durable-write verbs (emit, resolve,
+// promote, done) against silenced failures. Incident 2026-08-27: a model ran a malformed emit as
+// `director emit ... 2>/dev/null; <next command>` — the redirect swallowed the
+// rejection text and the `;` chain swallowed the exit code, so a refused write
+// against the system-of-record looked like a success in the session transcript.
+// Directive prose can't reliably prevent that class of slip; this mechanical
+// layer makes it unsilenceable instead: when a write verb FAILS and stderr is
+// pointed at the null device, the error is duplicated on stdout, which survives
+// both redirection idioms.
+//
+// Scope is deliberately failure-only. On success stdout carries the bare ULID
+// and nothing else — callers capture it through command substitution — so the
+// routing echo and the handoff warnings stay stderr-only even when stderr is
+// suppressed; losing advisory text is acceptable, losing a rejection is not.
+// adopt also writes durable state but stays outside the guard on purpose: it is
+// a setup-time verb driven by the /director:adopt ceremony, not chained on the
+// model hot path, and its success stdout is multi-line prose rather than a
+// captured bare value. done IS guarded — /director:complete has the model run
+// it directly, the incident idiom applies verbatim — while its hook-invoked
+// fleet siblings (register, heartbeat) stay out: hooks swallow their output by
+// design, so duplication buys nothing there.
+
+// failf reports a write-verb failure on stderr and, when stderr has been
+// redirected to the null device, on stdout as well. All emit/resolve/promote/
+// done failure paths route through it. (Flag-syntax errors printed by flag.Parse itself
+// bypass this; the guarded classes are the semantic rejections — bad type, bad
+// refs, unresolvable context, refused append.)
+func failf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format, args...)
+	if stderrSuppressed() {
+		// Ignore SIGPIPE first: Go treats a broken pipe on fd 1 as fatal, and a
+		// signal death here would replace the verb's 1/2 exit code. The process
+		// is on its failure path already, so the global ignore is inert beyond
+		// letting this write fail quietly with EPIPE.
+		signal.Ignore(syscall.SIGPIPE)
+		fmt.Fprintf(os.Stdout, format, args...)
+	}
+}

--- a/cmd/director/stderrguard_test.go
+++ b/cmd/director/stderrguard_test.go
@@ -1,0 +1,161 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/colinsurprenant/director/internal/id"
+)
+
+// captureStdoutNullStderr runs fn with os.Stdout captured and os.Stderr pointed
+// at the null device, and returns what stdout received. Counterpart to
+// captureStreams for the suppressed case — and like it, this swaps the os
+// package variables the fmt-level writers use, not the process's real fds, so
+// descriptor-level behavior (SIGPIPE on a broken real fd 1) is outside what
+// these tests can exercise.
+func captureStdoutNullStderr(t *testing.T, fn func()) (stdout string) {
+	t.Helper()
+	outR, outW := mustPipe(t)
+	null, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		outR.Close()
+		outW.Close()
+		t.Fatal(err)
+	}
+	origOut, origErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outW, null
+	outDone := drainPipe(outR)
+	// Deferred so the fds are restored, the writer closed, and the drain
+	// goroutine collected even when fn bails through t.Fatal or panics — same
+	// hygiene as captureStreams.
+	defer func() {
+		os.Stdout, os.Stderr = origOut, origErr
+		outW.Close()
+		null.Close()
+		stdout = <-outDone
+	}()
+	fn()
+	return
+}
+
+// TestStderrSuppressedDetection locks the fd probe both ways: a pipe is not
+// suppression, the null device is.
+func TestStderrSuppressedDetection(t *testing.T) {
+	origErr := os.Stderr
+	defer func() { os.Stderr = origErr }()
+
+	r, w := mustPipe(t)
+	defer r.Close()
+	os.Stderr = w
+	if stderrSuppressed() {
+		t.Error("stderr on a pipe reported as suppressed")
+	}
+	w.Close()
+
+	null, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer null.Close()
+	os.Stderr = null
+	if !stderrSuppressed() {
+		t.Error("stderr on the null device not reported as suppressed")
+	}
+
+	// A stderr that cannot be statted (`2>&-`) counts as suppressed: its error
+	// write already failed, so stdout is the only voice left.
+	closedR, closedW := mustPipe(t)
+	closedR.Close()
+	closedW.Close()
+	os.Stderr = closedW
+	if !stderrSuppressed() {
+		t.Error("unstattable (closed) stderr not reported as suppressed")
+	}
+}
+
+// TestSuppressedStderrFailureReachesStdout locks the incident guard: a write
+// verb rejected while stderr points at /dev/null must surface its error on
+// stdout, so no shell idiom can make a refused append look like a success.
+func TestSuppressedStderrFailureReachesStdout(t *testing.T) {
+	hub := t.TempDir()
+	t.Setenv("DIRECTOR_HUB", hub)
+	repo := filepath.Join(t.TempDir(), "proj")
+	gitInitRepo(t, repo)
+	t.Chdir(repo)
+
+	// The incident shape: an invalid --type, stderr silenced.
+	var code int
+	stdout := captureStdoutNullStderr(t, func() {
+		code = runEmit([]string{"--type", "core", "--area", "core", "body"})
+	})
+	if code == 0 {
+		t.Fatal("invalid --type accepted")
+	}
+	if !strings.Contains(stdout, "emit:") {
+		t.Errorf("suppressed-stderr emit failure left stdout silent, got %q", stdout)
+	}
+
+	// Same guard on resolve's failure path.
+	stdout = captureStdoutNullStderr(t, func() {
+		code = runResolve([]string{})
+	})
+	if code == 0 {
+		t.Fatal("argless resolve accepted")
+	}
+	if !strings.Contains(stdout, "resolve") {
+		t.Errorf("suppressed-stderr resolve failure left stdout silent, got %q", stdout)
+	}
+
+	// And on promote's — the third durable-write verb.
+	stdout = captureStdoutNullStderr(t, func() {
+		code = runPromote([]string{})
+	})
+	if code == 0 {
+		t.Fatal("argless promote accepted")
+	}
+	if !strings.Contains(stdout, "promote") {
+		t.Errorf("suppressed-stderr promote failure left stdout silent, got %q", stdout)
+	}
+
+	// And on done's — model-driven via /director:complete, where a typo'd
+	// --workstream is the incident shape one verb over.
+	stdout = captureStdoutNullStderr(t, func() {
+		code = runDone([]string{"--workstream", "no-such-workstream"})
+	})
+	if code == 0 {
+		t.Fatal("done for unknown workstream accepted")
+	}
+	if !strings.Contains(stdout, "done:") {
+		t.Errorf("suppressed-stderr done failure left stdout silent, got %q", stdout)
+	}
+}
+
+// TestSuppressedStderrSuccessKeepsBareULID locks the guard's boundary: on a
+// SUCCESSFUL emit, stdout stays the bare ULID even with stderr suppressed — the
+// routing echo and handoff warnings must not leak into command-substitution
+// captures.
+func TestSuppressedStderrSuccessKeepsBareULID(t *testing.T) {
+	hub := t.TempDir()
+	t.Setenv("DIRECTOR_HUB", hub)
+	repo := filepath.Join(t.TempDir(), "proj")
+	gitInitRepo(t, repo)
+	t.Chdir(repo)
+
+	var code int
+	stdout := captureStdoutNullStderr(t, func() {
+		code = runEmit([]string{"--type", "note", "--area", "x", "quiet success"})
+	})
+	if code != 0 {
+		t.Fatalf("emit exit = %d, want 0", code)
+	}
+	if strings.Count(stdout, "\n") != 1 || !strings.HasSuffix(stdout, "\n") {
+		t.Fatalf("stdout = %q, want exactly one ULID line", stdout)
+	}
+	if _, err := id.Parse(strings.TrimSuffix(stdout, "\n")); err != nil {
+		t.Fatalf("stdout %q is not a bare ULID: %v", stdout, err)
+	}
+}

--- a/cmd/director/stderrguard_unix.go
+++ b/cmd/director/stderrguard_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+// stderrSuppressed reports whether fd 2 currently points at the null device —
+// via the canonical os.DevNull node; a separately created node backed by the
+// null driver is out of scope. Asymmetric best-effort: a stderr that cannot
+// even be statted (`2>&-`) counts as suppressed, because the error write there
+// already failed and stdout is the only voice left; an unstattable os.DevNull
+// counts as not suppressed, because stderr statted fine and is presumed live.
+func stderrSuppressed() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return true
+	}
+	null, err := os.Stat(os.DevNull)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fi, null)
+}

--- a/cmd/director/stderrguard_windows.go
+++ b/cmd/director/stderrguard_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package main
+
+// stderrSuppressed is inert on Windows: os.SameFile cannot distinguish NUL from
+// a pipe there (Stat on FILE_TYPE_PIPE/CHAR handles yields a zero file id that
+// NUL may share), so a probe would either misfire on pipe-backed stderr —
+// breaking the bare-ULID stdout contract under captureStreams-style callers —
+// or never fire at all. Failures still reach stderr with a nonzero exit; only
+// the stdout duplication is forgone.
+func stderrSuppressed() bool {
+	return false
+}


### PR DESCRIPTION
## What

A refused durable write can no longer be silenced by shell redirection. The four model-driven durable-write verbs (`emit`, `resolve`, `promote`, `done`) now route every semantic-failure print through one choke point, `failf()`: the error always goes to stderr and, when fd 2 points at the null device (or cannot be statted at all — the `2>&-` shape), it is duplicated on stdout.

## Why

Live incident, 2026-08-27: a model ran a malformed emit as `director emit ... 2>/dev/null; <next command>`. The redirect swallowed the rejection text and the `;` chain swallowed the exit code, so a refused append to the append-only system-of-record looked like a success in the session transcript. Directive prose cannot reliably prevent that class of token-level slip; a mechanical layer makes it unsilenceable — stdout survives both redirection idioms.

## Contracts preserved

- On **success**, stdout stays exactly the bare captured ULID; the routing echo and handoff warnings remain stderr-only (nothing may leak into `$(...)` captures).
- Exit codes unchanged (2 user mistake, 1 fault). SIGPIPE is ignored just before the stdout duplication so a broken pipe on fd 1 cannot replace them with a signal death.
- Windows: the probe is unix-only (`os.SameFile` cannot distinguish NUL from a pipe there); the guard is inert, failures still land on stderr with a nonzero exit. `GOOS=windows` build and vet clean; fd-layout tests carry a `!windows` tag.

## Scope, documented in stderrguard.go

`adopt` stays out (setup-time verb, prose stdout). The hook-invoked fleet verbs (`register`, `heartbeat`) stay out (hooks swallow their output by design). `done` is IN — `/director:complete` has the model run it directly, so a typo'd `--workstream` with the incident idiom was the same hole one verb over.

## Review

Three lanes, all findings adjudicated:
- **ce:review**: Windows platform split (SameFile probe breaks windows CI), promote belongs in the guard, test-helper hygiene — all applied.
- **Codex adversarial**: SIGPIPE exit-code hazard, the `2>&-` semantic flip (unstattable stderr now counts as suppressed — the old conservative default re-opened the incident there), fd-leak reorder — applied; non-canonical null-device node documented out of scope.
- **Kimi K3 adversarial**: the `done` gap (verdict MERGEABLE); its attack log verified the guard on a real binary at the fd level — actual `2>/dev/null`, `2>&-`, broken-pipe-under-suppression exiting 1 rather than SIGPIPE, and `2>&1` non-duplication.

`go test ./... -race` green throughout; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FudztjDjwmkEc6sb7VHKv
