### PR TITLE
hooks: budget the injection in UTF-16 units, at the measured 10k cap

### DIFF
--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1492,7 +1492,7 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 
 	store := event.NewStore(hub, ws.RepoKey)
 	body := strings.Repeat("rationale ", 30) // ~300 chars, capped to a ~160-rune headline
-	for i := 0; i < 120; i++ {               // ~120 index lines ≈ 22KB > 16KB budget
+	for i := 0; i < 120; i++ {               // ~120 index lines ≈ 24K units > the 10,000-unit budget
 		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindDecision, Area: "hooks", Body: body}); err != nil {
 			t.Fatalf("seed decision %d: %v", i, err)
 		}
@@ -1529,8 +1529,8 @@ func TestSessionStartBudgetDegradesDeterministically(t *testing.T) {
 	if !strings.Contains(ctx, "the open loop must survive degradation") {
 		t.Errorf("degradation must never eat the open-set:\n%.2000s", ctx)
 	}
-	if len(ctx) > injectionBudgetBytes {
-		t.Errorf("degraded payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
+	if utf16Units(ctx) > injectionBudgetUnits {
+		t.Errorf("degraded payload still over budget: %d units > %d", utf16Units(ctx), injectionBudgetUnits)
 	}
 	health := readHealth(t, hub)
 	if !strings.Contains(health, "older decisions collapsed to count+pointer, newest 1 kept") {
@@ -1578,8 +1578,8 @@ func TestSessionStartBudgetSkipsEmptyKeptBand(t *testing.T) {
 	if !strings.Contains(ctx, "(120 active decisions elided for size") {
 		t.Errorf("empty kept band should inject the full-collapse line:\n%.2000s", ctx)
 	}
-	if len(ctx) > injectionBudgetBytes {
-		t.Errorf("collapsed payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
+	if utf16Units(ctx) > injectionBudgetUnits {
+		t.Errorf("collapsed payload still over budget: %d units > %d", utf16Units(ctx), injectionBudgetUnits)
 	}
 	health := readHealth(t, hub)
 	if !strings.Contains(health, "ALL decisions collapsed to count+pointer") {
@@ -1587,6 +1587,85 @@ func TestSessionStartBudgetSkipsEmptyKeptBand(t *testing.T) {
 	}
 	if strings.Contains(health, "kept") {
 		t.Errorf("health must not claim a kept band when nothing was kept:\n%s", health)
+	}
+}
+
+// TestUTF16Units locks the budget's measuring stick to the unit the harness
+// cap counts: one unit per BMP rune regardless of UTF-8 width (the digest's
+// middle dots, arrows, and accents are 2-3 bytes but ONE unit — the whole
+// point of measuring in units, byte-budgeting over-counts them), two per
+// supplementary rune, and one for an invalid byte (it decodes to U+FFFD).
+func TestUTF16Units(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"plain ascii", 11},
+		{"é", 1},      // 2 UTF-8 bytes, BMP → 1 unit
+		{"·", 1},      // the digest's separator: 2 bytes, 1 unit
+		{"→", 1},      // 3 bytes, 1 unit
+		{"⚠", 1},      // 3 bytes, 1 unit
+		{"🤖", 2},      // supplementary plane: 4 bytes, 2 units
+		{"a·b→c🤖", 7}, // 5 BMP runes + one 2-unit rune
+		{"\xff", 1},   // invalid byte → U+FFFD, 1 unit
+		{"a\xffb", 3}, // invalid byte embedded
+	}
+	for _, c := range cases {
+		if got := utf16Units(c.in); got != c.want {
+			t.Errorf("utf16Units(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// TestSessionStartBudgetCountsUnitsNotBytes locks the budget to the unit the
+// cap counts, at the integration boundary: a multibyte-dense payload whose
+// BYTE length is over 10,000 but whose UTF-16 unit count is under must inject
+// the FULL digest with no degradation rung — byte-budgeting (the pre-change
+// behavior, and the regression this guards) would wrongly degrade it. Every
+// other budget fixture is ASCII (units == bytes), so only this test fails if
+// the comparison ever reverts to len().
+func TestSessionStartBudgetCountsUnitsNotBytes(t *testing.T) {
+	hub := t.TempDir()
+	repo := gitRepo(t, "widget", "main")
+	ws := mustResolve(t, repo)
+
+	store := event.NewStore(hub, ws.RepoKey)
+	// "·→é⚠ " is 5 runes / 5 units / 11 bytes. 59 repeats = 295 runes (under
+	// the 300-rune cap) ≈ 649 bytes vs 295 units per body. 12 open-items land
+	// the payload at ~12K bytes but ~8K units: over the budget in bytes, under
+	// it in units.
+	openBody := strings.Repeat("·→é⚠ ", 59)
+	for i := 0; i < 12; i++ {
+		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindOpenItem, Area: "sync", Body: openBody}); err != nil {
+			t.Fatalf("seed open-item %d: %v", i, err)
+		}
+	}
+	if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindDecision, Area: "hooks", Body: "decision body that must survive undegraded"}); err != nil {
+		t.Fatalf("seed decision: %v", err)
+	}
+
+	in := `{"session_id":"s-real","cwd":` + jsonString(repo) + `,"hook_event_name":"SessionStart","source":"startup"}`
+	var out bytes.Buffer
+	if code := Dispatch(EventSessionStart, strings.NewReader(in), &out, hub); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	ctx := injectedContext(t, out.String())
+
+	if len(ctx) <= injectionBudgetUnits {
+		t.Fatalf("fixture too small to discriminate: %d bytes must exceed the %d-unit budget", len(ctx), injectionBudgetUnits)
+	}
+	if u := utf16Units(ctx); u > injectionBudgetUnits {
+		t.Fatalf("fixture too large to discriminate: %d units must fit the budget", u)
+	}
+	if !strings.Contains(ctx, "decision body that must survive undegraded") {
+		t.Error("unit-fitting payload was degraded: decision body missing")
+	}
+	if strings.Contains(ctx, "elided for size") {
+		t.Error("unit-fitting payload was degraded: decisions collapsed")
+	}
+	if health := readHealth(t, hub); strings.Contains(health, "injection budget") {
+		t.Errorf("no budget rung should fire for a unit-fitting payload, got:\n%s", health)
 	}
 }
 
@@ -1600,21 +1679,20 @@ func TestSessionStartBudgetCollapsesAllWhenKeptBandOverflows(t *testing.T) {
 	ws := mustResolve(t, repo)
 
 	store := event.NewStore(hub, ws.RepoKey)
-	// Bulk the ACTIONABLE section close to the budget so rung 1's ~2KB kept
-	// band (10 × ~200B lines) still overflows while rung 2 fits: ~36 open-items
-	// × ~300-char bodies (+13B date tag each) ≈ 12.0KB of open-set + ~2.9KB
-	// fixed blocks.
+	// Bulk the ACTIONABLE section close to the budget so rung 1's ~2K-unit kept
+	// band (10 × ~200-unit decision index lines) still overflows while rung 2
+	// fits: ~16
+	// open-items × ~330-unit lines ≈ 5.3K units of open-set + ~4.0K units of
+	// fixed blocks, against the 10,000-unit budget.
+	// (The fixture is ASCII, so units == bytes here.)
 	//
-	// Measured margins (2026-08-26, after the supersession rewrite trimmed
-	// emitProtocol back to 3,032B — 57B under its pre-supersession size): full
-	// 20,852B, rung 1 17,998B (~1.6KB over, as required), rung 2 15,970B — 414B
-	// of headroom under the 16,384B budget. If this test starts failing with "STILL over budget"
-	// after a fixed block (emitProtocol, preamble, banner) grows, the FIXTURE
-	// has drifted out of its window — re-tune the open-item count downward;
-	// don't suspect the ladder. (2026-07-15 window, for reference: 38
-	// open-items, rung 2 ≈ 15.8KB.)
+	// If this test starts failing with "STILL over budget" after a fixed block
+	// (emitProtocol, preamble, banner) grows, the FIXTURE has drifted out of
+	// its window — re-tune the open-item count downward; don't suspect the
+	// ladder. (Historical windows, for reference: 16,384-BYTE budget era of
+	// 2026-08-26 took 36 open-items, rung 2 ≈ 15,970B; 2026-07-15 took 38.)
 	openBody := strings.Repeat("open loop ", 29) // ~290 chars, under the 300-rune cap
-	for i := 0; i < 36; i++ {
+	for i := 0; i < 16; i++ {
 		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindOpenItem, Area: "sync", Body: openBody}); err != nil {
 			t.Fatalf("seed open-item %d: %v", i, err)
 		}
@@ -1642,8 +1720,8 @@ func TestSessionStartBudgetCollapsesAllWhenKeptBandOverflows(t *testing.T) {
 	if !strings.Contains(ctx, "open loop open loop") {
 		t.Errorf("degradation must never eat the open-set:\n%.2000s", ctx)
 	}
-	if len(ctx) > injectionBudgetBytes {
-		t.Errorf("rung-2 payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
+	if utf16Units(ctx) > injectionBudgetUnits {
+		t.Errorf("rung-2 payload still over budget: %d units > %d", utf16Units(ctx), injectionBudgetUnits)
 	}
 	health := readHealth(t, hub)
 	if !strings.Contains(health, "ALL decisions collapsed to count+pointer") {
@@ -1757,7 +1835,7 @@ func TestSessionStartBudgetAnchorsOnOldestPosition(t *testing.T) {
 		t.Fatalf("seed shared handoff: %v", err)
 	}
 	body := strings.Repeat("rationale ", 30) // ~300 chars, capped to a ~160-rune headline
-	for i := 0; i < 120; i++ {               // ~120 index lines ≈ 22KB > 16KB budget
+	for i := 0; i < 120; i++ {               // ~120 index lines ≈ 24K units > the 10,000-unit budget
 		if _, err := event.Emit(store, ws.ID, event.EmitParams{Type: event.KindDecision, Area: "hooks", Body: body}); err != nil {
 			t.Fatalf("seed decision %d: %v", i, err)
 		}
@@ -1790,8 +1868,8 @@ func TestSessionStartBudgetAnchorsOnOldestPosition(t *testing.T) {
 	if !strings.Contains(ctx, "(120 older decision(s) elided for size — the newest 1 follow") {
 		t.Errorf("over-budget injection should elide only the pre-anchor decisions:\n%.2000s", ctx)
 	}
-	if len(ctx) > injectionBudgetBytes {
-		t.Errorf("degraded payload still over budget: %dB > %dB", len(ctx), injectionBudgetBytes)
+	if utf16Units(ctx) > injectionBudgetUnits {
+		t.Errorf("degraded payload still over budget: %d units > %d", utf16Units(ctx), injectionBudgetUnits)
 	}
 	health := readHealth(t, hub)
 	if !strings.Contains(health, "older decisions collapsed to count+pointer, newest 1 kept") {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1620,8 +1620,9 @@ func TestUTF16Units(t *testing.T) {
 
 // TestSessionStartBudgetCountsUnitsNotBytes locks the budget to the unit the
 // cap counts, at the integration boundary: a multibyte-dense payload whose
-// BYTE length is over 10,000 but whose UTF-16 unit count is under must inject
-// the FULL digest with no degradation rung — byte-budgeting (the pre-change
+// BYTE length is over 10,000 but whose UTF-16 unit count is under the budget
+// must inject the FULL digest with no degradation rung — byte-budgeting (the
+// pre-change
 // behavior, and the regression this guards) would wrongly degrade it. Every
 // other budget fixture is ASCII (units == bytes), so only this test fails if
 // the comparison ever reverts to len().

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -160,9 +160,10 @@ func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
 // belongs in this comment, not in a reflexive per-flavor split.
 const injectionBudgetUnits = 10_000
 
-// utf16Units measures s the way the harness cap does: UTF-16 code units — one
-// per BMP rune, two per supplementary rune (utf16.RuneLen); an invalid byte
-// decodes to U+FFFD, one unit, matching what any decoder would deliver.
+// utf16Units counts the UTF-16 code units of the decoded string s — the unit
+// the harness cap measures: one per BMP rune, two per supplementary rune
+// (utf16.RuneLen); an invalid byte decodes to U+FFFD, one unit, matching what
+// any decoder would deliver.
 func utf16Units(s string) int {
 	n := 0
 	for _, r := range s {

--- a/internal/hook/sessionstart.go
+++ b/internal/hook/sessionstart.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"github.com/colinsurprenant/director/internal/event"
 	"github.com/colinsurprenant/director/internal/fleet"
@@ -133,28 +134,53 @@ func refreshFleet(hub string, ws identity.Workstream, uuid, cwd string) error {
 	return nil
 }
 
-// injectionBudgetBytes is the target size for the whole Ground-Truth injection.
-// It is sized to CONTEXT ECONOMY — what a session start should reasonably cost —
-// not to the harness's inline hook-output limit: that limit is undocumented and
-// has been observed to drift (docs said 50K; a 36KB payload was demoted to a 2KB
-// preview on 2026-07-03), so it must never be load-bearing. Over budget, the
-// digest degrades deterministically (DigestCompact: decisions collapse to a
-// count+pointer line — never the open loops or the resume stack) and the overflow is
-// health-logged so growth is loud long before any harness threshold bites. The
-// preamble's DELIVERY CHECK contract remains the backstop of last resort.
+// injectionBudgetUnits is the target size for the whole Ground-Truth injection,
+// in UTF-16 code units — the unit Claude Code's inline hook-output cap actually
+// counts, measured empirically at 10,000 units INCLUSIVE (10,000 arrives
+// inline, 10,001 is demoted to a persisted-file preview; probe on claude-code
+// #84021, comment 5431713505, 2026-08-26). Earlier revisions budgeted 16KB of
+// bytes on context-economy grounds with the delivery check as the working
+// backstop; that deliberately over-cap stance meant real sessions started on
+// the degraded preview path. Budgeting at the measured cap makes the normal
+// case an inline delivery. The cap is still an undocumented, driftable harness
+// behavior, so it must never be load-bearing: over budget, the digest degrades
+// deterministically (DigestCompact: decisions collapse to a count+pointer line
+// — never the open loops or the resume stack) and the overflow is
+// health-logged so growth is loud before the threshold bites. The preamble's
+// DELIVERY CHECK contract remains the backstop of last resort.
 //
-// Measured on the DECODED payload — what actually enters the model's context.
-// The JSON envelope on the wire runs ~30% larger (escaping of <>, quotes, and
-// newlines); account for that before ever comparing this constant to a
-// wire-size threshold.
-const injectionBudgetBytes = 16 * 1024
+// Measured on the DECODED payload — the string the harness counts against its
+// cap. The JSON envelope on the wire runs larger (escaping of <>, quotes, and
+// newlines); that layer is the harness's to strip and does not count.
+//
+// One budget serves all four delivery flavors: Claude Code's cap is the only
+// one MEASURED, so it sizes the constant; for codex/opencode/copilot (whose
+// inline caps are unknown and presumably different) the same figure stands in
+// as the context-economy bound. A future measurement of another flavor's cap
+// belongs in this comment, not in a reflexive per-flavor split.
+const injectionBudgetUnits = 10_000
+
+// utf16Units measures s the way the harness cap does: UTF-16 code units — one
+// per BMP rune, two per supplementary rune (utf16.RuneLen); an invalid byte
+// decodes to U+FFFD, one unit, matching what any decoder would deliver.
+func utf16Units(s string) int {
+	n := 0
+	for _, r := range s {
+		if utf16.RuneLen(r) == 2 {
+			n += 2
+		} else {
+			n++
+		}
+	}
+	return n
+}
 
 // buildGroundTruth assembles the injected block: the Ground-Truth preamble
 // (with the truncation contract), the write-side protocol (managed repos only),
 // the project CHARTER (graceful when absent), and the deterministic digest
 // folded from the LOG. Under budget — the normal case — the digest is
 // byte-for-byte the `director render` / `--verify` output, so what the session
-// is handed is exactly what the cockpit shows. Over injectionBudgetBytes it
+// is handed is exactly what the cockpit shows. Over injectionBudgetUnits it
 // degrades down a deterministic ladder: first DigestCompact (older decisions
 // collapse to a count+pointer line, the newest — anchored to this workstream's
 // OLDEST surviving position, i.e. the ones no prior session of this workstream
@@ -271,13 +297,13 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid, flavor string
 	}
 
 	ctx := assemble(render.Digest(proj, repoKey))
-	if len(ctx) > injectionBudgetBytes {
+	if utf16Units(ctx) > injectionBudgetUnits {
 		// Deterministic degradation ladder, loud in health/ at every rung —
 		// over-budget growth is a grooming signal (§15.5 / L2 promotion), not a
 		// silent state. Rung 1 collapses only the OLDER decisions — the ones a
 		// rehydrating session has not seen are the last decision content
 		// sacrificed (a sibling's course correction lives there).
-		full := len(ctx)
+		full := utf16Units(ctx)
 		anchor := ""
 		// The OLDEST surviving position anchors the band: with parallel
 		// sessions the stack holds several un-consolidated positions, and the
@@ -296,13 +322,13 @@ func buildGroundTruth(hub, repoKey, workstreamID, sessionID, uuid, flavor string
 		kept := render.KeptDecisions(proj, anchor)
 		if kept > 0 {
 			ctx = assemble(render.DigestCompact(proj, repoKey, anchor))
-			detail = fmt.Sprintf("injection budget: full payload %dB > %dB — older decisions collapsed to count+pointer, newest %d kept (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, kept, len(ctx))
+			detail = fmt.Sprintf("injection budget: full payload %d units > %d — older decisions collapsed to count+pointer, newest %d kept (now %d units); groom the log (resolve/supersede/promote)", full, injectionBudgetUnits, kept, utf16Units(ctx))
 		}
-		if kept == 0 || len(ctx) > injectionBudgetBytes {
+		if kept == 0 || utf16Units(ctx) > injectionBudgetUnits {
 			// Rung 2: every decision collapses.
 			ctx = assemble(render.DigestCollapsed(proj, repoKey))
-			detail = fmt.Sprintf("injection budget: full payload %dB > %dB — ALL decisions collapsed to count+pointer (now %dB); groom the log (resolve/supersede/promote)", full, injectionBudgetBytes, len(ctx))
-			if len(ctx) > injectionBudgetBytes {
+			detail = fmt.Sprintf("injection budget: full payload %d units > %d — ALL decisions collapsed to count+pointer (now %d units); groom the log (resolve/supersede/promote)", full, injectionBudgetUnits, utf16Units(ctx))
+			if utf16Units(ctx) > injectionBudgetUnits {
 				// Still over on open-items + handoffs alone: never eat the actionable
 				// sections — inject as-is and make the overflow visible. Both are
 				// named because either can be the cause: a deep resume stack

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -303,10 +303,12 @@ const (
 )
 
 // recentDecisionsKept bounds DigestCompact's kept-newest band. A decision index
-// line runs ≤ ~200 UTF-16 units (ULID + area + capped headline), so the band
-// re-adds at most ~2K units to an over-budget payload — a fifth of the
-// 10,000-unit injection budget, affordable because the hook still has
-// DigestCollapsed as the next rung when even that overflows.
+// line runs ~200 UTF-16 units in practice (ULID + area + headline capped in
+// RUNES — supplementary-plane runes count two units each, so the hard bound is
+// nearer 2× that for emoji-dense bodies). The band therefore re-adds ~2K units
+// typical, ~4K worst case, to an over-budget payload — affordable against the
+// 10,000-unit injection budget because the hook still has DigestCollapsed as
+// the next rung when even that overflows.
 const recentDecisionsKept = 10
 
 // headline collapses a body to one line and caps it at max runes, marking a cut

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -303,9 +303,10 @@ const (
 )
 
 // recentDecisionsKept bounds DigestCompact's kept-newest band. A decision index
-// line runs ≤ ~200B (ULID + area + capped headline), so the band re-adds at most
-// ~2KB to an over-budget payload — small against the 16KB injection budget, and
-// the hook still has DigestCollapsed as the next rung when even that overflows.
+// line runs ≤ ~200 UTF-16 units (ULID + area + capped headline), so the band
+// re-adds at most ~2K units to an over-budget payload — a fifth of the
+// 10,000-unit injection budget, affordable because the hook still has
+// DigestCollapsed as the next rung when even that overflows.
 const recentDecisionsKept = 10
 
 // headline collapses a body to one line and caps it at max runes, marking a cut


### PR DESCRIPTION
## What

The SessionStart injection budget moves from 16KB-of-bytes to **10,000 UTF-16 code units** — the unit and value of Claude Code's inline hook-output cap as measured on claude-code#84021 (comment 5431713505: 10,000 units arrive inline, inclusive; 10,001 demotes the block to a persisted-file preview).

`injectionBudgetBytes` (16*1024, compared via `len()`) becomes `injectionBudgetUnits` (10_000, via a new `utf16Units()`: one unit per BMP rune, two per supplementary, invalid bytes → U+FFFD → one). The two-rung degradation ladder is untouched: over budget still collapses decisions to a count+pointer line and never cuts open-items or the resume stack.

## Why

Byte-budgeting at 16KB was deliberately over-cap with the delivery check as backstop — which meant real sessions started on the degraded pull path (a 15.1KB digest observed spilling to a file live). It also over-counted the digest's multibyte punctuation: middle dots, arrows, and accents run 2–3 bytes but one unit each. Budgeting at the measured cap makes inline delivery the normal case again; the delivery-check contract stays as backstop since the cap is undocumented harness behavior that can drift.

One budget still serves all four delivery flavors — Claude Code's cap is the only measured one, so it sizes the constant (documented at the constant, so a future measurement of another flavor's cap lands there rather than in a reflexive per-flavor split).

## Tests

- `TestUTF16Units` locks the measure (BMP vs supplementary vs invalid bytes).
- A new integration test seeds a multibyte-dense payload **over 10K bytes but under 10K units** and asserts the full digest injects with no rung fired — **verified by mutation**: reverting the comparison to `len()` fails exactly this test, which every ASCII fixture is blind to.
- The rung-2 fixture re-tunes from 36 to 16 open-items per its own documented procedure. Measured margins: full ~14.1K units (ladder engages), rung 1 ~11.3K (still over, rung 2 engages), rung 2 ~9.2K (~760 units headroom).

Review: ce:review (5 findings, all applied — the mutation-survival gap, three stale byte-era comments, a kept-band figure that would misdirect re-tuners, the multi-flavor scoping note). `go test ./... -race` green across all 10 packages; `GOOS=windows` build clean.

Closes Director open-item `01M10239MFZZSW73035NMQS218`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FudztjDjwmkEc6sb7VHKv
