### PR TITLE
store: refuse duplicate event ids; fold ties break by file order

### DIFF
--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -176,7 +176,8 @@ func (s *Store) Tail(n int) ([]Event, error) {
 }
 
 // errStopScan is scan's early-exit sentinel: a callback returns it to end the
-// stream without surfacing an error to the caller.
+// stream early. scan propagates it like any callback error — the function that
+// installed the callback is responsible for swallowing it (see hasID).
 var errStopScan = errors.New("stop scan")
 
 // hasID reports whether an event with the given id already exists in the log.

--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -9,6 +9,7 @@ package event
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,6 +63,24 @@ func (s *Store) Path() string {
 func (s *Store) Append(ev Event) error {
 	if err := ev.Validate(); err != nil {
 		return fmt.Errorf("store: refusing to append invalid event: %w", err)
+	}
+
+	// A reused id would make the fold's total order ambiguous (two events, one
+	// ULID), so a duplicate is refused before it can poison the log. Two
+	// deliberate softenings keep this defense-in-depth, never an availability
+	// tax on the write path: (1) the check is not atomic with the append — two
+	// concurrent writers racing the SAME id could both pass — but ids are
+	// CLI-minted ULIDs, so a duplicate only arises from a replayed or
+	// hand-crafted id, the single-writer shape the scan does catch; (2) a log
+	// that cannot be READ skips the check rather than failing the append —
+	// emission must survive a read-broken log (the emit-on-unreadable-log
+	// degradation the CLI already promises), and the fold's stable sort keeps
+	// even an undetected duplicate deterministic. The scan makes each append
+	// O(log-length) — Θ(n²) cumulatively — accepted deliberately: writes are
+	// human-rate and logs human-scale, and the snapshot design (§15.5) is the
+	// planned answer if that ever stops being true.
+	if dup, err := s.hasID(ev.ID); err == nil && dup {
+		return fmt.Errorf("store: refusing to append event %s: id already exists in %s", ev.ID, s.Path())
 	}
 
 	line, err := Marshal(ev)
@@ -156,9 +175,32 @@ func (s *Store) Tail(n int) ([]Event, error) {
 	return out, nil
 }
 
+// errStopScan is scan's early-exit sentinel: a callback returns it to end the
+// stream without surfacing an error to the caller.
+var errStopScan = errors.New("stop scan")
+
+// hasID reports whether an event with the given id already exists in the log.
+// It streams and stops at the first hit, so the common no-duplicate append pays
+// one full read and a hit pays less. A missing log has no ids.
+func (s *Store) hasID(id string) (bool, error) {
+	found := false
+	err := s.scan(func(ev Event) error {
+		if ev.ID == id {
+			found = true
+			return errStopScan
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errStopScan) {
+		return false, err
+	}
+	return found, nil
+}
+
 // scan opens the log and feeds each parsed event to fn in order. It centralizes
 // the missing-file-is-empty rule and the enlarged scanner buffer so ReadAll and
-// Tail share one streaming path.
+// Tail share one streaming path. A callback may return errStopScan to end the
+// stream early; scan propagates it for the caller to swallow.
 func (s *Store) scan(fn func(Event) error) error {
 	f, err := os.Open(s.Path())
 	if err != nil {

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -398,6 +398,78 @@ func TestAppendRejectsInvalid(t *testing.T) {
 	}
 }
 
+// TestAppendRejectsDuplicateID locks the fold-determinism guard: a reused ULID
+// is refused before it reaches the log (two events sharing an id have no total
+// order), while distinct ids append freely around it.
+func TestAppendRejectsDuplicateID(t *testing.T) {
+	store := NewStore(t.TempDir(), "dup-repo")
+
+	first := newEvent(t, "original")
+	if err := store.Append(first); err != nil {
+		t.Fatalf("Append(first): %v", err)
+	}
+
+	replay := newEvent(t, "replayed under the same id")
+	replay.ID = first.ID
+	if err := store.Append(replay); err == nil {
+		t.Fatal("Append(duplicate id) = nil, want error")
+	} else if !strings.Contains(err.Error(), first.ID) {
+		t.Errorf("duplicate-id error does not name the id: %v", err)
+	}
+
+	other := newEvent(t, "distinct id still appends")
+	if err := store.Append(other); err != nil {
+		t.Fatalf("Append(other) after rejected duplicate: %v", err)
+	}
+
+	all, err := store.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("log has %d events, want 2 (duplicate must not be written)", len(all))
+	}
+	if all[0].Body != "original" || all[1].Body != "distinct id still appends" {
+		t.Fatalf("log content wrong: %q / %q", all[0].Body, all[1].Body)
+	}
+}
+
+// TestAppendSurvivesUnreadableLog locks the availability side of the
+// duplicate-id guard: when the log cannot be READ, the check degrades and the
+// append still lands — emission must survive a read-broken log rather than
+// brick the write path on a defense-in-depth scan.
+func TestAppendSurvivesUnreadableLog(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod permission bits do not gate reads on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("chmod 0 does not bar root from reading")
+	}
+	store := NewStore(t.TempDir(), "unreadable-repo")
+	if err := store.Append(newEvent(t, "seed")); err != nil {
+		t.Fatalf("Append(seed): %v", err)
+	}
+	if err := os.Chmod(store.Path(), 0o200); err != nil { // write-only: append works, read denied
+		t.Fatalf("chmod: %v", err)
+	}
+	defer os.Chmod(store.Path(), 0o644)
+
+	if err := store.Append(newEvent(t, "landed while unreadable")); err != nil {
+		t.Fatalf("Append on unreadable log: %v", err)
+	}
+
+	if err := os.Chmod(store.Path(), 0o644); err != nil {
+		t.Fatalf("chmod back: %v", err)
+	}
+	all, err := store.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(all) != 2 || all[1].Body != "landed while unreadable" {
+		t.Fatalf("append did not land: %d events", len(all))
+	}
+}
+
 // TestAppendBodySizeBound locks the M3 write/read invariant: a body at the cap
 // appends AND reads back (the largest write-accepted line is always within the
 // reader's scanner limit), while an over-cap body is rejected before any write.

--- a/internal/render/fold.go
+++ b/internal/render/fold.go
@@ -48,10 +48,14 @@ type Projection struct {
 	SupersededHandoffs []string
 }
 
-// Fold collapses an event set into a resolved Projection. It is a PURE function
-// of the SET, not the order: it sorts a copy by ULID (lexical = total order on a
-// single machine, §10) and then applies order-independent set logic, so any
-// permutation of the same events folds to an identical Projection.
+// Fold collapses an event set into a resolved Projection. For distinct ids —
+// the invariant Store.Append enforces — it is a PURE function of the SET, not
+// the order: it sorts a copy by ULID (lexical = total order on a single
+// machine, §10) and then applies order-independent set logic, so any
+// permutation of the same events folds to an identical Projection. A reused id
+// (a pathological log the guard predates) has no ULID order to give; there the
+// stable sort demotes the promise to input-order determinism — see the sort
+// below.
 //
 // Resolution rules:
 //   - open-set: an original open-item (open-item, status != closed) is OPEN
@@ -121,11 +125,15 @@ type Projection struct {
 // flagging same-millisecond cross-machine ties (rather than silently picking a
 // winner) is deferred to multi-machine sync; the fold never reorders to hide one.
 func Fold(events []event.Event) Projection {
-	// Sort a copy so the caller's slice is left untouched and the fold is a pure
-	// function of the set.
+	// Sort a copy so the caller's slice is left untouched. For distinct ids —
+	// the invariant Store.Append now enforces — the fold is a pure function of
+	// the set, input-order-independent. For a reused id (a pathological log:
+	// hand-edited, or written before the duplicate guard) the stable sort makes
+	// it instead a deterministic function of file order: the duplicates keep
+	// their input positions, later line wins.
 	sorted := make([]event.Event, len(events))
 	copy(sorted, events)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
 
 	proj := Projection{ResumeHandoffs: make(map[string][]event.Event)}
 

--- a/internal/render/fold_test.go
+++ b/internal/render/fold_test.go
@@ -716,6 +716,36 @@ func TestFoldConclusionRetiresWholeStack(t *testing.T) {
 	assertOrderIndependent(t, events, proj)
 }
 
+// TestFoldDuplicateIDTiesBreakByInputOrder locks the tie-break contract for a
+// pathological log carrying a reused id (Store.Append refuses one now, but a
+// hand-edited or pre-guard log can still hold it): input order decides the tie
+// — the later file line wins the newest position. The guarantee itself rests on
+// sort.SliceStable's spec; this test discriminates by folding the same pair in
+// BOTH input orders and asserting the winner flips with them, which an
+// order-insensitive rewrite (e.g. dedup-keep-first) would fail.
+func TestFoldDuplicateIDTiesBreakByInputOrder(t *testing.T) {
+	dupID := mint(t)
+	a := event.Event{ID: dupID, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws1", Body: "A"}
+	b := event.Event{ID: dupID, SchemaVersion: event.SchemaVersion, Type: event.KindHandoff, Workstream: "ws1", Body: "B"}
+	other := event.Event{ID: mint(t), SchemaVersion: event.SchemaVersion, Type: event.KindNote, Workstream: "ws1", Body: "bystander"}
+
+	newest := func(input []event.Event) string {
+		t.Helper()
+		stack := Fold(input).ResumeHandoffs["ws1"]
+		if len(stack) == 0 {
+			t.Fatal("no resume stack folded for ws1")
+		}
+		return stack[len(stack)-1].Body
+	}
+
+	if got := newest([]event.Event{a, b, other}); got != "B" {
+		t.Fatalf("newest position after [A,B] = %q, want the later line B", got)
+	}
+	if got := newest([]event.Event{b, a, other}); got != "A" {
+		t.Fatalf("newest position after [B,A] = %q, want the later line A", got)
+	}
+}
+
 // TestFoldLegacyEquivalenceProperty is the grandfather argument under randomized
 // pressure. The hand-written legacy cases pin the shapes we thought of; this one
 // generates thousands of LEGACY-shaped logs — every handoff implicit, notes


### PR DESCRIPTION
## What

Two-layer fix for the fold-nondeterminism hole on duplicate event ids (first flagged by the Codex review of the supersession PR, adjudicated real-but-pre-existing there):

1. **`Store.Append` refuses a reused ULID.** A new `hasID` pre-scan (early-exit sentinel on the shared streaming path) rejects an id that already exists in the log.
2. **The fold's sort becomes stable.** A pathological log that already carries a duplicate (hand-edited, or written before this guard) now folds deterministically in file order — later line wins — instead of by sort caprice. For distinct ids, stability is a no-op on a strict total order.

## Two deliberate softenings, documented at the check

- **Not atomic with the append** (TOCTOU accepted): ids are CLI-minted ULIDs, so a duplicate only arises from a replayed or hand-crafted id — the single-writer shape the scan does catch.
- **A log that cannot be READ skips the check** rather than failing the append: emission must survive a read-broken log. The existing emit-on-unreadable-log test caught the first version of this change, which made the write path depend on the read path; the shipped version degrades instead, locked by a new chmod-based test (unix-only — Windows chmod cannot make a file unreadable, so it skips there).

Appends are now O(log-length) each, Θ(n²) cumulatively — accepted deliberately at human-rate writes and human-scale logs; the §15.5 snapshot design is the planned answer if that ever stops being true.

## Review

- **ce:review**: relocated a test block that orphaned another test's doc comment; replaced a non-discriminating fold test with one folding the same dup-id pair in both input orders and asserting the winner flips (locks the input-order-decides-ties contract against order-insensitive rewrites); Windows skip; comment contradiction fixes.
- **Codex adversarial**: corrupt-line availability parity, scan/append races under `-race` (10 repeated runs), sentinel leakage into `ReadAll`/`Tail`, append atomicity, and SliceStable-on-unique-ids all explicitly checked clean; surfaced the Θ(n²) cost, now documented as accepted.

`go test ./... -race` green across all 10 packages; gofmt/vet clean.

Closes Director open-item `01M0Z7AYVGVDRN6SYTT30M29X0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FudztjDjwmkEc6sb7VHKv
